### PR TITLE
Hotfix/0.7.2

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-18)
 Phase: 57
 Plan: Not started
 Status: Phase complete — ready for verification
-Last activity: 2026-04-24
+Last activity: 2026-04-30 - Completed quick task 260430-vdz: review bug report semantic_views_parser_comment_bug.md, write failing test to reproduce, then implement fix
 
 Progress: [░░░░░░░░░░] 0%
 
@@ -86,6 +86,7 @@ Recent decisions affecting current work:
 | 260329-frb | Sync DuckDBVersionMonitor | 2026-03-29 | eef265b |
 | 260331-ta2 | Release recipe for CE registry | 2026-03-31 | 0390bab |
 | 260412-v5h | Generate complete CHANGELOG.md | 2026-04-12 | d42d240 |
+| 260430-vdz | Fix parser hook to skip leading SQL comments (-- and /* */) before prefix matching | 2026-04-30 | edf5196 |
 | Phase 51 P01 | 20min | 2 tasks | 6 files |
 | Phase 55 P01 | 18min | 2 tasks | 6 files |
 | Phase 56 P01 | 25min | 2 tasks | 8 files |

--- a/.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/260430-vdz-PLAN.md
+++ b/.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/260430-vdz-PLAN.md
@@ -1,0 +1,128 @@
+---
+quick_id: 260430-vdz
+description: Fix parser hook to skip leading SQL comments (-- and /* */) before prefix matching
+mode: quick
+---
+
+# Quick Task 260430-vdz: Parser Hook Comment-Stripping Fix
+
+## Goal
+
+Fix the bug reported at https://github.com/anentropic/dbt-duckdb/blob/claude/fix-duckdb-extension-loading-hhWnp/notes/semantic_views_parser_comment_bug.md
+
+The semantic_views parser hook (`detect_ddl_prefix` and friends in `src/parse.rs`) does case-insensitive prefix matching on the raw query but does not strip leading SQL comments. dbt-duckdb (and many other tools) prepend `/* {"app": "dbt", ...} */` annotations to every statement, causing `CREATE/ALTER/DROP/SHOW SEMANTIC VIEW` DDL to be classified as `PARSE_NOT_OURS`. Result: `Parser Error: syntax error at or near "SEMANTIC"`.
+
+Fix: add a `skip_leading_whitespace_and_comments(&str) -> usize` helper, apply at five trimming sites, preserve byte offsets so error-position carets (v0.5.1) still point into the original query.
+
+## Constraints
+
+- Stay on `hotfix/0.7.2` branch (already checked out).
+- No worktree isolation. No parallel builds. Foreground only.
+- Do NOT bump version numbers; user handles release tagging.
+- Failing-test-first: tests committed BEFORE the implementation that makes them pass.
+- Quality gate: `just test-all` must pass.
+
+## Tasks
+
+### Task 1: Write failing tests (sqllogictest + Rust unit tests)
+
+**files:**
+- `test/sql/quick_260430_vdz_leading_comments.test` (new)
+- `src/parse.rs` (extend existing `#[cfg(test)] mod tests`)
+
+**action:**
+1. Create new sqllogictest file `test/sql/quick_260430_vdz_leading_comments.test` covering:
+   - Baseline: plain DDL works
+   - Baseline: leading whitespace works
+   - Bug repro: leading `/* ... */` block comment before `CREATE OR REPLACE SEMANTIC VIEW` (dbt-style annotation)
+   - Bug repro: leading `-- ...\n` line comment before `CREATE`
+   - Mixed comments and whitespace
+   - Other DDL forms with leading comments: `DESCRIBE`, `SHOW`, `ALTER`, `DROP`
+   - Comment-only statement is NOT classified as semantic-view DDL
+   - Unterminated block comment does NOT panic
+   See RESEARCH.md section "Failing sqllogictest" for the exact file body.
+2. Add Rust unit tests to the `mod tests` block in `src/parse.rs`:
+   - Helper tests (will fail to compile until Task 2 adds the helper): `skip_lws_empty`, `skip_lws_only_whitespace`, `skip_lws_line_comment`, `skip_lws_block_comment`, `skip_lws_multiple_comments_and_ws`, `skip_lws_block_does_not_nest`, `skip_lws_unterminated_block_consumes_to_eof`, `skip_lws_no_leading_match`, `skip_lws_dash_dash_at_eof`
+   - Integrated detection tests: `detect_create_with_leading_block_comment`, `detect_create_with_leading_line_comment`, `detect_create_or_replace_with_dbt_style_annotation`, `detect_other_ddl_forms_with_leading_comment`, `comment_only_is_not_semantic_view_ddl`, `validate_and_rewrite_with_leading_comment_succeeds`, `extract_ddl_name_with_leading_comment`, `error_position_accounts_for_leading_comment`
+   See RESEARCH.md sections "Rust unit tests for the helper" and "Rust unit tests for the integrated detection layer" for exact test code.
+
+**verify:**
+- `just build` succeeds (the test file references the helper, but `cfg(test)` items only fail at test compile time — confirm the build still produces the extension binary).
+- `cargo test --no-run` will fail to compile because the helper doesn't exist yet — that's expected and proves the tests are wired up. Confirm the failure is "cannot find function `skip_leading_whitespace_and_comments`".
+- Alternative if test compile failure is undesirable in the commit: gate the helper unit tests with `#[cfg(all(test, FALSE))]` momentarily; cleaner is to commit broken-on-purpose. Choose: commit broken-on-purpose with a comment marking the failing-test-first intent, OR temporarily `#[ignore]` and remove in Task 2.
+  - **Decision:** Commit failing tests broken-on-purpose. The task 1 commit message will say "tests: add failing reproducer for parser comment bug (260430-vdz)". The task 2 commit makes them pass.
+- For the sqllogictest: `just test-sql` runs against the *currently built* extension. If we build before the fix, the new test cases that should pass will fail with the original `Parser Error: syntax error at or near "SEMANTIC"` — that confirms the repro.
+
+**done:**
+- New sqllogictest file committed.
+- Rust unit tests committed in `src/parse.rs` test module.
+- Atomic commit: `tests(parse): add failing reproducers for leading-comment bug (260430-vdz)`.
+
+### Task 2: Implement comment-stripping helper and apply at five sites
+
+**files:**
+- `src/parse.rs` (add helper + modify five trimming sites)
+
+**action:**
+1. Add private helper `skip_leading_whitespace_and_comments(input: &str) -> usize` near `match_keyword_prefix` in `src/parse.rs`. Implementation per RESEARCH.md "Helper function" section:
+   - Skip ASCII whitespace
+   - Skip `-- ... \n` line comments (terminate at `\n` or EOF)
+   - Skip `/* ... */` block comments (NON-NESTING, Postgres semantics)
+   - Unterminated block comment consumes to EOF
+   - Returns byte offset into original input
+2. Apply the helper at five trimming sites. Replace each occurrence of:
+   ```rust
+   let trimmed = query.trim();
+   let trimmed_no_semi = trimmed.trim_end_matches(';').trim();
+   // possibly: let trim_offset = query.len() - query.trim_start().len();
+   ```
+   with the offset-preserving form (see RESEARCH.md "Apply at five sites"):
+   ```rust
+   let lead = skip_leading_whitespace_and_comments(query);
+   let trimmed = query[lead..].trim_end();
+   let trimmed_no_semi = trimmed.trim_end_matches(';').trim();
+   let trim_offset = lead;
+   ```
+   Sites:
+   - `validate_and_rewrite` (~src/parse.rs:824) — primary site, preserves `trim_offset` for error-position math
+   - `detect_ddl_kind` (~src/parse.rs:179)
+   - `extract_ddl_name` (~src/parse.rs:669)
+   - `detect_near_miss` (~src/parse.rs:775)
+   - `rewrite_ddl` (~src/parse.rs:586)
+3. Do NOT modify `match_keyword_prefix`, `detect_ddl_prefix`, or `body_parser.rs` — they operate on already-stripped slices and the byte-offset semantics carry through.
+
+**verify:**
+- `cargo test` — green (all helper unit tests + integrated detection tests pass)
+- `just build` — extension binary builds cleanly (foreground)
+- `just test-sql` — sqllogictest passes including the new `quick_260430_vdz_leading_comments.test` file
+- `just test-all` — full quality gate green (Rust unit + proptest + sqllogictest + DuckLake)
+- Critical regression check: `error_position_accounts_for_leading_comment` test must pass — proves byte-offset preservation works.
+
+**done:**
+- Helper added, all five sites updated.
+- All previously-failing tests from Task 1 now pass.
+- `just test-all` green.
+- Atomic commit: `fix(parse): skip leading SQL comments before DDL prefix match (260430-vdz)`.
+
+## must_haves
+
+### truths
+- Bug repro from BUG-REPORT.md: `p.execute("/* hi */ " + DDL)` and `p.execute("-- hi\n" + DDL)` must succeed where `DDL = "CREATE OR REPLACE SEMANTIC VIEW sv AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.x AS xx) METRICS (t.y AS sum(y))"`.
+- Comment-only statements remain `PARSE_NOT_OURS` (DuckDB falls back to its own parser error).
+- Block comments do NOT nest (Postgres-aligned).
+- Error-position byte offsets in `ParseError.position` continue to reference the *original* query string after a leading comment.
+- All existing tests continue to pass — no regression on non-commented DDL or whitespace-only-prefix DDL.
+
+### artifacts
+- `test/sql/quick_260430_vdz_leading_comments.test` exists with comment-prefix DDL cases.
+- New `mod tests` entries in `src/parse.rs` covering helper + integrated detection + error-position regression.
+- Helper function `skip_leading_whitespace_and_comments` exists in `src/parse.rs`.
+- Five trimming sites updated to use the helper.
+- `just test-all` exits 0.
+
+### key_links
+- Bug report: `.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/BUG-REPORT.md`
+- Research: `.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/260430-vdz-RESEARCH.md`
+- Source: `src/parse.rs:62, 98, 179, 586, 669, 775, 824, 1454, 1549`
+- C++ shim (no changes needed): `cpp/src/shim.cpp:72, 146, 240`
+- Quality gate: `CLAUDE.md` — `just test-all`

--- a/.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/260430-vdz-RESEARCH.md
+++ b/.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/260430-vdz-RESEARCH.md
@@ -1,0 +1,414 @@
+# Quick Task 260430-vdz: Parser hook ignores leading SQL comments — Research
+
+**Researched:** 2026-04-30
+**Domain:** parse hook prefix matching (Rust + C++ FFI)
+**Confidence:** HIGH (codebase fully traced; bug report includes a verified reproducer)
+
+## Summary
+
+The parse hook's prefix matcher (`detect_ddl_prefix` in `src/parse.rs`) anchors at the trimmed start of the query and matches keyword tokens via `match_keyword_prefix`. It tolerates whitespace via `query.trim()` but does not strip SQL comments (`-- …\n`, `/* … */`). dbt-duckdb prepends a `/* {"app": "dbt", …} */` annotation to every statement, so every CREATE/ALTER/DROP/SHOW SEMANTIC VIEW statement is classified as `PARSE_NOT_OURS` (rc=2) and DuckDB's stock parser then errors with `syntax error at or near "SEMANTIC"`.
+
+There is a single canonical entry point — `validate_and_rewrite(query)` in `src/parse.rs` — that all FFI paths funnel through. Both `sv_validate_ddl_rust` (parser hook) and `sv_rewrite_ddl_rust` (bind-time re-rewrite) call it. The C++ shim (`cpp/src/shim.cpp`) does no prefix matching of its own. So the fix lives in exactly one Rust function chain.
+
+**Primary recommendation:** Add a small `skip_leading_whitespace_and_comments(&str) -> usize` helper in `src/parse.rs` (or `src/util.rs`) that returns a byte offset, and apply it at the two `query.trim()` sites in `validate_and_rewrite`, `detect_ddl_kind`, `detect_near_miss`, `extract_ddl_name`, and `rewrite_ddl`. Return an offset rather than a stripped slice, so the existing `trim_offset` math (used for error position reporting) absorbs the comment span and error carets continue to point into the *original* query string. Match Postgres semantics: line comments terminate at `\n`, block comments DO NOT nest.
+
+## Bug Location
+
+All prefix-match sites collapse onto **one** lexical entry: `match_keyword_prefix` (called only from `detect_ddl_prefix`). Every public detection function then passes a *trimmed* slice into it. The fix must be applied to the trimming step at every public entry point.
+
+### FFI surface (C++ → Rust)
+
+| Site | File:Line | What it does |
+|---|---|---|
+| Parser hook stub | `cpp/src/shim.cpp:72` (`sv_parse_stub`) | Calls `sv_validate_ddl_rust` (no own prefix logic) |
+| FFI validate entry | `src/parse.rs:1454` (`sv_validate_ddl_rust`) | Wraps `validate_and_rewrite(query)` |
+| FFI rewrite entry | `src/parse.rs:1549` (`sv_rewrite_ddl_rust`) | Also wraps `validate_and_rewrite(query)` (called from bind path `cpp/src/shim.cpp:146`, `cpp/src/shim.cpp:240`) |
+
+### Rust prefix-match call chain
+
+| Site | File:Line | Trimming step that misses comments |
+|---|---|---|
+| Core matcher | `src/parse.rs:62` (`match_keyword_prefix`) | Token-level matcher; agnostic — no change needed |
+| Prefix dispatcher | `src/parse.rs:98` (`detect_ddl_prefix`) | Caller-trimmed input — no change here |
+| `detect_ddl_kind` | `src/parse.rs:179` | `query.trim().trim_end_matches(';').trim()` — needs comment-skip |
+| `detect_semantic_view_ddl` | `src/parse.rs:189` | Delegates to `detect_ddl_kind` — fixed transitively |
+| `extract_ddl_name` | `src/parse.rs:669` | `query.trim().trim_end_matches(';').trim()` — needs comment-skip |
+| `detect_near_miss` | `src/parse.rs:776` | `query.trim().trim_end_matches(';').trim()` — needs comment-skip |
+| **`validate_and_rewrite`** | `src/parse.rs:824` | `query.trim().trim_end_matches(';').trim()` + `trim_offset = query.len() - query.trim_start().len()` — **primary fix site** |
+| `rewrite_ddl` | `src/parse.rs:586` | `query.trim().trim_end_matches(';').trim()` — needs comment-skip (called from `validate_and_rewrite` for non-CREATE forms) |
+
+**Key observation:** None of these functions parse comments today. The trimming pattern is uniform — `.trim().trim_end_matches(';').trim()` — making the fix mechanical. `validate_and_rewrite` additionally computes a `trim_offset` (line 827) used by every `ParseError { position: Some(trim_offset + …) }` site for error caret reporting (introduced v0.5.1).
+
+### Trailing comments
+
+Statements with trailing comments (`CREATE … METRICS (…) -- comment`) are not the reported bug, but they may also currently break body validation. Out of scope for this fix unless trivially handled by existing token-aware body parser. The `body_parser.rs` state machine (line 117, 128) uses `trim()` and may already strip trailing whitespace correctly; trailing block comments inside the AS-body are an open question — defer.
+
+## Recommended Fix
+
+### Helper function
+
+Add to `src/parse.rs` (private, near `match_keyword_prefix`). Keeping it co-located with `detect_ddl_prefix` is the natural home; it's specific to the parser hook context and not generally useful in `util.rs`.
+
+```rust
+/// Return the byte offset of the first character that is neither ASCII whitespace
+/// nor part of a SQL comment. Recognises:
+///   - `-- ... \n` line comments (terminated by newline or end-of-input)
+///   - `/* ... */` block comments (NOT nested — matches PostgreSQL/DuckDB behaviour)
+///
+/// Designed for prefix-matching: never errors. An unterminated `/* …` consumes to
+/// end of input (so the keyword match below it will simply fail and fall through
+/// to PARSE_NOT_OURS, matching today's behaviour for malformed queries).
+///
+/// Returns the byte offset where real SQL begins, in the *original* slice.
+fn skip_leading_whitespace_and_comments(input: &str) -> usize {
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    loop {
+        // ASCII whitespace
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        // Line comment: -- ... \n
+        if i + 1 < bytes.len() && bytes[i] == b'-' && bytes[i + 1] == b'-' {
+            i += 2;
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue; // re-enter loop to consume more whitespace/comments
+        }
+        // Block comment: /* ... */ (non-nesting, Postgres semantics)
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            if i + 1 < bytes.len() { i += 2; } // consume "*/"
+            else { i = bytes.len(); }          // unterminated — consume to end
+            continue;
+        }
+        break;
+    }
+    i
+}
+```
+
+### Why offset, not stripped slice
+
+The error-position reporting subsystem (added v0.5.1) computes positions as `trim_offset + plen + …` against the *original* `query` string. If we returned a stripped slice, every position downstream would be shifted by the comment length and carets would point at the wrong character. Returning a byte offset lets us update `trim_offset` once and have everything propagate correctly.
+
+### Apply at five sites
+
+Replace this pattern:
+
+```rust
+let trimmed = query.trim();
+let trimmed_no_semi = trimmed.trim_end_matches(';').trim();
+let trim_offset = query.len() - query.trim_start().len();
+```
+
+With:
+
+```rust
+let lead = skip_leading_whitespace_and_comments(query);
+let trimmed = query[lead..].trim_end();
+let trimmed_no_semi = trimmed.trim_end_matches(';').trim();
+let trim_offset = lead + (query[lead..].len() - query[lead..].trim_start().len());
+// (in practice, after skip_leading_whitespace_and_comments, there is no leading
+// whitespace, so `trim_offset = lead + 0`, but keep the form symmetric for safety)
+```
+
+Sites: `validate_and_rewrite` (parse.rs:824), `detect_ddl_kind` (parse.rs:179), `extract_ddl_name` (parse.rs:669), `detect_near_miss` (parse.rs:775), `rewrite_ddl` (parse.rs:586).
+
+`detect_semantic_view_ddl` is fixed transitively. `match_keyword_prefix` and `detect_ddl_prefix` are unchanged — they continue to receive an already-stripped slice.
+
+### Block-comment nesting decision (CONFIRMED)
+
+PostgresParser does NOT nest block comments. The bug report's suggestion to match that is correct. Snowflake also does not nest (simple `/* … */`). DuckDB's own parser doesn't nest either (uses libpg_query lex rules). Non-nesting also keeps the helper trivial (no depth counter). Decision: **non-nesting**.
+
+Edge cases worth knowing:
+- `/* outer /* inner */ trailing */ CREATE …` — outer comment ends at the *first* `*/`, leaving `trailing */ CREATE …` which fails to match (PARSE_NOT_OURS). Same as Postgres. Acceptable.
+- `/* unterminated CREATE …` — helper consumes to EOF, returns `len`, slice is empty, no match, PARSE_NOT_OURS. DuckDB's primary parser will then produce the real error. Correct fallback.
+
+## Test Plan (failing-test-first)
+
+CLAUDE.md gate: `just test-all` runs Rust unit tests + proptests + sqllogictest + DuckLake. Add tests in **all three** of: Rust unit tests (helper), Rust unit tests (validate_and_rewrite + detect_*), and sqllogictest (end-to-end through the C++ FFI + DuckDB parser hook).
+
+### 1. Failing sqllogictest (RECOMMENDED FIRST)
+
+This matches the bug reporter's reproducer most directly and exercises the full extension load → parser-hook → DDL → query pipeline.
+
+**File:** `test/sql/quick_260430_vdz_leading_comments.test` (new)
+
+```text
+# Quick task 260430-vdz: parser hook should accept DDL preceded by SQL comments.
+# Before the fix: every statement under the dbt query annotation comment fails
+# with "Parser Error: syntax error at or near \"SEMANTIC\"" because the prefix
+# match anchors at the trimmed start of the query and does not skip /* */ or --.
+
+require semantic_views
+
+statement ok
+CREATE TABLE t(x INTEGER, y INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 10), (2, 20);
+
+# Baseline: plain DDL works
+statement ok
+CREATE OR REPLACE SEMANTIC VIEW sv_plain AS
+TABLES (t AS t PRIMARY KEY (x))
+DIMENSIONS (t.xx AS t.x)
+METRICS (t.sy AS SUM(t.y))
+
+# Baseline: leading whitespace works (current behaviour)
+statement ok
+
+
+   CREATE OR REPLACE SEMANTIC VIEW sv_ws AS
+TABLES (t AS t PRIMARY KEY (x))
+DIMENSIONS (t.xx AS t.x)
+METRICS (t.sy AS SUM(t.y))
+
+# Bug repro #1: leading block comment (the dbt-duckdb case)
+statement ok
+/* {"app": "dbt", "node_id": "model.x"} */ CREATE OR REPLACE SEMANTIC VIEW sv_block AS
+TABLES (t AS t PRIMARY KEY (x))
+DIMENSIONS (t.xx AS t.x)
+METRICS (t.sy AS SUM(t.y))
+
+# Bug repro #2: leading line comment
+statement ok
+-- annotation
+CREATE OR REPLACE SEMANTIC VIEW sv_line AS
+TABLES (t AS t PRIMARY KEY (x))
+DIMENSIONS (t.xx AS t.x)
+METRICS (t.sy AS SUM(t.y))
+
+# Multiple comments + interleaved whitespace
+statement ok
+-- a
+/* b */
+   -- c
+/* d */ CREATE OR REPLACE SEMANTIC VIEW sv_mixed AS
+TABLES (t AS t PRIMARY KEY (x))
+DIMENSIONS (t.xx AS t.x)
+METRICS (t.sy AS SUM(t.y))
+
+# Other DDL forms must also work with leading comments
+statement ok
+/* x */ DESCRIBE SEMANTIC VIEW sv_block
+
+statement ok
+/* x */ SHOW SEMANTIC VIEWS
+
+statement ok
+/* x */ ALTER SEMANTIC VIEW sv_block SET COMMENT = 'hello'
+
+statement ok
+/* x */ DROP SEMANTIC VIEW sv_line
+
+# Comment-only must NOT be classified as semantic-view DDL.
+# (DuckDB will give its own error for the empty/comment-only statement.)
+statement error
+/* nothing */
+----
+
+# Unterminated block comment must NOT panic and must NOT match.
+statement error
+/* unterminated CREATE SEMANTIC VIEW broken AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.xx AS t.x) METRICS (t.sy AS SUM(t.y))
+----
+```
+
+Run it: `just build && just test-sql` (sqllogictest requires a fresh build per CLAUDE.md).
+
+### 2. Rust unit tests for the helper
+
+**File:** `src/parse.rs` (extend the existing `#[cfg(test)] mod tests` block).
+
+```rust
+#[test]
+fn skip_lws_empty() {
+    assert_eq!(skip_leading_whitespace_and_comments(""), 0);
+}
+
+#[test]
+fn skip_lws_only_whitespace() {
+    assert_eq!(skip_leading_whitespace_and_comments("   \n\t"), 5);
+}
+
+#[test]
+fn skip_lws_line_comment() {
+    let q = "-- hi\nCREATE";
+    assert_eq!(&q[skip_leading_whitespace_and_comments(q)..], "CREATE");
+}
+
+#[test]
+fn skip_lws_block_comment() {
+    let q = "/* hi */ CREATE";
+    assert_eq!(&q[skip_leading_whitespace_and_comments(q)..], "CREATE");
+}
+
+#[test]
+fn skip_lws_multiple_comments_and_ws() {
+    let q = "-- a\n  /* b */\n\t-- c\n/*d*/CREATE";
+    assert_eq!(&q[skip_leading_whitespace_and_comments(q)..], "CREATE");
+}
+
+#[test]
+fn skip_lws_block_does_not_nest() {
+    // Outer ends at first */, leaving "trailing */ CREATE"
+    let q = "/* outer /* inner */ trailing */ CREATE";
+    let rest = &q[skip_leading_whitespace_and_comments(q)..];
+    assert!(rest.starts_with("trailing"), "got: {rest:?}");
+}
+
+#[test]
+fn skip_lws_unterminated_block_consumes_to_eof() {
+    let q = "/* never ends";
+    assert_eq!(skip_leading_whitespace_and_comments(q), q.len());
+}
+
+#[test]
+fn skip_lws_no_leading_match() {
+    // No comments and no whitespace -> offset 0
+    assert_eq!(skip_leading_whitespace_and_comments("CREATE"), 0);
+}
+
+#[test]
+fn skip_lws_dash_dash_at_eof() {
+    let q = "-- no newline at end";
+    assert_eq!(skip_leading_whitespace_and_comments(q), q.len());
+}
+```
+
+### 3. Rust unit tests for the integrated detection layer
+
+Same `mod tests` block in `src/parse.rs` — verifies the fix flows through public entry points:
+
+```rust
+#[test]
+fn detect_create_with_leading_block_comment() {
+    assert_eq!(
+        detect_semantic_view_ddl("/* hi */ CREATE SEMANTIC VIEW x AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.xx AS t.x) METRICS (t.sy AS SUM(t.y))"),
+        PARSE_DETECTED
+    );
+}
+
+#[test]
+fn detect_create_with_leading_line_comment() {
+    assert_eq!(
+        detect_semantic_view_ddl("-- hi\nCREATE SEMANTIC VIEW x AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.xx AS t.x) METRICS (t.sy AS SUM(t.y))"),
+        PARSE_DETECTED
+    );
+}
+
+#[test]
+fn detect_create_or_replace_with_dbt_style_annotation() {
+    let q = "/* {\"app\": \"dbt\", \"node_id\": \"model.x\"} */ CREATE OR REPLACE SEMANTIC VIEW x AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.xx AS t.x) METRICS (t.sy AS SUM(t.y))";
+    assert_eq!(detect_semantic_view_ddl(q), PARSE_DETECTED);
+    let kind = detect_ddl_kind(q);
+    assert_eq!(kind, Some(DdlKind::CreateOrReplace));
+}
+
+#[test]
+fn detect_other_ddl_forms_with_leading_comment() {
+    for q in [
+        "/* x */ DROP SEMANTIC VIEW v",
+        "/* x */ ALTER SEMANTIC VIEW v RENAME TO w",
+        "/* x */ DESCRIBE SEMANTIC VIEW v",
+        "/* x */ SHOW SEMANTIC VIEWS",
+        "/* x */ SHOW SEMANTIC METRICS IN v",
+        "-- annotation\nDROP SEMANTIC VIEW v",
+    ] {
+        assert_eq!(detect_semantic_view_ddl(q), PARSE_DETECTED, "failed: {q}");
+    }
+}
+
+#[test]
+fn comment_only_is_not_semantic_view_ddl() {
+    assert_eq!(detect_semantic_view_ddl("/* just a comment */"), PARSE_NOT_OURS);
+    assert_eq!(detect_semantic_view_ddl("-- just a comment\n"), PARSE_NOT_OURS);
+}
+
+#[test]
+fn validate_and_rewrite_with_leading_comment_succeeds() {
+    let q = "/* annotation */ DROP SEMANTIC VIEW v";
+    let result = validate_and_rewrite(q).expect("should not error");
+    assert!(result.is_some(), "expected DDL detection");
+    let sql = result.unwrap();
+    assert!(sql.contains("drop_semantic_view"), "got: {sql}");
+}
+
+#[test]
+fn extract_ddl_name_with_leading_comment() {
+    assert_eq!(
+        extract_ddl_name("/* annotation */ DROP SEMANTIC VIEW my_view").unwrap(),
+        Some("my_view".to_string())
+    );
+}
+
+#[test]
+fn error_position_accounts_for_leading_comment() {
+    // Missing view name — error position should point at the offset AFTER
+    // both the comment AND the prefix, in the ORIGINAL query string.
+    let q = "/* hi */ DROP SEMANTIC VIEW";
+    let err = validate_and_rewrite(q).expect_err("should error: missing name");
+    let pos = err.position.expect("position should be set");
+    // Position should be inside the original string (not into the stripped slice)
+    // The prefix "DROP SEMANTIC VIEW" starts at byte 9 (after "/* hi */ ").
+    // After consuming the prefix (18 bytes), we're at byte 27 == query.len().
+    assert_eq!(pos, q.len(), "position should reference original query");
+}
+```
+
+The last test is the critical regression test for the byte-offset preservation strategy — proves the v0.5.1 caret reporting still points into the original query.
+
+### 4. Optional proptest extension
+
+`tests/parse_proptest.rs` already has `arb_whitespace()`. Add an `arb_leading_comments()` strategy generating mixed `--` / `/* */` / whitespace prefixes, and assert detection still succeeds. Lower priority — unit tests above cover the deterministic edge cases.
+
+### Implementation order (failing-test-first)
+
+1. Add the sqllogictest file → run `just test-sql` → confirm failure with the expected `Parser Error: syntax error at or near "SEMANTIC"`.
+2. Add the helper unit tests → run `cargo test` → fails (function doesn't exist).
+3. Implement `skip_leading_whitespace_and_comments`.
+4. Wire it into the five sites listed above.
+5. `cargo test` → green.
+6. `just build && just test-sql` → green.
+7. `just test-all` → green (full quality gate).
+
+## Pitfalls & Edge Cases
+
+1. **Statement rewriting path consumes original string.** `sv_rewrite_ddl_rust` (`src/parse.rs:1549`) is called from C++ at bind time (`cpp/src/shim.cpp:146`, `cpp/src/shim.cpp:240`) with the *same* original query that the parse hook saw. Both delegate to `validate_and_rewrite`, so applying the fix once at the `validate_and_rewrite` entry covers both. Confirmed by tracing — there is no second prefix-match site in the bind path. **No multi-site coordination needed.**
+
+2. **Re-invocation in YAML FILE bind path.** `cpp/src/shim.cpp:240` re-invokes `sv_rewrite_ddl_rust` with a *reconstructed* string (`kind_prefix + view_name + … + " FROM YAML $__sv_file$…$__sv_file$"`). That reconstructed string never carries comments, so the fix is irrelevant on that path — but it does prove that comments on the original input must be tolerated only on the first invocation. ✓ No regression risk.
+
+3. **Error-position carets (v0.5.1).** Every `ParseError { position: Some(trim_offset + plen + …) }` in `validate_and_rewrite` and below assumes positions are relative to the *original* `query`. Returning an offset (rather than slicing) preserves this invariant. The new `lead` value replaces `trim_offset` and absorbs the comment span. **Add the regression test in section 3** to lock this in.
+
+4. **`body_parser.rs` offsets.** `validate_create_body` (parse.rs:1010) computes `body_offset` via byte arithmetic relative to `trimmed_no_semi`, then passes it to `parse_keyword_body(body_text, base_offset)`. As long as `trim_offset` correctly points at where `trimmed_no_semi` begins in the original, all downstream math stays correct. The fix changes `trim_offset` from "leading whitespace count" to "leading whitespace + comments count" — same semantics, larger value. ✓ No body-parser changes needed.
+
+5. **`detect_near_miss`** does its own `query.trim()` (parse.rs:776) and computes `trim_offset = query.len() - query.trim_start().len()` (parse.rs:804). Must apply the helper here too, or near-miss suggestions for comment-prefixed typos will report the wrong caret position.
+
+6. **No existing test passes a comment.** Verified via grep — `tests/parse_proptest.rs` uses `arb_whitespace()` (parse.rs:28) which generates only ` `, `\t`, `\n`, `\r`. No existing test would accidentally regress. The `peg_compat.test` sqllogictest tests parser-extension interaction but does not exercise comments.
+
+7. **DuckDB's own parser strips comments before calling extension hooks?** No. The bug report demonstrates that DuckDB's parser-extension fallback receives the *raw* query text (comments included). This is consistent with how `parse_function` works — it's called when DuckDB's primary parser already failed. Other parser extensions in the wild (substrait, etc.) handle comment-stripping themselves.
+
+8. **Comment-only / empty statements.** With the fix, `skip_leading_whitespace_and_comments("/* x */")` returns 7 (full length), `trimmed_no_semi` is empty, `detect_ddl_prefix` returns `None`, and `validate_and_rewrite` returns `Ok(None)` → rc=2 → `DISPLAY_ORIGINAL_ERROR`. DuckDB shows its own error. ✓ Correct fallback.
+
+9. **`trim_end_matches(';').trim()` after the helper.** Still needed: the helper only strips *leading* whitespace/comments. Trailing semicolons and trailing whitespace are still handled by the existing `.trim_end_matches(';').trim()` chain. No change needed there.
+
+10. **Performance / O(n²).** The helper is O(n) and runs once per statement at the parse hook. The keyword-prefix matcher already documents avoiding O(n²) — this fix doesn't introduce any. ✓
+
+11. **CR/LF line endings.** `--` line comments terminate at `\n`. Windows-style `\r\n` works fine because `\r` is then consumed by the whitespace loop on the next iteration before the next comment/keyword. ✓
+
+## RESEARCH COMPLETE
+
+**File:** `/Users/paul/Documents/Dev/Personal/duckdb-semantic-views/.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/260430-vdz-RESEARCH.md`
+
+**Key findings:**
+- Single canonical fix site: `validate_and_rewrite` in `src/parse.rs:824` is funneled to by both FFI entries (`sv_validate_ddl_rust`, `sv_rewrite_ddl_rust`); the C++ shim has no prefix logic of its own.
+- Five Rust functions trim with `.trim()` and miss comments: `validate_and_rewrite`, `detect_ddl_kind`, `extract_ddl_name`, `detect_near_miss`, `rewrite_ddl`. All call `detect_ddl_prefix` after trimming, so the lexical layer is uniform.
+- Fix returns a byte offset (not a stripped slice) to preserve v0.5.1 error-caret positions — the `trim_offset` variable simply absorbs the comment span.
+- Block comments do NOT nest (Postgres/DuckDB-aligned). Confirmed against bug report.
+- Failing-test-first sequence: sqllogictest reproducer → helper unit tests → integrated detection tests → implement → `just test-all`.
+- Critical regression test: error-position must still point into the *original* query after a leading comment.

--- a/.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/260430-vdz-SUMMARY.md
+++ b/.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/260430-vdz-SUMMARY.md
@@ -1,0 +1,68 @@
+---
+quick_id: 260430-vdz
+description: Fix parser hook to skip leading SQL comments (-- and /* */) before prefix matching
+status: completed
+date: 2026-04-30
+commits:
+  - ca9197a tests(parse): add failing reproducers for leading-comment bug (260430-vdz)
+  - edf5196 fix(parse): skip leading SQL comments before DDL prefix match (260430-vdz)
+---
+
+# Quick Task 260430-vdz Summary
+
+## Bug
+
+`semantic_views`' parser hook (`detect_ddl_prefix` in `src/parse.rs`) anchored at the trimmed start of the query string but did not strip leading SQL comments. Tools that prepend annotations — most notably **dbt-duckdb**, which unconditionally prefixes every statement with `/* {"app": "dbt", "node_id": "model.X"} */` — caused every `CREATE / ALTER / DROP / SHOW SEMANTIC VIEW` to be classified as `PARSE_NOT_OURS` (rc=2). DuckDB then surfaced its primary-parser error: `syntax error at or near "SEMANTIC"`.
+
+Reported at https://github.com/anentropic/dbt-duckdb/blob/claude/fix-duckdb-extension-loading-hhWnp/notes/semantic_views_parser_comment_bug.md
+
+## Failing-test-first
+
+Commit `ca9197a` landed reproducer tests *before* the implementation, demonstrating the bug:
+
+- `test/sql/quick_260430_vdz_leading_comments.test` — end-to-end via the C++ FFI + DuckDB parser hook. Covers leading block comments, leading line comments, mixed comments + whitespace, all DDL forms (DESCRIBE / SHOW / ALTER / DROP), comment-only rejection, and unterminated-block safety.
+- `src/parse.rs` `mod tests` additions — 9 helper unit tests (`skip_lws_*`) and 8 integrated detection tests including a regression test that locks in v0.5.1 error-position byte-offset semantics.
+
+## Fix
+
+Commit `edf5196`. Added a private helper to `src/parse.rs`:
+
+```rust
+fn skip_leading_whitespace_and_comments(input: &str) -> usize
+```
+
+- Skips ASCII whitespace.
+- Skips `-- ... \n` line comments (terminate at `\n` or EOF).
+- Skips `/* ... */` block comments (NON-NESTING, Postgres-aligned).
+- Unterminated `/*` consumes to EOF — keyword match fails, falls through to `PARSE_NOT_OURS`.
+- Returns a **byte offset** into the original string (not a stripped slice) so existing `trim_offset` math used by `ParseError.position` continues to point at the correct byte in the original query (the v0.5.1 error-caret invariant).
+
+Applied at five trimming sites previously using `query.trim()`:
+
+| Site | Old | New |
+|---|---|---|
+| `validate_and_rewrite` | `query.trim()` + `trim_offset = ws_count` | `skip_leading_whitespace_and_comments(query)` + `trim_offset = lead` |
+| `detect_ddl_kind` | `query.trim()` | `query[lead..].trim_end()` |
+| `extract_ddl_name` | `query.trim()` | `query[lead..].trim_end()` |
+| `detect_near_miss` | `query.trim()` + `trim_offset = ws_count` | `query[lead..].trim_end()` + `trim_offset = lead` |
+| `rewrite_ddl` | `query.trim()` | `query[lead..].trim_end()` |
+
+`match_keyword_prefix`, `detect_ddl_prefix`, and `body_parser.rs` were intentionally not touched — they operate on already-stripped slices and the new offset semantics propagate correctly.
+
+## Quality Gate
+
+`just test-all` (CLAUDE.md mandate) — green:
+- cargo: 841 tests pass (749 lib + 5 + 36 + 42 + 5 + 3 + 1 doc)
+- sqllogictest: 37 files pass (including new reproducer)
+- DuckLake CI: 6 tests pass
+
+## Files Changed
+
+- `src/parse.rs` — added helper + 17 new tests + 5 site updates
+- `test/sql/quick_260430_vdz_leading_comments.test` — new (sqllogictest reproducer)
+- `test/sql/TEST_LIST` — registered new test file
+
+## Notes for Future Work
+
+- Trailing comments inside DDL bodies (`CREATE … METRICS (…) -- comment`) were not in scope. The body parser uses `trim()` and may not handle inline comments. Defer until reported.
+- v0.7.2 hotfix branch — user will handle release tagging.

--- a/.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/BUG-REPORT.md
+++ b/.planning/quick/260430-vdz-review-bug-report-semantic-views-parser-/BUG-REPORT.md
@@ -1,0 +1,91 @@
+**Source:** https://github.com/anentropic/dbt-duckdb/blob/claude/fix-duckdb-extension-loading-hhWnp/notes/semantic_views_parser_comment_bug.md
+
+**Title:** Parser hook fails to recognise DDL when query is preceded by a SQL comment (breaks dbt-duckdb / any caller that annotates queries)
+
+## Summary
+
+`sv_validate_ddl_rust` (and therefore `sv_parse_stub`) does case-insensitive **prefix** matching on the raw query string but does not strip leading SQL comments (`/* … */`, `-- …`). Any statement of the form
+
+```sql
+/* anything */ CREATE OR REPLACE SEMANTIC VIEW …
+```
+
+is classified as "not our statement" (rc=2 → `DISPLAY_ORIGINAL_ERROR`), so DuckDB falls back to the built-in PostgresParser error:
+
+```
+Parser Error: syntax error at or near "SEMANTIC"
+```
+
+Plain leading whitespace works fine — only comments trigger this.
+
+This makes `semantic_views` effectively unusable through **dbt-duckdb**, because dbt-core unconditionally prepends a query annotation comment (`/* {"app": "dbt", …, "node_id": "model.X"} */`) to every statement it executes. It will also affect anything else that annotates queries (sqlfluff, BI tools that prepend session/user metadata, etc.).
+
+## Reproducer (bare duckdb-python, no dbt)
+
+DuckDB 1.5.2, semantic_views v0.7.1:
+
+```python
+import duckdb
+
+p = duckdb.connect(":memory:", config={"allow_unsigned_extensions": "true"})
+p.execute("INSTALL semantic_views FROM community")
+p.load_extension("semantic_views")
+p.execute("CREATE TABLE t(x INT, y INT)")
+
+DDL = "CREATE OR REPLACE SEMANTIC VIEW sv AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.x AS xx) METRICS (t.y AS sum(y))"
+
+p.execute(DDL)                       # OK
+p.execute("\n\n   " + DDL)           # OK (whitespace only)
+p.execute("/* hi */ " + DDL)         # FAIL: Parser Error: syntax error at or near "SEMANTIC"
+p.execute("-- hi\n" + DDL)           # FAIL: same
+```
+
+## How it manifests in dbt-duckdb
+
+`profiles.yml`:
+```yaml
+extensions:
+  - { name: semantic_views, repo: community }
+```
+
+A `semantic_view` materialization that emits `CREATE OR REPLACE SEMANTIC VIEW …` directly fails with:
+```
+Parser Error: syntax error at or near "semantic"
+LINE 2: create or replace semantic view "memory"."main"."sem_simple" as
+                          ^
+```
+
+even though `INSTALL` and `LOAD` ran successfully on the database. The compiled SQL dbt sends includes its standard query annotation comment in front of the DDL, which is what trips the validator.
+
+## Confirmed dbt workaround
+
+```yaml
+# dbt_project.yml
+query-comment:
+  comment: ''
+  append: true
+```
+
+`append: true` moves the (now-empty) annotation to the trailing position instead of the leading position, which keeps the prefix match happy. Verified end-to-end: `OK created sql semantic_view model main.sem_simple`.
+
+## Suggested fix
+
+In `sv_validate_ddl_rust` (and `sv_parse_stub` if it does any pre-checking), before the keyword match, skip a leading run of:
+
+- whitespace
+- `-- … \n` line comments
+- `/* … */` block comments (handle nesting if you want to be conservative; PostgresParser doesn't, so matching that is fine)
+
+This is what the built-in DuckDB parser already does and what every other parser-extension extension I've seen does. The same change should apply at any other prefix-matching site (e.g. ALTER / DROP / SHOW SEMANTIC VIEW).
+
+## Diagnosis context
+
+I spent a while chasing a dbt-duckdb plumbing hypothesis (per-cursor `LOAD`, pool rebinding) before isolating this. For the record:
+
+- DuckDB 1.5.2 stores parser extensions on `DBConfig::GetCallbackManager()` (database-level, one per `DatabaseInstance`); every `ClientContext` reads from the same registry. Sibling cursors (including ones created before `LOAD`) **do** see registered parser hooks.
+- `sv_register_parser_hooks` correctly registers via `ParserExtension::Register(DBConfig::GetConfig(db), ext)`, so the hooks are visible everywhere on that database.
+- The disconnect is purely at the prefix-match step inside the extension.
+
+Bare-duckdb probes (parent / sibling / before-load cursor / multiple sibling cursors / replay of dbt-duckdb's `LocalEnvironment.handle()` flow) all pass. Add a single `/* … */` to the front of the DDL and they all fail identically.
+
+Happy to PR the fix if useful.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-05-01
+
+### Fixed
+
+- Parser hook now strips leading SQL comments before matching `CREATE / ALTER / DROP / SHOW SEMANTIC VIEW` DDL. Previously, any statement preceded by a `/* ... */` block comment or `-- ... \n` line comment was misclassified as not-our-statement and DuckDB surfaced `Parser Error: syntax error at or near "SEMANTIC"`. This made the extension unusable through dbt-duckdb (which unconditionally prepends a query annotation comment to every statement) and any other tool that prefixes annotations (sqlfluff, BI tools that prepend session/user metadata, etc.). Reported and diagnosed by an external user. Block comments are non-nesting, matching PostgreSQL/DuckDB semantics. Error-position byte offsets are preserved across the consumed comment span, so error carets continue to reference the original query string.
+
 ## [0.7.1] - 2026-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,7 +1863,7 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semantic_views"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arbitrary",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic_views"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "DuckDB extension providing semantic views — a declarative layer for dimensions, measures, and relationships"
 license = "MIT"

--- a/description.yml
+++ b/description.yml
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: anentropic/duckdb-semantic-views
-  ref: 9cc07b74723bcb2977f4b84821e58867cefc2627
+  ref: 74fffadf0b1ef82d8fce01cf93332823b059b1fe
 
 docs:
   hello_world: |

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -86,6 +86,56 @@ fn match_keyword_prefix(input: &[u8], keywords: &[&[u8]]) -> Option<usize> {
     Some(pos)
 }
 
+/// Return the byte offset of the first character that is neither ASCII whitespace
+/// nor part of a SQL comment. Recognises:
+///   - `-- ... \n` line comments (terminated by newline or end-of-input)
+///   - `/* ... */` block comments (NOT nested -- matches PostgreSQL/DuckDB behaviour)
+///
+/// Designed for prefix-matching: never errors. An unterminated `/* ...` consumes to
+/// end of input (so the keyword match below it will simply fail and fall through
+/// to `PARSE_NOT_OURS`, matching today's behaviour for malformed queries).
+///
+/// Returns the byte offset where real SQL begins, in the *original* slice. Callers
+/// substitute this for the `query.len() - query.trim_start().len()` whitespace
+/// offset so that v0.5.1 error-caret positions continue to reference the original
+/// query string after a leading comment is consumed.
+///
+/// Quick task 260430-vdz: fixes parser hook compatibility with dbt-duckdb (and
+/// any other tool that prepends a query annotation comment).
+fn skip_leading_whitespace_and_comments(input: &str) -> usize {
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    loop {
+        // ASCII whitespace
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        // Line comment: -- ... \n
+        if i + 1 < bytes.len() && bytes[i] == b'-' && bytes[i + 1] == b'-' {
+            i += 2;
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue; // re-enter loop to consume more whitespace/comments
+        }
+        // Block comment: /* ... */ (non-nesting, Postgres semantics)
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            if i + 1 < bytes.len() {
+                i += 2; // consume "*/"
+            } else {
+                i = bytes.len(); // unterminated -- consume to end
+            }
+            continue;
+        }
+        break;
+    }
+    i
+}
+
 /// Detect the DDL kind and consumed prefix byte count from a query string.
 ///
 /// The input must already be trimmed of leading/trailing whitespace and
@@ -177,7 +227,8 @@ fn detect_ddl_prefix(trimmed: &str) -> Option<(DdlKind, usize)> {
 /// returns, vertical tabs, form feeds) between prefix keywords.
 #[must_use]
 pub fn detect_ddl_kind(query: &str) -> Option<DdlKind> {
-    let trimmed = query.trim().trim_end_matches(';').trim();
+    let lead = skip_leading_whitespace_and_comments(query);
+    let trimmed = query[lead..].trim_end().trim_end_matches(';').trim();
     detect_ddl_prefix(trimmed).map(|(kind, _)| kind)
 }
 
@@ -584,7 +635,8 @@ fn rewrite_alter(trimmed: &str, plen: usize, kind: DdlKind) -> Result<String, St
 ///
 /// CREATE forms must go through `validate_and_rewrite` -> `rewrite_ddl_keyword_body`.
 fn rewrite_ddl(query: &str) -> Result<String, String> {
-    let trimmed = query.trim();
+    let lead = skip_leading_whitespace_and_comments(query);
+    let trimmed = query[lead..].trim_end();
     let trimmed = trimmed.trim_end_matches(';').trim();
 
     let (kind, plen) = detect_ddl_prefix(trimmed)
@@ -667,7 +719,8 @@ fn rewrite_ddl(query: &str) -> Result<String, String> {
 /// DESCRIBE), and `Ok(None)` for SHOW (no name). Returns `Err` if the query
 /// is not a semantic view DDL statement or is malformed.
 pub fn extract_ddl_name(query: &str) -> Result<Option<String>, String> {
-    let trimmed = query.trim();
+    let lead = skip_leading_whitespace_and_comments(query);
+    let trimmed = query[lead..].trim_end();
     let trimmed = trimmed.trim_end_matches(';').trim();
 
     let (kind, plen) = detect_ddl_prefix(trimmed)
@@ -773,7 +826,8 @@ const DDL_PREFIXES: &[&str] = &[
 /// prefix. Returns `None` if no near-miss is found.
 #[must_use]
 pub fn detect_near_miss(query: &str) -> Option<ParseError> {
-    let trimmed = query.trim();
+    let lead = skip_leading_whitespace_and_comments(query);
+    let trimmed = query[lead..].trim_end();
     let trimmed_no_semi = trimmed.trim_end_matches(';').trim();
     let lower = trimmed_no_semi.to_ascii_lowercase();
 
@@ -801,7 +855,7 @@ pub fn detect_near_miss(query: &str) -> Option<ParseError> {
     }
 
     best.map(|(_, prefix)| {
-        let trim_offset = query.len() - query.trim_start().len();
+        let trim_offset = lead;
         ParseError {
             message: format!(
                 "Unknown statement. Did you mean '{}'?",
@@ -822,9 +876,10 @@ pub fn detect_near_miss(query: &str) -> Option<ParseError> {
 /// - `Ok(None)` -- not a semantic view DDL statement
 /// - `Err(ParseError)` -- validation error with message and optional position
 pub fn validate_and_rewrite(query: &str) -> Result<Option<String>, ParseError> {
-    let trimmed = query.trim();
+    let lead = skip_leading_whitespace_and_comments(query);
+    let trimmed = query[lead..].trim_end();
     let trimmed_no_semi = trimmed.trim_end_matches(';').trim();
-    let trim_offset = query.len() - query.trim_start().len();
+    let trim_offset = lead;
 
     let Some((kind, plen)) = detect_ddl_prefix(trimmed_no_semi) else {
         return Ok(None);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3280,4 +3280,146 @@ $$"#;
             err.message
         );
     }
+
+    // ===================================================================
+    // Quick task 260430-vdz: leading-comment skipping
+    //
+    // Failing-test-first: these reference `skip_leading_whitespace_and_comments`
+    // and rely on the helper being applied at five trimming sites. They will
+    // not compile/pass until the fix lands in the next commit.
+    // ===================================================================
+
+    #[test]
+    fn skip_lws_empty() {
+        assert_eq!(skip_leading_whitespace_and_comments(""), 0);
+    }
+
+    #[test]
+    fn skip_lws_only_whitespace() {
+        assert_eq!(skip_leading_whitespace_and_comments("   \n\t"), 5);
+    }
+
+    #[test]
+    fn skip_lws_line_comment() {
+        let q = "-- hi\nCREATE";
+        assert_eq!(&q[skip_leading_whitespace_and_comments(q)..], "CREATE");
+    }
+
+    #[test]
+    fn skip_lws_block_comment() {
+        let q = "/* hi */ CREATE";
+        assert_eq!(&q[skip_leading_whitespace_and_comments(q)..], "CREATE");
+    }
+
+    #[test]
+    fn skip_lws_multiple_comments_and_ws() {
+        let q = "-- a\n  /* b */\n\t-- c\n/*d*/CREATE";
+        assert_eq!(&q[skip_leading_whitespace_and_comments(q)..], "CREATE");
+    }
+
+    #[test]
+    fn skip_lws_block_does_not_nest() {
+        // Outer ends at first */, leaving "trailing */ CREATE"
+        let q = "/* outer /* inner */ trailing */ CREATE";
+        let rest = &q[skip_leading_whitespace_and_comments(q)..];
+        assert!(rest.starts_with("trailing"), "got: {rest:?}");
+    }
+
+    #[test]
+    fn skip_lws_unterminated_block_consumes_to_eof() {
+        let q = "/* never ends";
+        assert_eq!(skip_leading_whitespace_and_comments(q), q.len());
+    }
+
+    #[test]
+    fn skip_lws_no_leading_match() {
+        // No comments and no whitespace -> offset 0
+        assert_eq!(skip_leading_whitespace_and_comments("CREATE"), 0);
+    }
+
+    #[test]
+    fn skip_lws_dash_dash_at_eof() {
+        let q = "-- no newline at end";
+        assert_eq!(skip_leading_whitespace_and_comments(q), q.len());
+    }
+
+    #[test]
+    fn detect_create_with_leading_block_comment() {
+        assert_eq!(
+            detect_semantic_view_ddl("/* hi */ CREATE SEMANTIC VIEW x AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.xx AS t.x) METRICS (t.sy AS SUM(t.y))"),
+            PARSE_DETECTED
+        );
+    }
+
+    #[test]
+    fn detect_create_with_leading_line_comment() {
+        assert_eq!(
+            detect_semantic_view_ddl("-- hi\nCREATE SEMANTIC VIEW x AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.xx AS t.x) METRICS (t.sy AS SUM(t.y))"),
+            PARSE_DETECTED
+        );
+    }
+
+    #[test]
+    fn detect_create_or_replace_with_dbt_style_annotation() {
+        let q = "/* {\"app\": \"dbt\", \"node_id\": \"model.x\"} */ CREATE OR REPLACE SEMANTIC VIEW x AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.xx AS t.x) METRICS (t.sy AS SUM(t.y))";
+        assert_eq!(detect_semantic_view_ddl(q), PARSE_DETECTED);
+        let kind = detect_ddl_kind(q);
+        assert_eq!(kind, Some(DdlKind::CreateOrReplace));
+    }
+
+    #[test]
+    fn detect_other_ddl_forms_with_leading_comment() {
+        for q in [
+            "/* x */ DROP SEMANTIC VIEW v",
+            "/* x */ ALTER SEMANTIC VIEW v RENAME TO w",
+            "/* x */ DESCRIBE SEMANTIC VIEW v",
+            "/* x */ SHOW SEMANTIC VIEWS",
+            "/* x */ SHOW SEMANTIC METRICS IN v",
+            "-- annotation\nDROP SEMANTIC VIEW v",
+        ] {
+            assert_eq!(detect_semantic_view_ddl(q), PARSE_DETECTED, "failed: {q}");
+        }
+    }
+
+    #[test]
+    fn comment_only_is_not_semantic_view_ddl() {
+        assert_eq!(
+            detect_semantic_view_ddl("/* just a comment */"),
+            PARSE_NOT_OURS
+        );
+        assert_eq!(
+            detect_semantic_view_ddl("-- just a comment\n"),
+            PARSE_NOT_OURS
+        );
+    }
+
+    #[test]
+    fn validate_and_rewrite_with_leading_comment_succeeds() {
+        let q = "/* annotation */ DROP SEMANTIC VIEW v";
+        let result = validate_and_rewrite(q).expect("should not error");
+        assert!(result.is_some(), "expected DDL detection");
+        let sql = result.unwrap();
+        assert!(sql.contains("drop_semantic_view"), "got: {sql}");
+    }
+
+    #[test]
+    fn extract_ddl_name_with_leading_comment() {
+        assert_eq!(
+            extract_ddl_name("/* annotation */ DROP SEMANTIC VIEW my_view").unwrap(),
+            Some("my_view".to_string())
+        );
+    }
+
+    #[test]
+    fn error_position_accounts_for_leading_comment() {
+        // Missing view name -- error position should point at the offset AFTER
+        // both the comment AND the prefix, in the ORIGINAL query string.
+        let q = "/* hi */ DROP SEMANTIC VIEW";
+        let err = validate_and_rewrite(q).expect_err("should error: missing name");
+        let pos = err.position.expect("position should be set");
+        // Position should be inside the original string (not into the stripped slice).
+        // The prefix "DROP SEMANTIC VIEW" starts at byte 9 (after "/* hi */ ").
+        // After consuming the prefix (18 bytes), we're at byte 27 == query.len().
+        assert_eq!(pos, q.len(), "position should reference original query");
+    }
 }

--- a/test/sql/TEST_LIST
+++ b/test/sql/TEST_LIST
@@ -34,3 +34,4 @@ test/sql/phase54_materializations.test
 test/sql/phase55_materialization_routing.test
 test/sql/phase56_yaml_export.test
 test/sql/phase57_introspection.test
+test/sql/quick_260430_vdz_leading_comments.test

--- a/test/sql/quick_260430_vdz_leading_comments.test
+++ b/test/sql/quick_260430_vdz_leading_comments.test
@@ -1,0 +1,82 @@
+# Quick task 260430-vdz: parser hook should accept DDL preceded by SQL comments.
+#
+# Before the fix: every statement under the dbt query annotation comment fails
+# with "Parser Error: syntax error at or near \"SEMANTIC\"" because the prefix
+# match anchors at the trimmed start of the query and does not skip /* */ or --.
+#
+# Reported by dbt-duckdb users -- dbt-core unconditionally prepends a query
+# annotation comment of the form `/* {"app": "dbt", "node_id": "model.X"} */`
+# to every statement, which trips the prefix matcher.
+
+require semantic_views
+
+statement ok
+CREATE TABLE t(x INTEGER, y INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 10), (2, 20);
+
+# Baseline: plain DDL works
+statement ok
+CREATE OR REPLACE SEMANTIC VIEW sv_plain AS
+TABLES (t AS t PRIMARY KEY (x))
+DIMENSIONS (t.xx AS t.x)
+METRICS (t.sy AS SUM(t.y))
+
+# Baseline: leading whitespace works (current behaviour)
+statement ok
+
+
+   CREATE OR REPLACE SEMANTIC VIEW sv_ws AS
+TABLES (t AS t PRIMARY KEY (x))
+DIMENSIONS (t.xx AS t.x)
+METRICS (t.sy AS SUM(t.y))
+
+# Bug repro #1: leading block comment (the dbt-duckdb case)
+statement ok
+/* {"app": "dbt", "node_id": "model.x"} */ CREATE OR REPLACE SEMANTIC VIEW sv_block AS
+TABLES (t AS t PRIMARY KEY (x))
+DIMENSIONS (t.xx AS t.x)
+METRICS (t.sy AS SUM(t.y))
+
+# Bug repro #2: leading line comment
+statement ok
+-- annotation
+CREATE OR REPLACE SEMANTIC VIEW sv_line AS
+TABLES (t AS t PRIMARY KEY (x))
+DIMENSIONS (t.xx AS t.x)
+METRICS (t.sy AS SUM(t.y))
+
+# Multiple comments + interleaved whitespace
+statement ok
+-- a
+/* b */
+   -- c
+/* d */ CREATE OR REPLACE SEMANTIC VIEW sv_mixed AS
+TABLES (t AS t PRIMARY KEY (x))
+DIMENSIONS (t.xx AS t.x)
+METRICS (t.sy AS SUM(t.y))
+
+# Other DDL forms must also work with leading comments
+statement ok
+/* x */ DESCRIBE SEMANTIC VIEW sv_block
+
+statement ok
+/* x */ SHOW SEMANTIC VIEWS
+
+statement ok
+/* x */ ALTER SEMANTIC VIEW sv_block SET COMMENT = 'hello'
+
+statement ok
+/* x */ DROP SEMANTIC VIEW sv_line
+
+# Comment-only must NOT be classified as semantic-view DDL.
+# (DuckDB will give its own error for the empty/comment-only statement.)
+statement error
+/* nothing */
+----
+
+# Unterminated block comment must NOT panic and must NOT match.
+statement error
+/* unterminated CREATE SEMANTIC VIEW broken AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.xx AS t.x) METRICS (t.sy AS SUM(t.y))
+----

--- a/test/sql/quick_260430_vdz_leading_comments.test
+++ b/test/sql/quick_260430_vdz_leading_comments.test
@@ -23,10 +23,10 @@ TABLES (t AS t PRIMARY KEY (x))
 DIMENSIONS (t.xx AS t.x)
 METRICS (t.sy AS SUM(t.y))
 
-# Baseline: leading whitespace works (current behaviour)
+# Baseline: leading single-line whitespace works (current behaviour).
+# sqllogictest treats blank lines as block terminators, so this exercises
+# leading spaces only -- multiline whitespace is covered by Rust unit tests.
 statement ok
-
-
    CREATE OR REPLACE SEMANTIC VIEW sv_ws AS
 TABLES (t AS t PRIMARY KEY (x))
 DIMENSIONS (t.xx AS t.x)


### PR DESCRIPTION
Work on https://github.com/anentropic/dbt-duckdb-semantic-views identified the following issue:

---

Parser hook fails to recognise DDL when query is preceded by a SQL comment (breaks dbt-duckdb / any caller that annotates queries)

## Summary

`sv_validate_ddl_rust` (and therefore `sv_parse_stub`) does case-insensitive **prefix** matching on the raw query string but does not strip leading SQL comments (`/* … */`, `-- …`). Any statement of the form

```sql
/* anything */ CREATE OR REPLACE SEMANTIC VIEW …
```

is classified as "not our statement" (rc=2 → `DISPLAY_ORIGINAL_ERROR`), so DuckDB falls back to the built-in PostgresParser error:

```
Parser Error: syntax error at or near "SEMANTIC"
```

Plain leading whitespace works fine — only comments trigger this.

This makes `semantic_views` effectively unusable through **dbt-duckdb**, because dbt-core unconditionally prepends a query annotation comment (`/* {"app": "dbt", …, "node_id": "model.X"} */`) to every statement it executes. It will also affect anything else that annotates queries (sqlfluff, BI tools that prepend session/user metadata, etc.).

## Reproducer (bare duckdb-python, no dbt)

DuckDB 1.5.2, semantic_views v0.7.1:

```python
import duckdb

p = duckdb.connect(":memory:", config={"allow_unsigned_extensions": "true"})
p.execute("INSTALL semantic_views FROM community")
p.load_extension("semantic_views")
p.execute("CREATE TABLE t(x INT, y INT)")

DDL = "CREATE OR REPLACE SEMANTIC VIEW sv AS TABLES (t AS t PRIMARY KEY (x)) DIMENSIONS (t.x AS xx) METRICS (t.y AS sum(y))"

p.execute(DDL)                       # OK
p.execute("\n\n   " + DDL)           # OK (whitespace only)
p.execute("/* hi */ " + DDL)         # FAIL: Parser Error: syntax error at or near "SEMANTIC"
p.execute("-- hi\n" + DDL)           # FAIL: same
```

## How it manifests in dbt-duckdb

`profiles.yml`:
```yaml
extensions:
  - { name: semantic_views, repo: community }
```

A `semantic_view` materialization that emits `CREATE OR REPLACE SEMANTIC VIEW …` directly fails with:
```
Parser Error: syntax error at or near "semantic"
LINE 2: create or replace semantic view "memory"."main"."sem_simple" as
                          ^
```

even though `INSTALL` and `LOAD` ran successfully on the database. The compiled SQL dbt sends includes its standard query annotation comment in front of the DDL, which is what trips the validator.

## Confirmed dbt workaround

```yaml
# dbt_project.yml
query-comment:
  comment: ''
  append: true
```

`append: true` moves the (now-empty) annotation to the trailing position instead of the leading position, which keeps the prefix match happy. Verified end-to-end: `OK created sql semantic_view model main.sem_simple`.

## Suggested fix

In `sv_validate_ddl_rust` (and `sv_parse_stub` if it does any pre-checking), before the keyword match, skip a leading run of:

- whitespace
- `-- … \n` line comments
- `/* … */` block comments (handle nesting if you want to be conservative; PostgresParser doesn't, so matching that is fine)

This is what the built-in DuckDB parser already does and what every other parser-extension extension I've seen does. The same change should apply at any other prefix-matching site (e.g. ALTER / DROP / SHOW SEMANTIC VIEW).

## Diagnosis context

I spent a while chasing a dbt-duckdb plumbing hypothesis (per-cursor `LOAD`, pool rebinding) before isolating this. For the record:

- DuckDB 1.5.2 stores parser extensions on `DBConfig::GetCallbackManager()` (database-level, one per `DatabaseInstance`); every `ClientContext` reads from the same registry. Sibling cursors (including ones created before `LOAD`) **do** see registered parser hooks.
- `sv_register_parser_hooks` correctly registers via `ParserExtension::Register(DBConfig::GetConfig(db), ext)`, so the hooks are visible everywhere on that database.
- The disconnect is purely at the prefix-match step inside the extension.

Bare-duckdb probes (parent / sibling / before-load cursor / multiple sibling cursors / replay of dbt-duckdb's `LocalEnvironment.handle()` flow) all pass. Add a single `/* … */` to the front of the DDL and they all fail identically.