### PR TITLE
v0.8.0: transactional CREATE/DROP/ALTER SEMANTIC VIEW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-02
+
+### Added
+
+- Transactional DDL: `CREATE`, `DROP`, and `ALTER SEMANTIC VIEW` now participate in the caller's transaction. `BEGIN ... ROLLBACK` rolls back uncommitted catalog changes and `BEGIN ... COMMIT` persists them, matching the contract that ADBC, dbt, and other transaction-aware clients expect.
+- `parser_override` extension hook: recognised DDL is rewritten into native `INSERT` / `UPDATE` / `DELETE` against `semantic_layer._definitions` and executed on the caller's connection. Non-matching statements fall through to DuckDB's default parser unchanged.
+- All four `CREATE` forms participate in the caller's transaction: inline `AS` keyword body, inline `FROM YAML $$ ... $$`, `FROM YAML FILE '<path>'` (including `https://` and S3 paths via httpfs), and `CREATE OR REPLACE` / `CREATE IF NOT EXISTS` variants.
+- `peg_compat.test`: regression coverage that the override path keeps working under DuckDB's experimental PEG parser, so v0.8.0's transactional DDL survives the upcoming parser switch.
+- ADBC end-to-end test (`test/integration/test_adbc_transactions.py`, runnable via `just test-adbc`) exercising `autocommit=False` rollback / commit semantics for inline, FROM YAML FILE, ALTER, and DROP forms — proves the original ADBC bug is fixed end-to-end.
+
+### Changed
+
+- The in-memory `CatalogState` HashMap that mirrored `_definitions` was removed. All catalog reads now query `_definitions` directly through a single shared `CatalogReader`. This eliminates the divergence risk between the HashMap and the on-disk table that the old write-through-both pattern carried.
+
+### Known limitations
+
+- `semantic_view(...)` queries do not see uncommitted writes to user tables in the same transaction. Expansion runs on a separate `query_conn`, which only sees committed state. Workaround: commit the user-table writes before querying. Inline expansion will be revisited when DuckDB 2.0's PEG grammar-extension API ships.
+- A `CREATE SEMANTIC VIEW` issued in the same uncommitted transaction is no longer visible to subsequent reads in that transaction (e.g. `SHOW SEMANTIC VIEWS` will not list it until commit). Pre-v0.8.0 this happened to work because the in-memory HashMap was updated eagerly; with the HashMap gone, reads see only committed catalog state. Workaround: commit before reading.
+
 ## [0.7.2] - 2026-05-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,7 +1863,7 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semantic_views"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "arbitrary",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic_views"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2021"
 description = "DuckDB extension providing semantic views — a declarative layer for dimensions, measures, and relationships"
 license = "MIT"

--- a/Justfile
+++ b/Justfile
@@ -110,10 +110,17 @@ test-caret: build
 test-adbc: build
     uv run test/integration/test_adbc_transactions.py
 
-# Run all tests: Rust unit tests + SQL logic tests + DuckLake integration + vtab crash + caret position + ADBC
+# Run regression test for the v0.8.0 silent-truncation FFI buffer bug.
+# Creates a semantic view large enough that the rewritten INSERT exceeds
+# the legacy 64 KB shim buffer; pre-fix this would have produced a
+# misleading "Parser Error: syntax error" instead of succeeding.
+test-large-view: build
+    uv run test/integration/test_large_view_rewrite.py
+
+# Run all tests: Rust unit tests + SQL logic tests + DuckLake integration + vtab crash + caret position + ADBC + large-view
 # Note: test-iceberg requires `just setup-ducklake` first. test-ducklake-ci uses synthetic data.
 # _ensure-test-deps runs early to catch pip version mismatches before slow builds.
-test-all: _ensure-test-deps test-rust test-sql test-ducklake-ci test-vtab-crash test-caret test-adbc
+test-all: _ensure-test-deps test-rust test-sql test-ducklake-ci test-vtab-crash test-caret test-adbc test-large-view
 
 # Check that fuzz targets compile (requires nightly)
 check-fuzz:

--- a/Justfile
+++ b/Justfile
@@ -103,10 +103,17 @@ test-vtab-crash: build
 test-caret: build
     uv run test/integration/test_caret_position.py
 
-# Run all tests: Rust unit tests + SQL logic tests + DuckLake integration + vtab crash + caret position
+# Run ADBC end-to-end transactional DDL tests against the built extension.
+# Exercises CREATE / DROP / ALTER SEMANTIC VIEW under an ADBC autocommit=False
+# connection — proves the v0.8.0 transactional-DDL fix works for the original
+# motivating bug.
+test-adbc: build
+    uv run test/integration/test_adbc_transactions.py
+
+# Run all tests: Rust unit tests + SQL logic tests + DuckLake integration + vtab crash + caret position + ADBC
 # Note: test-iceberg requires `just setup-ducklake` first. test-ducklake-ci uses synthetic data.
 # _ensure-test-deps runs early to catch pip version mismatches before slow builds.
-test-all: _ensure-test-deps test-rust test-sql test-ducklake-ci test-vtab-crash test-caret
+test-all: _ensure-test-deps test-rust test-sql test-ducklake-ci test-vtab-crash test-caret test-adbc
 
 # Check that fuzz targets compile (requires nightly)
 check-fuzz:

--- a/Justfile
+++ b/Justfile
@@ -117,10 +117,18 @@ test-adbc: build
 test-large-view: build
     uv run test/integration/test_large_view_rewrite.py
 
-# Run all tests: Rust unit tests + SQL logic tests + DuckLake integration + vtab crash + caret position + ADBC + large-view
+# Multi-DB DDL isolation regression: load the extension into two databases
+# in the same process and verify DESCRIBE / SHOW route to the right database.
+# Pre-fix the C++ shim held a global sv_ddl_conn that the second LOAD would
+# overwrite, causing the first DB's DESCRIBE/SHOW to silently target the
+# second DB's connection.
+test-multi-db: build
+    uv run test/integration/test_multi_db_isolation.py
+
+# Run all tests: Rust unit tests + SQL logic tests + DuckLake integration + vtab crash + caret position + ADBC + large-view + multi-DB
 # Note: test-iceberg requires `just setup-ducklake` first. test-ducklake-ci uses synthetic data.
 # _ensure-test-deps runs early to catch pip version mismatches before slow builds.
-test-all: _ensure-test-deps test-rust test-sql test-ducklake-ci test-vtab-crash test-caret test-adbc test-large-view
+test-all: _ensure-test-deps test-rust test-sql test-ducklake-ci test-vtab-crash test-caret test-adbc test-large-view test-multi-db
 
 # Check that fuzz targets compile (requires nightly)
 check-fuzz:

--- a/cpp/include/parser_extension_compat.hpp
+++ b/cpp/include/parser_extension_compat.hpp
@@ -17,11 +17,15 @@
 // these declarations still match by:
 //   grep -A 120 'duckdb/parser/parser_extension.hpp' cpp/include/duckdb.cpp
 //
-// NOTE: We intentionally omit the ParserOverrideResult constructors that
-// take vector<unique_ptr<SQLStatement>> and std::exception&, because we
-// never construct ParserOverrideResult objects. The default constructor
-// and the struct layout (type, statements, error fields in order) match
-// duckdb.cpp exactly, which is what matters for ODR compliance.
+// NOTE: ParserOverrideResult constructors are kept in sync with duckdb.cpp;
+// shim.cpp constructs all three forms (default, statements, exception).
+// The struct layout (type, statements, error fields in order) must match
+// duckdb.cpp exactly for ODR compliance.
+//
+// AllowParserOverride enum, full ParserOptions struct, and minimal Parser
+// class declaration are also re-declared here so shim.cpp can re-parse
+// rewritten SQL produced by the parser_override callback. Definitions
+// match duckdb.cpp lines ~23790, ~23800, ~23949.
 
 #pragma once
 
@@ -116,7 +120,22 @@ struct ParserOverrideResult {
 	ErrorData error;
 };
 
-struct ParserOptions;
+//===--------------------------------------------------------------------===//
+// AllowParserOverride
+//===--------------------------------------------------------------------===//
+enum class AllowParserOverride : uint8_t { DEFAULT_OVERRIDE, FALLBACK_OVERRIDE, STRICT_OVERRIDE };
+
+//===--------------------------------------------------------------------===//
+// ParserOptions
+//===--------------------------------------------------------------------===//
+struct ParserOptions {
+	bool preserve_identifier_case = true;
+	bool integer_division = false;
+	idx_t max_expression_depth = 1000;
+	optional_ptr<const ExtensionCallbackManager> extensions;
+	AllowParserOverride parser_override_setting = AllowParserOverride::DEFAULT_OVERRIDE;
+};
+
 typedef ParserOverrideResult (*parser_override_function_t)(ParserExtensionInfo *info, const string &query,
                                                            ParserOptions &options);
 
@@ -149,6 +168,19 @@ class ExtensionCallbackManager {
 public:
 	static ExtensionCallbackManager &Get(DatabaseInstance &db);
 	void Register(ParserExtension extension);
+};
+
+//===--------------------------------------------------------------------===//
+// Parser (minimal — only the surface shim.cpp uses to re-parse rewritten SQL)
+//===--------------------------------------------------------------------===//
+class Parser {
+public:
+	explicit Parser(ParserOptions options = ParserOptions());
+
+	vector<unique_ptr<SQLStatement>> statements;
+
+public:
+	void ParseQuery(const string &query);
 };
 
 } // namespace duckdb

--- a/cpp/include/parser_extension_compat.hpp
+++ b/cpp/include/parser_extension_compat.hpp
@@ -173,6 +173,13 @@ public:
 //===--------------------------------------------------------------------===//
 // Parser (minimal — only the surface shim.cpp uses to re-parse rewritten SQL)
 //===--------------------------------------------------------------------===//
+//
+// Layout MUST mirror duckdb::Parser in the linked amalgamation exactly,
+// including the trailing private `options` field. Truncating it makes
+// `Parser parser;` allocate too little storage and the constructor / ParseQuery
+// will write past the object — observed as garbage parse errors like
+// `syntax error at or near "" position 0`. Keep this in sync with
+// duckdb.cpp's class Parser declaration when bumping DuckDB.
 class Parser {
 public:
 	explicit Parser(ParserOptions options = ParserOptions());
@@ -181,6 +188,9 @@ public:
 
 public:
 	void ParseQuery(const string &query);
+
+private:
+	ParserOptions options;
 };
 
 } // namespace duckdb

--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -14,6 +14,9 @@
 // them. See cpp/include/parser_extension_compat.hpp for details.
 
 #include "parser_extension_compat.hpp"
+#include <atomic>
+#include <cstdint>
+#include <memory>
 
 using namespace duckdb;
 
@@ -55,11 +58,29 @@ extern "C" {
     // for re-parsing through DuckDB's own parser and execution on the caller's
     // connection. Distinct from sv_rewrite_ddl_rust which targets the internal
     // table function. Returns 0=success, 1=validation error, 2=not-ours.
+    //
+    // `db_token` identifies which database's catalog connection to use for
+    // existence checks and CREATE-time enrichment. Each extension load is
+    // assigned a unique token (see sv_register_parser_hooks) so multi-DB
+    // processes (e.g. Python tests opening successive in-memory + file-backed
+    // databases) don't share a stale catalog connection.
     uint8_t sv_parser_override_rust(
+        uint64_t db_token,
         const char *query_ptr, size_t query_len,
         char *sql_out, size_t sql_out_len,
         char *error_out, size_t error_out_len);
 }
+
+// Per-extension-load info struct attached to ParserExtension::parser_info.
+// `db_token` selects the right catalog connection on the Rust side; we
+// generate a fresh token on every sv_register_parser_hooks call so each
+// loaded database has an isolated entry in the Rust-side connection map.
+struct SemanticViewsParserInfo : public ParserExtensionInfo {
+    uint64_t db_token;
+    explicit SemanticViewsParserInfo(uint64_t token) : db_token(token) {}
+};
+
+static std::atomic<uint64_t> sv_next_db_token{1};
 
 // ---------------------------------------------------------------------------
 // File-scope static: DDL connection for executing rewritten statements
@@ -359,13 +380,22 @@ static void sv_ddl_execute(ClientContext &, TableFunctionInput &input,
 // disabled (allow_parser_override_extension=DEFAULT) or our override hits an
 // unexpected error — preserving v0.7.x non-transactional behaviour as a safety net.
 static ParserOverrideResult sv_parser_override(
-    ParserExtensionInfo *, const string &query, ParserOptions &) {
+    ParserExtensionInfo *info, const string &query, ParserOptions &) {
 
     std::string sql_str(65536, '\0');  // 64 KB headroom for large rewritten DDL
     char error_buf[1024];
     memset(error_buf, 0, sizeof(error_buf));
 
+    // Identify which DB's catalog connection this query should use. info is
+    // the per-extension-load SemanticViewsParserInfo we attached at registration
+    // time; without it we cannot route correctly, so defer to the legacy path.
+    auto *sv_info = dynamic_cast<SemanticViewsParserInfo *>(info);
+    if (!sv_info) {
+        return ParserOverrideResult();
+    }
+
     uint8_t rc = sv_parser_override_rust(
+        sv_info->db_token,
         query.c_str(), query.size(),
         sql_str.data(), sql_str.size(),
         error_buf, sizeof(error_buf));
@@ -422,7 +452,9 @@ static ParserExtensionPlanResult sv_plan_function(
 // execution. Extracts DatabaseInstance& and registers the parser extension
 // hooks on DBConfig.
 extern "C" {
-    bool sv_register_parser_hooks(duckdb_database db_handle, duckdb_connection ddl_conn) {
+    bool sv_register_parser_hooks(duckdb_database db_handle,
+                                  duckdb_connection ddl_conn,
+                                  uint64_t *out_db_token) {
         try {
             // Store the DDL connection for use by sv_ddl_bind
             sv_ddl_conn = ddl_conn;
@@ -437,10 +469,26 @@ extern "C" {
             // Register parser extension.
             // DuckDB 1.5.0 moved parser extension registration from direct
             // vector push_back to ParserExtension::Register(config, ext).
+            //
+            // Allocate a fresh per-load token and stash it on parser_info.
+            // The parser_override callback reads it back to look up the right
+            // catalog connection — required for processes that load the
+            // extension against multiple DBs sequentially (e.g. Python tests).
+            uint64_t token = sv_next_db_token.fetch_add(1, std::memory_order_relaxed);
+            if (out_db_token) {
+                *out_db_token = token;
+            }
             ParserExtension ext;
             ext.parse_function = sv_parse_stub;
             ext.plan_function = sv_plan_function;
             ext.parser_override = sv_parser_override;
+            // duckdb::shared_ptr<T> doesn't have an upcast constructor, so we
+            // build the std::shared_ptr<ParserExtensionInfo> first (allocates
+            // the SemanticViewsParserInfo and immediately upcasts) then hand
+            // it to duckdb::shared_ptr's std-interop constructor.
+            std::shared_ptr<ParserExtensionInfo> info_std(
+                new SemanticViewsParserInfo(token));
+            ext.parser_info = duckdb::shared_ptr<ParserExtensionInfo>(info_std);
             auto &config = DBConfig::GetConfig(db);
             ParserExtension::Register(config, ext);
 

--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -37,19 +37,27 @@ struct SemanticViewParseData : public ParserExtensionParseData {
 // Rust FFI declarations (defined in src/parse.rs)
 // ---------------------------------------------------------------------------
 extern "C" {
-    // DDL rewrite: rewrites DDL to function call SQL (does NOT execute)
-    // Returns 0 on success (SQL written to sql_out), 1 on failure (error in error_out)
+    // DDL rewrite: rewrites DDL to function call SQL (does NOT execute).
+    //
+    // On rc=0: a heap-owned byte buffer pointer + length is written to
+    // *sql_out_ptr / *sql_out_len. The caller takes ownership and MUST
+    // release the buffer via sv_free_buffer once done with it. The buffer
+    // is NOT NUL-terminated — read exactly *sql_out_len bytes.
+    //
+    // On rc=1: error message written to error_out (NUL-terminated, capped at
+    // error_out_len-1 bytes); *sql_out_ptr left untouched (typically null).
     uint8_t sv_rewrite_ddl_rust(
         const char *query_ptr, size_t query_len,
-        char *sql_out, size_t sql_out_len,
+        char **sql_out_ptr, size_t *sql_out_len,
         char *error_out, size_t error_out_len);
 
-    // DDL validation with error reporting: 0=success, 1=error, 2=not-ours
+    // DDL validation with error reporting: 0=success, 1=error, 2=not-ours.
     // On error: error message in error_out, position in *position_out.
     // position_out is set to UINT32_MAX when no position is available.
+    // The validate path discards its rewritten SQL (the parse stub carries
+    // the original query text forward), so no SQL output buffer is needed.
     uint8_t sv_validate_ddl_rust(
         const char *query_ptr, size_t query_len,
-        char *sql_out, size_t sql_out_len,
         char *error_out, size_t error_out_len,
         uint32_t *position_out);
 
@@ -59,6 +67,8 @@ extern "C" {
     // connection. Distinct from sv_rewrite_ddl_rust which targets the internal
     // table function. Returns 0=success, 1=validation error, 2=not-ours.
     //
+    // Same heap-owned out-buffer convention as sv_rewrite_ddl_rust on rc=0.
+    //
     // `db_token` identifies which database's catalog connection to use for
     // existence checks and CREATE-time enrichment. Each extension load is
     // assigned a unique token (see sv_register_parser_hooks) so multi-DB
@@ -67,9 +77,46 @@ extern "C" {
     uint8_t sv_parser_override_rust(
         uint64_t db_token,
         const char *query_ptr, size_t query_len,
-        char *sql_out, size_t sql_out_len,
+        char **sql_out_ptr, size_t *sql_out_len,
         char *error_out, size_t error_out_len);
+
+    // Releases a buffer previously produced by sv_rewrite_ddl_rust or
+    // sv_parser_override_rust. Safe to call with a null pointer (no-op).
+    // ptr/len must be the exact pair the Rust side returned.
+    void sv_free_buffer(char *ptr, size_t len);
 }
+
+// RAII guard for heap-owned buffers returned by the Rust FFI. Ensures the
+// buffer is released even if a downstream call (Parser::ParseQuery,
+// duckdb_query) throws.
+struct SvOwnedBuffer {
+    char *ptr = nullptr;
+    size_t len = 0;
+    SvOwnedBuffer() = default;
+    SvOwnedBuffer(const SvOwnedBuffer &) = delete;
+    SvOwnedBuffer &operator=(const SvOwnedBuffer &) = delete;
+    SvOwnedBuffer(SvOwnedBuffer &&other) noexcept
+        : ptr(other.ptr), len(other.len) {
+        other.ptr = nullptr;
+        other.len = 0;
+    }
+    SvOwnedBuffer &operator=(SvOwnedBuffer &&other) noexcept {
+        if (this != &other) {
+            if (ptr) sv_free_buffer(ptr, len);
+            ptr = other.ptr;
+            len = other.len;
+            other.ptr = nullptr;
+            other.len = 0;
+        }
+        return *this;
+    }
+    ~SvOwnedBuffer() {
+        if (ptr) sv_free_buffer(ptr, len);
+    }
+    string to_string() const {
+        return ptr ? string(ptr, len) : string();
+    }
+};
 
 // Per-extension-load info struct attached to ParserExtension::parser_info.
 // `db_token` selects the right catalog connection on the Rust side; we
@@ -102,7 +149,6 @@ static duckdb_connection sv_ddl_conn = nullptr;
 //   - DISPLAY_ORIGINAL_ERROR: not our statement, let DuckDB show its error
 static ParserExtensionParseResult sv_parse_stub(
     ParserExtensionInfo *, const string &query) {
-    std::string sql_str(16384, '\0');  // 16 KB: validation path, not executed
     char error_buf[1024];
     uint32_t position = UINT32_MAX;
     memset(error_buf, 0, sizeof(error_buf));
@@ -110,7 +156,6 @@ static ParserExtensionParseResult sv_parse_stub(
     uint8_t rc = sv_validate_ddl_rust(
         reinterpret_cast<const char *>(query.c_str()),
         query.size(),
-        sql_str.data(), sql_str.size(),
         error_buf, sizeof(error_buf),
         &position);
 
@@ -169,14 +214,15 @@ static unique_ptr<FunctionData> sv_ddl_bind(
     // The query text is passed as the first (and only) positional parameter
     auto query = StringValue::Get(input.inputs[0]);
 
-    // Step 1: Rewrite DDL to function call SQL via Rust FFI
-    std::string sql_str(65536, '\0');  // 64 KB: execution path needs headroom for large views
+    // Step 1: Rewrite DDL to function call SQL via Rust FFI. Rust hands us
+    // a heap-owned byte buffer (size unbounded — no truncation cap).
+    SvOwnedBuffer sql_buf;
     char error_buf[1024];
     memset(error_buf, 0, sizeof(error_buf));
 
     uint8_t rc = sv_rewrite_ddl_rust(
         query.c_str(), query.size(),
-        sql_str.data(), sql_str.size(),
+        &sql_buf.ptr, &sql_buf.len,
         error_buf, sizeof(error_buf));
 
     if (rc != 0) {
@@ -184,7 +230,7 @@ static unique_ptr<FunctionData> sv_ddl_bind(
     }
 
     // Phase 53: Intercept YAML FILE sentinel and read file before final rewrite
-    string sql(sql_str.c_str());
+    string sql = sql_buf.to_string();
 
     if (sql.rfind("__SV_YAML_FILE__", 0) == 0) {
         // Parse sentinel: __SV_YAML_FILE__<path>\x01<kind>\x01<name>\x01<comment>
@@ -262,21 +308,20 @@ static unique_ptr<FunctionData> sv_ddl_bind(
         }
         reconstructed += " FROM YAML $__sv_file$" + yaml_content + "$__sv_file$";
 
-        // Step 3: Re-invoke Rust rewrite with the inline YAML query
-        // Allocate buffer large enough for potentially large YAML content
-        size_t rewrite_buf_size = std::max(size_t(65536), yaml_content.size() * 2 + 4096);
-        std::string rewrite_sql(rewrite_buf_size, '\0');
+        // Step 3: Re-invoke Rust rewrite with the inline YAML query.
+        // Heap-owned return — no buffer-size heuristic needed.
+        SvOwnedBuffer rewrite_buf;
         memset(error_buf, 0, sizeof(error_buf));
 
         rc = sv_rewrite_ddl_rust(
             reconstructed.c_str(), reconstructed.size(),
-            rewrite_sql.data(), rewrite_sql.size(),
+            &rewrite_buf.ptr, &rewrite_buf.len,
             error_buf, sizeof(error_buf));
 
         if (rc != 0) {
             throw BinderException("Semantic view DDL failed: %s", error_buf);
         }
-        sql = string(rewrite_sql.c_str());
+        sql = rewrite_buf.to_string();
     }
 
     // Step 2: Execute the rewritten SQL on the DDL connection
@@ -382,10 +427,6 @@ static void sv_ddl_execute(ClientContext &, TableFunctionInput &input,
 static ParserOverrideResult sv_parser_override(
     ParserExtensionInfo *info, const string &query, ParserOptions &) {
 
-    std::string sql_str(65536, '\0');  // 64 KB headroom for large rewritten DDL
-    char error_buf[1024];
-    memset(error_buf, 0, sizeof(error_buf));
-
     // Identify which DB's catalog connection this query should use. info is
     // the per-extension-load SemanticViewsParserInfo we attached at registration
     // time; without it we cannot route correctly, so defer to the legacy path.
@@ -394,10 +435,14 @@ static ParserOverrideResult sv_parser_override(
         return ParserOverrideResult();
     }
 
+    SvOwnedBuffer sql_buf;
+    char error_buf[1024];
+    memset(error_buf, 0, sizeof(error_buf));
+
     uint8_t rc = sv_parser_override_rust(
         sv_info->db_token,
         query.c_str(), query.size(),
-        sql_str.data(), sql_str.size(),
+        &sql_buf.ptr, &sql_buf.len,
         error_buf, sizeof(error_buf));
 
     if (rc == 2) {
@@ -413,8 +458,11 @@ static ParserOverrideResult sv_parser_override(
 
     // rc == 0: native SQL produced. Re-parse via DuckDB's Parser. Use
     // default-constructed ParserOptions so parser_override doesn't recurse
-    // (DEFAULT_OVERRIDE skips parser_override hooks entirely).
-    string native_sql(sql_str.c_str());
+    // (DEFAULT_OVERRIDE skips parser_override hooks entirely). The
+    // rewritten SQL is read by exact length, so size is unbounded — the
+    // pre-fix 64 KB cap silently truncated and produced confusing parser
+    // errors for large views.
+    string native_sql = sql_buf.to_string();
     try {
         Parser parser;
         parser.ParseQuery(native_sql);

--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -122,20 +122,29 @@ struct SvOwnedBuffer {
 // `db_token` selects the right catalog connection on the Rust side; we
 // generate a fresh token on every sv_register_parser_hooks call so each
 // loaded database has an isolated entry in the Rust-side connection map.
+// `ddl_conn` is the per-load connection used by the legacy table-function
+// DDL path (sv_ddl_bind) — see SemanticViewsBindInfo for the bind-side
+// counterpart that carries it through TableFunction::function_info.
 struct SemanticViewsParserInfo : public ParserExtensionInfo {
     uint64_t db_token;
-    explicit SemanticViewsParserInfo(uint64_t token) : db_token(token) {}
+    duckdb_connection ddl_conn;
+    SemanticViewsParserInfo(uint64_t token, duckdb_connection conn)
+        : db_token(token), ddl_conn(conn) {}
+};
+
+// Per-load info attached to the sv_ddl_internal TableFunction's function_info.
+// Carries the ddl_conn from sv_plan_function (which has access to the
+// ParserExtensionInfo) down to sv_ddl_bind (which only sees the
+// TableFunctionBindInput.info pointer). Lifetime: the shared_ptr is owned
+// by the TableFunction's function_info; the underlying duckdb_connection
+// is owned by Rust's extension::init_extension for the database's lifetime
+// (we hold a non-owning copy of the handle).
+struct SemanticViewsBindInfo : public TableFunctionInfo {
+    duckdb_connection ddl_conn;
+    explicit SemanticViewsBindInfo(duckdb_connection conn) : ddl_conn(conn) {}
 };
 
 static std::atomic<uint64_t> sv_next_db_token{1};
-
-// ---------------------------------------------------------------------------
-// File-scope static: DDL connection for executing rewritten statements
-// ---------------------------------------------------------------------------
-// Set by sv_register_parser_hooks, used by sv_ddl_bind.
-// This is a separate connection to avoid deadlocking with the main
-// connection's ClientContext lock during bind.
-static duckdb_connection sv_ddl_conn = nullptr;
 
 // ---------------------------------------------------------------------------
 // Parser hook: sv_parse_stub
@@ -206,13 +215,26 @@ struct SvDdlBindData : public FunctionData {
 };
 
 // Bind callback: extracts query from input, calls Rust FFI to rewrite DDL,
-// then executes the rewritten SQL on sv_ddl_conn and captures the full result.
+// then executes the rewritten SQL on the per-load ddl_conn (carried via
+// TableFunction::function_info → SemanticViewsBindInfo) and captures the
+// full result.
 static unique_ptr<FunctionData> sv_ddl_bind(
     ClientContext &, TableFunctionBindInput &input,
     vector<LogicalType> &return_types, vector<string> &names) {
 
     // The query text is passed as the first (and only) positional parameter
     auto query = StringValue::Get(input.inputs[0]);
+
+    // Per-load ddl_conn — attached to function_info by sv_plan_function.
+    // Each extension load has its own SemanticViewsBindInfo so processes
+    // that load the extension into multiple databases (e.g. Python tests)
+    // route DESCRIBE / SHOW SEMANTIC * statements to the right DB.
+    auto *bind_info = dynamic_cast<SemanticViewsBindInfo *>(input.info.get());
+    if (!bind_info || !bind_info->ddl_conn) {
+        throw BinderException(
+            "Semantic view DDL: missing per-load ddl_conn (internal error)");
+    }
+    duckdb_connection ddl_conn = bind_info->ddl_conn;
 
     // Step 1: Rewrite DDL to function call SQL via Rust FFI. Rust hands us
     // a heap-owned byte buffer (size unbounded — no truncation cap).
@@ -270,7 +292,7 @@ static unique_ptr<FunctionData> sv_ddl_bind(
         string read_sql = "SELECT content FROM read_text('" + escaped_path + "')";
 
         duckdb_result file_result;
-        if (duckdb_query(sv_ddl_conn, read_sql.c_str(), &file_result) != DuckDBSuccess) {
+        if (duckdb_query(ddl_conn, read_sql.c_str(), &file_result) != DuckDBSuccess) {
             auto err_ptr = duckdb_result_error(&file_result);
             string err_msg = err_ptr ? string(err_ptr) : "File read failed";
             duckdb_destroy_result(&file_result);
@@ -326,7 +348,7 @@ static unique_ptr<FunctionData> sv_ddl_bind(
 
     // Step 2: Execute the rewritten SQL on the DDL connection
     duckdb_result result;
-    if (duckdb_query(sv_ddl_conn, sql.c_str(), &result) != DuckDBSuccess) {
+    if (duckdb_query(ddl_conn, sql.c_str(), &result) != DuckDBSuccess) {
         auto err_ptr = duckdb_result_error(&result);
         string err_msg = err_ptr ? string(err_ptr) : "DDL execution failed (unknown error)";
         duckdb_destroy_result(&result);
@@ -474,17 +496,30 @@ static ParserOverrideResult sv_parser_override(
 
 // Plan function: transforms the intercepted CREATE SEMANTIC VIEW statement
 // into a DDL-executing TableFunction. The query text is carried from the
-// parse phase via SemanticViewParseData.
+// parse phase via SemanticViewParseData. The per-load ddl_conn is pulled
+// off the SemanticViewsParserInfo and attached to TableFunction::function_info
+// so sv_ddl_bind can route execution to the right database's connection in
+// processes that load the extension into multiple databases.
 static ParserExtensionPlanResult sv_plan_function(
-    ParserExtensionInfo *, ClientContext &,
+    ParserExtensionInfo *info, ClientContext &,
     unique_ptr<ParserExtensionParseData> parse_data) {
     auto &sv_data = dynamic_cast<SemanticViewParseData &>(*parse_data);
+
+    auto *sv_info = dynamic_cast<SemanticViewsParserInfo *>(info);
+    if (!sv_info || !sv_info->ddl_conn) {
+        // Should be impossible — sv_register_parser_hooks always installs
+        // a SemanticViewsParserInfo with a non-null ddl_conn.
+        throw InternalException(
+            "Semantic view DDL: missing parser_info ddl_conn");
+    }
 
     ParserExtensionPlanResult result;
     result.function = TableFunction("sv_ddl_internal",
                                     {LogicalType::VARCHAR},
                                     sv_ddl_execute, sv_ddl_bind,
                                     sv_ddl_init_global);
+    result.function.function_info =
+        make_shared_ptr<SemanticViewsBindInfo>(sv_info->ddl_conn);
     // Push the raw query text as the VARCHAR parameter
     result.parameters.push_back(Value(sv_data.query));
 
@@ -504,9 +539,6 @@ extern "C" {
                                   duckdb_connection ddl_conn,
                                   uint64_t *out_db_token) {
         try {
-            // Store the DDL connection for use by sv_ddl_bind
-            sv_ddl_conn = ddl_conn;
-
             // Extract DatabaseInstance from the C API handle.
             // duckdb_database -> internal_ptr -> DatabaseWrapper ->
             //   shared_ptr<DuckDB> -> shared_ptr<DatabaseInstance>
@@ -522,6 +554,10 @@ extern "C" {
             // The parser_override callback reads it back to look up the right
             // catalog connection — required for processes that load the
             // extension against multiple DBs sequentially (e.g. Python tests).
+            // The same parser_info also carries `ddl_conn` for the legacy
+            // table-function path; sv_plan_function copies it onto each
+            // produced TableFunction's function_info so sv_ddl_bind reaches
+            // the right database's connection.
             uint64_t token = sv_next_db_token.fetch_add(1, std::memory_order_relaxed);
             if (out_db_token) {
                 *out_db_token = token;
@@ -535,7 +571,7 @@ extern "C" {
             // the SemanticViewsParserInfo and immediately upcasts) then hand
             // it to duckdb::shared_ptr's std-interop constructor.
             std::shared_ptr<ParserExtensionInfo> info_std(
-                new SemanticViewsParserInfo(token));
+                new SemanticViewsParserInfo(token, ddl_conn));
             ext.parser_info = duckdb::shared_ptr<ParserExtensionInfo>(info_std);
             auto &config = DBConfig::GetConfig(db);
             ParserExtension::Register(config, ext);

--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -49,6 +49,16 @@ extern "C" {
         char *sql_out, size_t sql_out_len,
         char *error_out, size_t error_out_len,
         uint32_t *position_out);
+
+    // Parser-override DDL rewrite: validates DDL and produces *native* SQL
+    // (INSERT / DELETE / UPDATE against semantic_layer._definitions) suitable
+    // for re-parsing through DuckDB's own parser and execution on the caller's
+    // connection. Distinct from sv_rewrite_ddl_rust which targets the internal
+    // table function. Returns 0=success, 1=validation error, 2=not-ours.
+    uint8_t sv_parser_override_rust(
+        const char *query_ptr, size_t query_len,
+        char *sql_out, size_t sql_out_len,
+        char *error_out, size_t error_out_len);
 }
 
 // ---------------------------------------------------------------------------
@@ -334,6 +344,56 @@ static void sv_ddl_execute(ClientContext &, TableFunctionInput &input,
     state.offset += count;
 }
 
+// ---------------------------------------------------------------------------
+// Parser-override hook: sv_parser_override
+// ---------------------------------------------------------------------------
+// Runs *before* the default parser. Recognized semantic-view DDL is rewritten
+// into native SQL (INSERT / DELETE / UPDATE against semantic_layer._definitions)
+// and re-parsed via DuckDB's own Parser, producing SQLStatement ASTs that DuckDB
+// then plans and executes on the caller's connection — so the writes participate
+// in the caller's transaction (the v0.8.0 fix for ADBC autocommit=false).
+//
+// For non-matching queries, returns DISPLAY_ORIGINAL_ERROR so the dispatcher
+// falls through to the default parser. The legacy sv_parse_stub / sv_plan_function
+// path remains as a defensive fallback for the case where parser_override is
+// disabled (allow_parser_override_extension=DEFAULT) or our override hits an
+// unexpected error — preserving v0.7.x non-transactional behaviour as a safety net.
+static ParserOverrideResult sv_parser_override(
+    ParserExtensionInfo *, const string &query, ParserOptions &) {
+
+    std::string sql_str(65536, '\0');  // 64 KB headroom for large rewritten DDL
+    char error_buf[1024];
+    memset(error_buf, 0, sizeof(error_buf));
+
+    uint8_t rc = sv_parser_override_rust(
+        query.c_str(), query.size(),
+        sql_str.data(), sql_str.size(),
+        error_buf, sizeof(error_buf));
+
+    if (rc == 2) {
+        // Not our query — let DuckDB's default parser handle it.
+        return ParserOverrideResult();
+    }
+
+    if (rc == 1) {
+        // Validation error — propagate the message via DISPLAY_EXTENSION_ERROR.
+        std::runtime_error err(error_buf);
+        return ParserOverrideResult(err);
+    }
+
+    // rc == 0: native SQL produced. Re-parse via DuckDB's Parser. Use
+    // default-constructed ParserOptions so parser_override doesn't recurse
+    // (DEFAULT_OVERRIDE skips parser_override hooks entirely).
+    string native_sql(sql_str.c_str());
+    try {
+        Parser parser;
+        parser.ParseQuery(native_sql);
+        return ParserOverrideResult(std::move(parser.statements));
+    } catch (std::exception &e) {
+        return ParserOverrideResult(e);
+    }
+}
+
 // Plan function: transforms the intercepted CREATE SEMANTIC VIEW statement
 // into a DDL-executing TableFunction. The query text is carried from the
 // parse phase via SemanticViewParseData.
@@ -380,8 +440,16 @@ extern "C" {
             ParserExtension ext;
             ext.parse_function = sv_parse_stub;
             ext.plan_function = sv_plan_function;
+            ext.parser_override = sv_parser_override;
             auto &config = DBConfig::GetConfig(db);
             ParserExtension::Register(config, ext);
+
+            // Enable parser_override dispatch in FALLBACK mode so our hook
+            // runs *before* the default parser for every query, but a miss
+            // (DISPLAY_ORIGINAL_ERROR) cleanly falls through to it. This is
+            // what makes CREATE / DROP / ALTER SEMANTIC VIEW writes participate
+            // in the caller's transaction (v0.8.0).
+            config.SetOption("allow_parser_override_extension", Value("FALLBACK"));
 
             return true;
         } catch (const std::exception &e) {

--- a/description.yml
+++ b/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: semantic_views
   description: "Semantic views -- a declarative layer for dimensions, metrics, and relationships"
-  version: 0.7.1
+  version: 0.7.2
   language: Rust
   build: cargo
   license: MIT
@@ -12,7 +12,7 @@ extension:
 
 repo:
   github: anentropic/duckdb-semantic-views
-  ref: 74fffadf0b1ef82d8fce01cf93332823b059b1fe
+  ref: 9971f4bf0e30756a15cda0b7e1373379626ab123
 
 docs:
   hello_world: |

--- a/description.yml
+++ b/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: semantic_views
   description: "Semantic views -- a declarative layer for dimensions, metrics, and relationships"
-  version: 0.7.2
+  version: 0.8.0
   language: Rust
   build: cargo
   license: MIT

--- a/examples/transactional_ddl.py
+++ b/examples/transactional_ddl.py
@@ -7,6 +7,10 @@
 # ]
 # requires-python = ">=3.10"
 # ///
+# Note: `import adbc_driver_duckdb` resolves to the module bundled inside
+# the `duckdb` wheel (see duckdb-1.5.x dist-info/RECORD). There is no
+# separate `adbc-driver-duckdb` package on PyPI, so it does not appear in
+# the dependencies list above.
 """
 uv run examples/transactional_ddl.py
 

--- a/examples/transactional_ddl.py
+++ b/examples/transactional_ddl.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "duckdb==1.5.2",
+#   "adbc-driver-manager>=1.10",
+#   "pyarrow>=16",
+# ]
+# requires-python = ">=3.10"
+# ///
+"""
+uv run examples/transactional_ddl.py
+
+Demonstrates v0.8.0 features:
+  - Transactional CREATE / DROP / ALTER SEMANTIC VIEW
+  - BEGIN / ROLLBACK actually rolls back catalog changes
+  - Works through ADBC's autocommit=False mode (the original motivating use case)
+
+Two scenarios:
+  1. Native DuckDB connection with explicit BEGIN / COMMIT / ROLLBACK.
+  2. ADBC DBAPI connection (autocommit=False) using commit() / rollback().
+
+Both use the same parser_override mechanism under the hood — DDL is rewritten
+into native INSERT / UPDATE / DELETE against the catalog table and runs on
+the caller's connection, so transaction semantics work exactly as you would
+expect for any other DML.
+"""
+
+import os
+import tempfile
+
+import adbc_driver_duckdb
+import adbc_driver_manager
+import adbc_driver_manager.dbapi
+import duckdb
+
+EXTENSION_PATH = os.environ.get(
+    "SEMANTIC_VIEWS_EXTENSION_PATH",
+    "build/debug/semantic_views.duckdb_extension",
+)
+
+
+def setup(con) -> None:
+    con.execute(
+        """
+        CREATE TABLE orders (
+            id INTEGER PRIMARY KEY,
+            region VARCHAR,
+            amount DECIMAL(10,2)
+        );
+        INSERT INTO orders VALUES
+            (1, 'US', 100.00),
+            (2, 'EU', 200.00),
+            (3, 'US', 150.00);
+        """
+    )
+
+
+CREATE_VIEW = """
+CREATE SEMANTIC VIEW orders_view AS
+  TABLES (o AS orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+"""
+
+
+def list_views(con) -> list[str]:
+    rows = con.execute("SELECT name FROM list_semantic_views()").fetchall()
+    return [r[0] for r in rows]
+
+
+def adbc_list_views(conn) -> list[str]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT name FROM list_semantic_views()")
+        return [r[0] for r in cur.fetchall()]
+
+
+def native_demo() -> None:
+    print("=== Scenario 1: native DuckDB BEGIN / ROLLBACK ===\n")
+    con = duckdb.connect(config={"allow_unsigned_extensions": "true"})
+    con.execute(f"LOAD '{EXTENSION_PATH}'")
+    setup(con)
+
+    print("Before:        ", list_views(con))
+
+    con.execute("BEGIN")
+    con.execute(CREATE_VIEW)
+    con.execute("ROLLBACK")
+    print("After rollback:", list_views(con))
+    print("  -> view did NOT persist (correct).")
+
+    con.execute("BEGIN")
+    con.execute(CREATE_VIEW)
+    con.execute("COMMIT")
+    print("After commit:  ", list_views(con))
+    print("  -> view persisted (correct).\n")
+
+    # ALTER and DROP also participate.
+    con.execute("BEGIN")
+    con.execute("DROP SEMANTIC VIEW orders_view")
+    con.execute("ROLLBACK")
+    print("After DROP+rollback:", list_views(con))
+    print("  -> DROP rolled back, view still present.\n")
+
+    # Note on visibility:
+    #   list_semantic_views() runs on a separate read connection that only
+    #   sees committed catalog state, so a view created in the current
+    #   uncommitted transaction is not visible to it until COMMIT. To
+    #   inspect in-flight catalog rows use the underlying table directly
+    #   on the same connection:
+    second_view = CREATE_VIEW.replace("orders_view", "orders_view_2")
+    con.execute("BEGIN")
+    con.execute(second_view)
+    in_flight = con.execute(
+        "SELECT name FROM semantic_layer._definitions WHERE name = 'orders_view_2'"
+    ).fetchall()
+    print("In-flight (same conn, _definitions):", in_flight)
+    con.execute("ROLLBACK")
+    print()
+
+    con.close()
+
+
+def adbc_demo() -> None:
+    print("=== Scenario 2: ADBC autocommit=False ===\n")
+    with tempfile.TemporaryDirectory(prefix="sv_adbc_demo_") as tmp:
+        db_path = os.path.join(tmp, "demo.duckdb")
+        # The high-level adbc_driver_duckdb.dbapi.connect() does not expose
+        # DBConfig, so we use AdbcDatabase directly. DuckDB's ADBC driver
+        # passes any unrecognised key through duckdb_set_config().
+        db = adbc_driver_manager.AdbcDatabase(
+            driver=adbc_driver_duckdb.driver_path(),
+            entrypoint="duckdb_adbc_init",
+            path=db_path,
+            allow_unsigned_extensions="true",
+        )
+        raw = adbc_driver_manager.AdbcConnection(db)
+        conn = adbc_driver_manager.dbapi.Connection(db, raw, autocommit=False)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(f"LOAD '{EXTENSION_PATH}'")
+                cur.execute(
+                    "CREATE TABLE orders (id INTEGER PRIMARY KEY, "
+                    "region VARCHAR, amount DECIMAL(10,2))"
+                )
+                cur.execute(
+                    "INSERT INTO orders VALUES "
+                    "(1, 'US', 100.00), (2, 'EU', 200.00)"
+                )
+            conn.commit()
+
+            print("Before:        ", adbc_list_views(conn))
+
+            with conn.cursor() as cur:
+                cur.execute(CREATE_VIEW)
+            conn.rollback()
+            print("After rollback:", adbc_list_views(conn))
+            print("  -> view did NOT persist (the v0.8.0 fix).")
+            conn.commit()
+
+            with conn.cursor() as cur:
+                cur.execute(CREATE_VIEW)
+            conn.commit()
+            print("After commit:  ", adbc_list_views(conn))
+            print("  -> view persisted (correct).")
+            conn.commit()
+        finally:
+            conn.close()
+
+
+if __name__ == "__main__":
+    native_demo()
+    adbc_demo()

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "semantic_views"
-version = "0.6.0"
+version = "0.7.2"
 dependencies = [
  "arbitrary",
  "duckdb",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "semantic_views"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "arbitrary",
  "duckdb",

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,33 +1,28 @@
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    sync::{Arc, RwLock},
-};
+//! Persistent catalog for semantic view definitions stored in
+//! `semantic_layer._definitions`.
+//!
+//! Prior to v0.8.0 this module also maintained an in-memory `HashMap` mirror
+//! that DDL writes updated alongside the catalog table. v0.8.0 removed the
+//! mirror so catalog reads always see the same state `DuckDB` does — which is
+//! a prerequisite for transactional DDL: the parser-override path emits
+//! `INSERT/DELETE/UPDATE` against `_definitions` directly on the caller's
+//! connection, and any cached mirror would diverge across rollback.
+
+use std::path::PathBuf;
 
 use duckdb::{Connection, Result};
-
-use crate::model::SemanticViewDefinition;
-
-/// Shared in-memory cache of semantic view definitions.
-/// Key: view name. Value: raw JSON string of the definition.
-pub type CatalogState = Arc<RwLock<HashMap<String, String>>>;
 
 // Extension appended to the DuckDB file path to form the v0.1.0 companion file.
 // Used only in the one-time migration below. After the migration runs, the
 // companion file is deleted and this constant is never referenced again at runtime.
 const V010_COMPANION_EXT: &str = "semantic_views";
 
-/// Create the `semantic_layer` schema and `_definitions` table if they do not exist,
-/// then load all existing rows into a new [`CatalogState`].
+/// Create the `semantic_layer` schema and `_definitions` table if they do not
+/// exist, and run the v0.1.0 companion-file migration once for file-backed
+/// databases.
 ///
-/// For file-backed databases, performs a one-time migration: if a v0.1.0 companion
-/// file exists alongside the database, its contents are imported into the table
-/// and the file is deleted. After the migration runs once, the companion file is
-/// gone and this block is a no-op on subsequent loads.
-///
-/// This function is called once at extension load time. It is idempotent: safe to call
-/// on every extension load regardless of whether the catalog already exists.
-pub fn init_catalog(con: &Connection, db_path: &str) -> Result<CatalogState> {
+/// Idempotent: safe to call on every extension load.
+pub fn init_catalog(con: &Connection, db_path: &str) -> Result<()> {
     con.execute_batch(
         "CREATE SCHEMA IF NOT EXISTS semantic_layer;
          CREATE TABLE IF NOT EXISTS semantic_layer._definitions (
@@ -36,24 +31,9 @@ pub fn init_catalog(con: &Connection, db_path: &str) -> Result<CatalogState> {
          );",
     )?;
 
-    // Read existing rows from the DuckDB table.
-    let mut map = HashMap::new();
-    let mut stmt = con.prepare("SELECT name, definition FROM semantic_layer._definitions")?;
-    let rows = stmt.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-    })?;
-    for row in rows {
-        let (name, def) = row?;
-        map.insert(name, def);
-    }
-
     // One-time migration: if a v0.1.0 companion file exists alongside the database,
     // import its contents into the table then delete the file.
-    // After this migration runs once, the companion file is gone and this block
-    // is a no-op on subsequent loads (file absent → skip silently).
     if db_path != ":memory:" {
-        // Derive the companion file path: <db_path>.<ext>.<V010_COMPANION_EXT>
-        // e.g. /path/to/mydb.duckdb → /path/to/mydb.duckdb.<companion>
         let migration_path: PathBuf = {
             let mut p = PathBuf::from(db_path);
             let ext = match p.extension() {
@@ -64,222 +44,196 @@ pub fn init_catalog(con: &Connection, db_path: &str) -> Result<CatalogState> {
             p
         };
         if migration_path.exists() {
-            // Read v0.1.0 definitions from the companion file
             if let Ok(contents) = std::fs::read_to_string(&migration_path) {
-                if let Ok(migrated) = serde_json::from_str::<HashMap<String, String>>(&contents) {
+                if let Ok(migrated) =
+                    serde_json::from_str::<std::collections::HashMap<String, String>>(&contents)
+                {
                     for (name, def) in &migrated {
-                        // INSERT OR REPLACE: companion file wins on conflict (latest session state)
                         con.execute(
                             "INSERT OR REPLACE INTO semantic_layer._definitions (name, definition) VALUES (?, ?)",
                             duckdb::params![name, def],
                         )?;
-                        // Also update the in-memory map
-                        map.insert(name.clone(), def.clone());
                     }
                 }
             }
-            // Delete the companion file regardless of whether it had data.
-            // Ignore errors (read-only filesystem, race condition, etc.)
             let _ = std::fs::remove_file(&migration_path);
         }
     }
 
-    Ok(Arc::new(RwLock::new(map)))
-}
-
-/// Write a new semantic view definition to the in-memory catalog.
-///
-/// Returns an error if:
-/// - The JSON is invalid
-/// - A view with `name` already exists
-pub fn catalog_insert(
-    state: &CatalogState,
-    name: &str,
-    json: &str,
-) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    // Validate JSON before writing — fail fast, nothing written on invalid input
-    SemanticViewDefinition::from_json(name, json).map_err(Box::<dyn std::error::Error>::from)?;
-
-    let mut guard = state
-        .write()
-        .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?;
-    if guard.contains_key(name) {
-        return Err(format!(
-            "semantic view '{name}' already exists; use CREATE OR REPLACE SEMANTIC VIEW to overwrite"
-        )
-        .into());
-    }
-    guard.insert(name.to_string(), json.to_string());
     Ok(())
 }
 
-/// Remove a semantic view definition from the in-memory catalog.
-///
-/// Returns an error if no view with `name` exists.
-pub fn catalog_delete(
-    state: &CatalogState,
-    name: &str,
-) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let mut guard = state
-        .write()
-        .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?;
-    if !guard.contains_key(name) {
-        return Err(format!("semantic view '{name}' does not exist").into());
-    }
-    guard.remove(name);
-    Ok(())
-}
+// ---------------------------------------------------------------------------
+// CatalogReader — extension-side handle wrapping the catalog connection.
+// ---------------------------------------------------------------------------
+//
+// Gated on the `extension` feature because it depends on the C-API stubs
+// (`duckdb_query`, `duckdb_prepare`, ...) which are only linked when the
+// crate is built as a loadable extension.
 
-/// Write or overwrite a semantic view definition in the in-memory catalog.
-///
-/// Unlike `catalog_insert`, this does not error on duplicates — it replaces
-/// any existing definition for `name`.
-///
-/// Returns an error if the JSON is invalid.
-pub fn catalog_upsert(
-    state: &CatalogState,
-    name: &str,
-    json: &str,
-) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    SemanticViewDefinition::from_json(name, json).map_err(Box::<dyn std::error::Error>::from)?;
-    state
-        .write()
-        .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-        .insert(name.to_string(), json.to_string());
-    Ok(())
-}
-
-/// Remove a semantic view definition from the in-memory catalog if it exists.
-///
-/// Unlike `catalog_delete`, this silently succeeds when the view does not exist.
-pub fn catalog_delete_if_exists(state: &CatalogState, name: &str) {
-    if let Ok(mut guard) = state.write() {
-        guard.remove(name);
-    }
-}
-
-/// Rename a semantic view in the in-memory catalog.
-///
-/// Atomically removes the old name and inserts the new name.
-/// Returns an error if `old_name` does not exist or `new_name` already exists.
-pub fn catalog_rename(
-    state: &CatalogState,
-    old_name: &str,
-    new_name: &str,
-) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let mut guard = state
-        .write()
-        .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?;
-    let json = guard
-        .remove(old_name)
-        .ok_or_else(|| format!("semantic view '{old_name}' does not exist"))?;
-    if guard.contains_key(new_name) {
-        // Rollback: put the old entry back
-        guard.insert(old_name.to_string(), json);
-        return Err(format!("semantic view '{new_name}' already exists").into());
-    }
-    guard.insert(new_name.to_string(), json);
-    Ok(())
-}
-
-/// FFI-callable catalog mutation functions.
-///
-/// These functions are gated on the `extension` feature so they are not included in
-/// standalone test binaries (which cannot use the loadable-extension C API stubs).
-///
-/// All functions take an opaque `*const CatalogState` pointer (the Rust Arc<RwLock<HashMap>>)
-/// and return 0 on success, -1 on error.
 #[cfg(feature = "extension")]
-mod ffi_catalog {
-    use super::*;
-    use std::ffi::c_char;
+mod reader {
+    use std::ffi::{CStr, CString};
+    use std::os::raw::c_void;
 
-    unsafe fn str_from_ptr<'a>(ptr: *const c_char) -> Option<&'a str> {
-        if ptr.is_null() {
-            return None;
+    use libduckdb_sys as ffi;
+
+    /// Read-side handle for `semantic_layer._definitions`.
+    ///
+    /// Wraps a raw `duckdb_connection` ("catalog connection") created at
+    /// extension load time. Reads see the connection's transactional view
+    /// of the table, which for the catalog connection is always committed
+    /// state. Writes performed by parser-override-emitted SQL run on the
+    /// *caller's* connection and become visible here on commit.
+    #[derive(Clone, Copy)]
+    pub struct CatalogReader {
+        conn: ffi::duckdb_connection,
+    }
+
+    // SAFETY: `duckdb_connection` is an opaque pointer managed by DuckDB.
+    // The connection itself owns its synchronisation; reads from multiple
+    // threads via the same handle are serialised by DuckDB internally.
+    unsafe impl Send for CatalogReader {}
+    unsafe impl Sync for CatalogReader {}
+
+    impl CatalogReader {
+        pub fn new(conn: ffi::duckdb_connection) -> Self {
+            Self { conn }
         }
-        std::ffi::CStr::from_ptr(ptr).to_str().ok()
+
+        pub fn raw(&self) -> ffi::duckdb_connection {
+            self.conn
+        }
+
+        /// Fetch the JSON definition for a single view.
+        ///
+        /// Returns `Ok(None)` when no row exists.
+        pub fn lookup(&self, name: &str) -> Result<Option<String>, String> {
+            unsafe { prepared_lookup(self.conn, name) }
+        }
+
+        /// Whether a view with this name exists.
+        pub fn exists(&self, name: &str) -> Result<bool, String> {
+            Ok(self.lookup(name)?.is_some())
+        }
+
+        /// Return `(name, definition_json)` for every registered view,
+        /// sorted by name.
+        pub fn list_all(&self) -> Result<Vec<(String, String)>, String> {
+            unsafe { execute_list_all(self.conn) }
+        }
+
+        /// Return just the view names, sorted.
+        pub fn list_names(&self) -> Result<Vec<String>, String> {
+            Ok(self.list_all()?.into_iter().map(|(n, _)| n).collect())
+        }
     }
 
-    /// Insert a new semantic view into the in-memory catalog.
-    /// Returns 0 on success, -1 if pointer null / json invalid / duplicate.
-    #[no_mangle]
-    pub unsafe extern "C" fn semantic_views_catalog_insert(
-        catalog_ptr: *const CatalogState,
-        name_ptr: *const c_char,
-        json_ptr: *const c_char,
-    ) -> i32 {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let Some(state) = catalog_ptr.as_ref() else {
-                return -1;
+    unsafe fn prepared_lookup(
+        conn: ffi::duckdb_connection,
+        name: &str,
+    ) -> Result<Option<String>, String> {
+        let c_sql =
+            CString::new("SELECT definition FROM semantic_layer._definitions WHERE name = $1")
+                .map_err(|_| "SQL contains null byte".to_string())?;
+        let mut stmt: ffi::duckdb_prepared_statement = std::ptr::null_mut();
+        let rc = ffi::duckdb_prepare(conn, c_sql.as_ptr(), &mut stmt);
+        if rc != ffi::DuckDBSuccess {
+            let err = ffi::duckdb_prepare_error(stmt);
+            let msg = if err.is_null() {
+                "unknown prepare error".to_string()
+            } else {
+                CStr::from_ptr(err).to_string_lossy().into_owned()
             };
-            let (Some(name), Some(json)) = (str_from_ptr(name_ptr), str_from_ptr(json_ptr)) else {
-                return -1;
+            ffi::duckdb_destroy_prepare(&mut stmt);
+            return Err(msg);
+        }
+
+        let c_name = CString::new(name).map_err(|_| "view name contains null byte".to_string())?;
+        if ffi::duckdb_bind_varchar(stmt, 1, c_name.as_ptr()) != ffi::DuckDBSuccess {
+            ffi::duckdb_destroy_prepare(&mut stmt);
+            return Err("failed to bind view name".to_string());
+        }
+
+        let mut result: ffi::duckdb_result = std::mem::zeroed();
+        let exec_rc = ffi::duckdb_execute_prepared(stmt, &mut result);
+        if exec_rc != ffi::DuckDBSuccess {
+            let err_ptr = ffi::duckdb_result_error(&mut result);
+            let msg = if err_ptr.is_null() {
+                "catalog lookup failed".to_string()
+            } else {
+                CStr::from_ptr(err_ptr).to_string_lossy().into_owned()
             };
-            catalog_insert(state, name, json).map(|_| 0).unwrap_or(-1)
-        }));
-        result.unwrap_or(-1)
+            ffi::duckdb_destroy_result(&mut result);
+            ffi::duckdb_destroy_prepare(&mut stmt);
+            return Err(msg);
+        }
+
+        let row_count = ffi::duckdb_row_count(&mut result);
+        let value = if row_count == 0 {
+            None
+        } else {
+            let val_ptr = ffi::duckdb_value_varchar(&mut result, 0, 0);
+            if val_ptr.is_null() {
+                None
+            } else {
+                let s = CStr::from_ptr(val_ptr).to_string_lossy().into_owned();
+                ffi::duckdb_free(val_ptr.cast::<c_void>());
+                Some(s)
+            }
+        };
+        ffi::duckdb_destroy_result(&mut result);
+        ffi::duckdb_destroy_prepare(&mut stmt);
+        Ok(value)
     }
 
-    /// Upsert a semantic view in the in-memory catalog.
-    /// Returns 0 on success, -1 if pointer null or json invalid.
-    #[no_mangle]
-    pub unsafe extern "C" fn semantic_views_catalog_upsert(
-        catalog_ptr: *const CatalogState,
-        name_ptr: *const c_char,
-        json_ptr: *const c_char,
-    ) -> i32 {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let Some(state) = catalog_ptr.as_ref() else {
-                return -1;
+    unsafe fn execute_list_all(
+        conn: ffi::duckdb_connection,
+    ) -> Result<Vec<(String, String)>, String> {
+        let c_sql =
+            CString::new("SELECT name, definition FROM semantic_layer._definitions ORDER BY name")
+                .map_err(|_| "SQL contains null byte".to_string())?;
+        let mut result: ffi::duckdb_result = std::mem::zeroed();
+        let rc = ffi::duckdb_query(conn, c_sql.as_ptr(), &mut result);
+        if rc != ffi::DuckDBSuccess {
+            let err_ptr = ffi::duckdb_result_error(&mut result);
+            let msg = if err_ptr.is_null() {
+                "catalog list failed".to_string()
+            } else {
+                CStr::from_ptr(err_ptr).to_string_lossy().into_owned()
             };
-            let (Some(name), Some(json)) = (str_from_ptr(name_ptr), str_from_ptr(json_ptr)) else {
-                return -1;
-            };
-            catalog_upsert(state, name, json).map(|_| 0).unwrap_or(-1)
-        }));
-        result.unwrap_or(-1)
-    }
+            ffi::duckdb_destroy_result(&mut result);
+            return Err(msg);
+        }
 
-    /// Delete a semantic view from the in-memory catalog.
-    /// Returns 0 on success, -1 if not found.
-    #[no_mangle]
-    pub unsafe extern "C" fn semantic_views_catalog_delete(
-        catalog_ptr: *const CatalogState,
-        name_ptr: *const c_char,
-    ) -> i32 {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let Some(state) = catalog_ptr.as_ref() else {
-                return -1;
+        let row_count = ffi::duckdb_row_count(&mut result);
+        let mut out = Vec::with_capacity(row_count as usize);
+        for r in 0..row_count {
+            let name_ptr = ffi::duckdb_value_varchar(&mut result, 0, r);
+            let def_ptr = ffi::duckdb_value_varchar(&mut result, 1, r);
+            let name = if name_ptr.is_null() {
+                String::new()
+            } else {
+                let s = CStr::from_ptr(name_ptr).to_string_lossy().into_owned();
+                ffi::duckdb_free(name_ptr.cast::<c_void>());
+                s
             };
-            let Some(name) = str_from_ptr(name_ptr) else {
-                return -1;
+            let def = if def_ptr.is_null() {
+                String::new()
+            } else {
+                let s = CStr::from_ptr(def_ptr).to_string_lossy().into_owned();
+                ffi::duckdb_free(def_ptr.cast::<c_void>());
+                s
             };
-            catalog_delete(state, name).map(|_| 0).unwrap_or(-1)
-        }));
-        result.unwrap_or(-1)
-    }
-
-    /// Delete a semantic view if it exists; silently succeeds if absent.
-    /// Returns 0 always (unless null pointer, which returns -1).
-    #[no_mangle]
-    pub unsafe extern "C" fn semantic_views_catalog_delete_if_exists(
-        catalog_ptr: *const CatalogState,
-        name_ptr: *const c_char,
-    ) -> i32 {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let Some(state) = catalog_ptr.as_ref() else {
-                return -1;
-            };
-            let Some(name) = str_from_ptr(name_ptr) else {
-                return -1;
-            };
-            catalog_delete_if_exists(state, name);
-            0
-        }));
-        result.unwrap_or(-1)
+            out.push((name, def));
+        }
+        ffi::duckdb_destroy_result(&mut result);
+        Ok(out)
     }
 }
+
+#[cfg(feature = "extension")]
+pub use reader::CatalogReader;
 
 #[cfg(test)]
 mod tests {
@@ -293,53 +247,18 @@ mod tests {
     #[test]
     fn init_catalog_creates_schema_and_table() {
         let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        assert!(state.read().unwrap().is_empty());
+        init_catalog(&con, ":memory:").unwrap();
         // Idempotent: second call must not error
-        let state2 = init_catalog(&con, ":memory:").unwrap();
-        assert!(state2.read().unwrap().is_empty());
-    }
+        init_catalog(&con, ":memory:").unwrap();
 
-    #[test]
-    fn insert_and_retrieve() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let json = r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#;
-        catalog_insert(&state, "orders", json).unwrap();
-        let guard = state.read().unwrap();
-        assert_eq!(guard.get("orders").map(String::as_str), Some(json));
-    }
-
-    #[test]
-    fn duplicate_insert_is_error() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let json = r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#;
-        catalog_insert(&state, "orders", json).unwrap();
-        let result = catalog_insert(&state, "orders", json);
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("already exists"), "unexpected: {msg}");
-    }
-
-    #[test]
-    fn delete_removes_from_hashmap() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let json = r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#;
-        catalog_insert(&state, "orders", json).unwrap();
-        catalog_delete(&state, "orders").unwrap();
-        assert!(!state.read().unwrap().contains_key("orders"));
-    }
-
-    #[test]
-    fn delete_nonexistent_is_error() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let result = catalog_delete(&state, "nonexistent");
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("does not exist"), "unexpected: {msg}");
+        let count: i64 = con
+            .query_row(
+                "SELECT count(*) FROM semantic_layer._definitions",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
     }
 
     #[test]
@@ -382,195 +301,6 @@ mod tests {
             file_path.is_none(),
             "PRAGMA database_list should return no file path for in-memory DB, got: {file_path:?}"
         );
-    }
-
-    #[test]
-    fn init_catalog_loads_existing_rows() {
-        // Simulate data already in the DuckDB table (no sidecar).
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let json = r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#;
-        // Write directly to the table (simulating a previous entrypoint sync).
-        con.execute(
-            "INSERT INTO semantic_layer._definitions (name, definition) VALUES (?, ?)",
-            duckdb::params!["orders", json],
-        )
-        .unwrap();
-        // Second load: simulates restart — loads from catalog
-        let state2 = init_catalog(&con, ":memory:").unwrap();
-        assert!(state2.read().unwrap().contains_key("orders"));
-        drop(state);
-    }
-
-    #[test]
-    fn upsert_inserts_when_absent() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let json = r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#;
-        catalog_upsert(&state, "orders", json).unwrap();
-        let guard = state.read().unwrap();
-        assert_eq!(guard.get("orders").map(String::as_str), Some(json));
-    }
-
-    #[test]
-    fn upsert_replaces_when_present() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let json1 = r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#;
-        let json2 = r#"{"base_table":"orders","dimensions":[{"name":"region","expr":"region"}],"metrics":[]}"#;
-        catalog_upsert(&state, "orders", json1).unwrap();
-        catalog_upsert(&state, "orders", json2).unwrap();
-        let guard = state.read().unwrap();
-        assert_eq!(guard.get("orders").map(String::as_str), Some(json2));
-    }
-
-    #[test]
-    fn upsert_rejects_invalid_json() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let result = catalog_upsert(&state, "orders", "{invalid json}");
-        assert!(result.is_err());
-        // Catalog must remain unchanged
-        assert!(!state.read().unwrap().contains_key("orders"));
-    }
-
-    #[test]
-    fn delete_if_exists_removes() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let json = r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#;
-        catalog_insert(&state, "orders", json).unwrap();
-        catalog_delete_if_exists(&state, "orders");
-        assert!(!state.read().unwrap().contains_key("orders"));
-    }
-
-    #[test]
-    fn delete_if_exists_silent_when_absent() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        // Should not panic or error
-        catalog_delete_if_exists(&state, "nonexistent");
-        assert!(state.read().unwrap().is_empty());
-    }
-
-    #[test]
-    fn rename_moves_entry() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let json = r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#;
-        catalog_insert(&state, "orders", json).unwrap();
-        catalog_rename(&state, "orders", "sales").unwrap();
-        let guard = state.read().unwrap();
-        assert!(!guard.contains_key("orders"));
-        assert_eq!(guard.get("sales").map(String::as_str), Some(json));
-    }
-
-    #[test]
-    fn rename_nonexistent_is_error() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let result = catalog_rename(&state, "nonexistent", "something");
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("does not exist"), "unexpected: {msg}");
-    }
-
-    #[test]
-    fn catalog_insert_poisoned_lock_returns_error() {
-        let state: CatalogState = Arc::new(RwLock::new(HashMap::new()));
-        // Poison the lock by panicking in a write guard
-        let state_clone = state.clone();
-        let _ = std::thread::spawn(move || {
-            let _guard = state_clone.write().unwrap();
-            panic!("intentional poison");
-        })
-        .join();
-        // Lock is now poisoned
-        let result = catalog_insert(
-            &state,
-            "test",
-            r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#,
-        );
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("poisoned"),
-            "Expected poisoned error, got: {err_msg}"
-        );
-    }
-
-    #[test]
-    fn catalog_delete_poisoned_lock_returns_error() {
-        let state: CatalogState = Arc::new(RwLock::new(HashMap::new()));
-        let state_clone = state.clone();
-        let _ = std::thread::spawn(move || {
-            let _guard = state_clone.write().unwrap();
-            panic!("intentional poison");
-        })
-        .join();
-        let result = catalog_delete(&state, "test");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("poisoned"));
-    }
-
-    #[test]
-    fn catalog_upsert_poisoned_lock_returns_error() {
-        let state: CatalogState = Arc::new(RwLock::new(HashMap::new()));
-        let state_clone = state.clone();
-        let _ = std::thread::spawn(move || {
-            let _guard = state_clone.write().unwrap();
-            panic!("intentional poison");
-        })
-        .join();
-        let result = catalog_upsert(
-            &state,
-            "test",
-            r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#,
-        );
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("poisoned"));
-    }
-
-    #[test]
-    fn catalog_delete_if_exists_poisoned_lock_does_not_panic() {
-        let state: CatalogState = Arc::new(RwLock::new(HashMap::new()));
-        let state_clone = state.clone();
-        let _ = std::thread::spawn(move || {
-            let _guard = state_clone.write().unwrap();
-            panic!("intentional poison");
-        })
-        .join();
-        // Should not panic — silently ignores poisoned lock
-        catalog_delete_if_exists(&state, "test");
-    }
-
-    #[test]
-    fn catalog_rename_poisoned_lock_returns_error() {
-        let state: CatalogState = Arc::new(RwLock::new(HashMap::new()));
-        let state_clone = state.clone();
-        let _ = std::thread::spawn(move || {
-            let _guard = state_clone.write().unwrap();
-            panic!("intentional poison");
-        })
-        .join();
-        let result = catalog_rename(&state, "old", "new");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("poisoned"));
-    }
-
-    #[test]
-    fn rename_to_existing_is_error() {
-        let con = in_memory_con();
-        let state = init_catalog(&con, ":memory:").unwrap();
-        let json = r#"{"base_table":"orders","dimensions":[],"metrics":[]}"#;
-        catalog_insert(&state, "orders", json).unwrap();
-        catalog_insert(&state, "sales", json).unwrap();
-        let result = catalog_rename(&state, "orders", "sales");
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("already exists"), "unexpected: {msg}");
-        // Verify old entry was rolled back
-        assert!(state.read().unwrap().contains_key("orders"));
     }
 
     #[test]

--- a/src/ddl/alter.rs
+++ b/src/ddl/alter.rs
@@ -6,7 +6,7 @@ use duckdb::{
 };
 use libduckdb_sys as ffi;
 
-use crate::catalog::{catalog_rename, catalog_upsert, CatalogState};
+use crate::catalog::CatalogReader;
 use crate::model::SemanticViewDefinition;
 
 /// Shared state for `alter_semantic_view_rename` and
@@ -15,7 +15,7 @@ use crate::model::SemanticViewDefinition;
 /// See [`crate::ddl::define::DefineState`] for the persist_conn pattern.
 #[derive(Clone)]
 pub struct AlterRenameState {
-    pub catalog: CatalogState,
+    pub catalog: CatalogReader,
     pub persist_conn: Option<ffi::duckdb_connection>,
     /// When true, silently succeeds if the view does not exist.
     pub if_exists: bool,
@@ -88,13 +88,10 @@ impl VTab for AlterRenameVTab {
             let state = unsafe { &*state_ptr };
 
             // Check if old_name exists in catalog.
-            let json = {
-                let guard = state
-                    .catalog
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?;
-                guard.get(&old_name).cloned()
-            };
+            let json = state
+                .catalog
+                .lookup(&old_name)
+                .map_err(Box::<dyn std::error::Error>::from)?;
 
             match json {
                 None => {
@@ -105,23 +102,16 @@ impl VTab for AlterRenameVTab {
                     return Err(format!("semantic view '{old_name}' does not exist").into());
                 }
                 Some(json_str) => {
-                    // Check if new_name already exists
+                    if state
+                        .catalog
+                        .exists(&new_name)
+                        .map_err(Box::<dyn std::error::Error>::from)?
                     {
-                        let guard = state.catalog.read().map_err(|_| {
-                            Box::<dyn std::error::Error>::from("catalog lock poisoned")
-                        })?;
-                        if guard.contains_key(&new_name) {
-                            return Err(format!("semantic view '{new_name}' already exists").into());
-                        }
+                        return Err(format!("semantic view '{new_name}' already exists").into());
                     }
 
-                    // 1. Persist first (write-first for consistency).
-                    if let Some(conn) = state.persist_conn {
-                        persist_rename(conn, &old_name, &new_name, &json_str);
-                    }
-
-                    // 2. Update in-memory catalog.
-                    catalog_rename(&state.catalog, &old_name, &new_name)?;
+                    let conn = state.persist_conn.unwrap_or(state.catalog.raw());
+                    persist_rename(conn, &old_name, &new_name, &json_str);
                 }
             }
 
@@ -173,7 +163,7 @@ impl VTab for AlterRenameVTab {
 /// See [`crate::ddl::define::DefineState`] for the persist_conn pattern.
 #[derive(Clone)]
 pub struct AlterCommentState {
-    pub catalog: CatalogState,
+    pub catalog: CatalogReader,
     pub persist_conn: Option<ffi::duckdb_connection>,
     /// When true, silently succeeds if the view does not exist.
     pub if_exists: bool,
@@ -221,14 +211,10 @@ fn alter_comment_impl(
     name: &str,
     new_comment: Option<String>,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    // Read existing JSON from catalog.
-    let json = {
-        let guard = state
-            .catalog
-            .read()
-            .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?;
-        guard.get(name).cloned()
-    };
+    let json = state
+        .catalog
+        .lookup(name)
+        .map_err(Box::<dyn std::error::Error>::from)?;
 
     match json {
         None => {
@@ -247,13 +233,8 @@ fn alter_comment_impl(
             def.comment = new_comment;
             let new_json = serde_json::to_string(&def)?;
 
-            // 1. Persist first (write-first for consistency).
-            if let Some(conn) = state.persist_conn {
-                persist_comment_update(conn, name, &new_json);
-            }
-
-            // 2. Update in-memory catalog.
-            catalog_upsert(&state.catalog, name, &new_json)?;
+            let conn = state.persist_conn.unwrap_or(state.catalog.raw());
+            persist_comment_update(conn, name, &new_json);
 
             Ok(status.to_string())
         }

--- a/src/ddl/define.rs
+++ b/src/ddl/define.rs
@@ -91,8 +91,10 @@ unsafe impl Sync for DefineInitData {}
 /// For each table with empty `pk_columns`, queries `duckdb_constraints()`
 /// and fills in the PK columns if found. Tables that have no catalog PK
 /// are left with empty `pk_columns` -- downstream validation will catch them.
-fn resolve_pk_from_catalog(state: &DefineState, def: &mut crate::model::SemanticViewDefinition) {
-    let conn = state.catalog_conn;
+fn resolve_pk_from_catalog(
+    conn: ffi::duckdb_connection,
+    def: &mut crate::model::SemanticViewDefinition,
+) {
     if conn.is_null() {
         return; // No catalog connection available -- skip lookup.
     }
@@ -148,6 +150,194 @@ fn resolve_pk_from_catalog(state: &DefineState, def: &mut crate::model::Semantic
     }
 }
 
+/// Run all CREATE-time enrichment + validation against `conn` (a connection
+/// with read access to the user catalog and committed user tables) and return
+/// the enriched JSON string ready for storage in `_definitions`.
+///
+/// Steps performed in order:
+/// 1. Resolve PRIMARY KEY columns from `duckdb_constraints()` for tables
+///    declared without an explicit PK.
+/// 2. Re-run cardinality inference now that catalog PKs are populated.
+/// 3. Validate that no join still has FK columns without resolved ref columns.
+/// 4. Run graph / facts / derived-metric / using-relationship validations.
+/// 5. Capture metadata (`created_on`, `database_name`, `schema_name`) by
+///    querying `now()` / `current_database()` / `current_schema()`.
+/// 6. Run `LIMIT 0` against the expanded query to populate
+///    `column_type_names` / `column_types_inferred` and back-fill
+///    dimension/metric `output_type` fields.
+/// 7. Run `typeof(expr)` against the source table for each fact to populate
+///    fact `output_type` (best-effort).
+///
+/// Used by both the legacy `DefineFromJsonVTab::bind` path (CREATE FROM YAML
+/// FILE still routes through it) and the v0.8.0 transactional CREATE path
+/// emitted by `parser_override`.
+pub fn enrich_definition_for_create(
+    name: &str,
+    mut def: crate::model::SemanticViewDefinition,
+    conn: ffi::duckdb_connection,
+    infer_types: bool,
+) -> Result<String, String> {
+    // 1. Catalog PK resolution.
+    resolve_pk_from_catalog(conn, &mut def);
+
+    // 2. Re-run cardinality inference now that catalog PKs are resolved.
+    crate::parse::infer_cardinality(&def.tables, &mut def.joins).map_err(|e| e.message)?;
+
+    // 3. Catch joins that still have FK columns but no resolved ref_columns.
+    for join in &def.joins {
+        if !join.fk_columns.is_empty() && join.ref_columns.is_empty() {
+            let to_alias_lower = join.table.to_ascii_lowercase();
+            let target = def
+                .tables
+                .iter()
+                .find(|t| t.alias.to_ascii_lowercase() == to_alias_lower);
+            if let Some(t) = target {
+                return Err(format!(
+                    "Table '{}' has no PRIMARY KEY. \
+                     Specify referenced columns explicitly: REFERENCES {}(col).",
+                    t.alias, t.alias
+                ));
+            }
+            return Err("This semantic view was created with an older version. \
+                 Please recreate it with the new DDL syntax."
+                .to_string());
+        }
+    }
+
+    // 4. Graph validations.
+    crate::graph::validate_graph(&def)?;
+    crate::graph::validate_facts(&def)?;
+    crate::graph::validate_derived_metrics(&def)?;
+    crate::graph::validate_using_relationships(&def)?;
+
+    // 5. Capture metadata: timestamp + database_name + schema_name.
+    let metadata_sql = "SELECT strftime(now(), '%Y-%m-%dT%H:%M:%SZ'), \
+                        current_database(), current_schema()";
+    if let Ok(mut result) =
+        unsafe { crate::query::table_function::execute_sql_raw(conn, metadata_sql) }
+    {
+        unsafe {
+            let ts_ptr = ffi::duckdb_value_varchar(&mut result, 0, 0);
+            if !ts_ptr.is_null() {
+                def.created_on = Some(CStr::from_ptr(ts_ptr).to_string_lossy().into_owned());
+                ffi::duckdb_free(ts_ptr as *mut std::ffi::c_void);
+            }
+            let db_ptr = ffi::duckdb_value_varchar(&mut result, 1, 0);
+            if !db_ptr.is_null() {
+                def.database_name = Some(CStr::from_ptr(db_ptr).to_string_lossy().into_owned());
+                ffi::duckdb_free(db_ptr as *mut std::ffi::c_void);
+            }
+            let schema_ptr = ffi::duckdb_value_varchar(&mut result, 2, 0);
+            if !schema_ptr.is_null() {
+                def.schema_name = Some(CStr::from_ptr(schema_ptr).to_string_lossy().into_owned());
+                ffi::duckdb_free(schema_ptr as *mut std::ffi::c_void);
+            }
+            ffi::duckdb_destroy_result(&mut result);
+        }
+    }
+
+    // 6. DDL-time type inference via LIMIT 0 probe (file-backed only —
+    // matches v0.7.1 design; in-memory DBs skip inference).
+    if infer_types {
+        let req_all = crate::expand::QueryRequest {
+            dimensions: def
+                .dimensions
+                .iter()
+                .map(|d| crate::expand::DimensionName::new(d.name.clone()))
+                .collect(),
+            metrics: def
+                .metrics
+                .iter()
+                .map(|m| crate::expand::MetricName::new(m.name.clone()))
+                .collect(),
+            facts: vec![],
+        };
+        if let Ok(expanded_for_inference) = crate::expand::expand(name, &def, &req_all) {
+            let limit0_sql = format!("{expanded_for_inference} LIMIT 0");
+            if let Some((names, types)) =
+                unsafe { crate::query::table_function::try_infer_schema(conn, &limit0_sql) }
+            {
+                def.column_type_names = names;
+                def.column_types_inferred = types
+                    .iter()
+                    .map(|t| crate::query::table_function::normalize_type_id(*t as u32))
+                    .collect();
+            }
+        }
+
+        if !def.column_type_names.is_empty() {
+            let type_map: std::collections::HashMap<String, u32> = def
+                .column_type_names
+                .iter()
+                .zip(def.column_types_inferred.iter())
+                .map(|(name, &tid)| (name.to_ascii_lowercase(), tid))
+                .collect();
+
+            for dim in &mut def.dimensions {
+                if dim.output_type.is_none() {
+                    if let Some(&tid) = type_map.get(&dim.name.to_ascii_lowercase()) {
+                        dim.output_type =
+                            crate::query::table_function::type_id_to_display_name(tid)
+                                .map(|s| s.to_string());
+                    }
+                }
+            }
+            for met in &mut def.metrics {
+                if met.output_type.is_none() {
+                    if let Some(&tid) = type_map.get(&met.name.to_ascii_lowercase()) {
+                        met.output_type =
+                            crate::query::table_function::type_id_to_display_name(tid)
+                                .map(|s| s.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // 7. Fact type inference via typeof(expr).
+    if !def.facts.is_empty() {
+        let alias_to_table: std::collections::HashMap<String, String> = def
+            .tables
+            .iter()
+            .map(|t| (t.alias.to_ascii_lowercase(), t.table.clone()))
+            .collect();
+        let fallback_table = def.base_table().to_string();
+
+        for fact in &mut def.facts {
+            let alias = fact.source_table.as_deref().unwrap_or("");
+            let table_name = fact
+                .source_table
+                .as_ref()
+                .and_then(|a| alias_to_table.get(&a.to_ascii_lowercase()).cloned())
+                .unwrap_or_else(|| fallback_table.clone());
+
+            let from_clause = if alias.is_empty() {
+                format!("\"{}\"", table_name.replace('"', "\"\""))
+            } else {
+                format!("\"{}\" AS {}", table_name.replace('"', "\"\""), alias)
+            };
+            let sql = format!("SELECT typeof({}) FROM {} LIMIT 1", fact.expr, from_clause);
+            if let Ok(mut result) =
+                unsafe { crate::query::table_function::execute_sql_raw(conn, &sql) }
+            {
+                let row_count = unsafe { ffi::duckdb_row_count(&mut result) };
+                if row_count > 0 {
+                    let val_ptr = unsafe { ffi::duckdb_value_varchar(&mut result, 0, 0) };
+                    if !val_ptr.is_null() {
+                        let type_name =
+                            unsafe { CStr::from_ptr(val_ptr).to_string_lossy().into_owned() };
+                        unsafe { ffi::duckdb_free(val_ptr as *mut std::ffi::c_void) };
+                        fact.output_type = Some(type_name);
+                    }
+                }
+                unsafe { ffi::duckdb_destroy_result(&mut result) };
+            }
+        }
+    }
+
+    serde_json::to_string(&def).map_err(|e| e.to_string())
+}
+
 /// `create_semantic_view_from_json(name, json)` table function.
 ///
 /// Accepts a pre-parsed JSON-serialized `SemanticViewDefinition` (produced by
@@ -174,204 +364,21 @@ impl VTab for DefineFromJsonVTab {
             let json = bind.get_parameter(1).to_string();
 
             // Deserialize the JSON into a SemanticViewDefinition.
-            let mut def = crate::model::SemanticViewDefinition::from_json(&name, &json)
+            let def = crate::model::SemanticViewDefinition::from_json(&name, &json)
                 .map_err(|e| Box::<dyn std::error::Error>::from(e))?;
 
             // Access the DefineState from extra_info (moved up for catalog PK resolution).
             let state_ptr = bind.get_extra_info::<DefineState>();
             let state = unsafe { &*state_ptr };
 
-            // Resolve PKs from catalog for tables without explicit PRIMARY KEY.
-            // Works for both file-backed and in-memory databases.
-            resolve_pk_from_catalog(state, &mut def);
-
-            // Re-run cardinality inference now that catalog PKs are resolved.
-            // Any joins with still-empty ref_columns (no catalog PK found) will
-            // be caught by the Phase 33 guard or validate_fk_references below.
-            crate::parse::infer_cardinality(&def.tables, &mut def.joins)
-                .map_err(|e| Box::<dyn std::error::Error>::from(e.message))?;
-
-            // After catalog PK resolution and re-inference, check for joins that
-            // still have FK columns but no resolved ref_columns.
-            for join in &def.joins {
-                if !join.fk_columns.is_empty() && join.ref_columns.is_empty() {
-                    // Find the target table to produce the right error message.
-                    let to_alias_lower = join.table.to_ascii_lowercase();
-                    let target = def
-                        .tables
-                        .iter()
-                        .find(|t| t.alias.to_ascii_lowercase() == to_alias_lower);
-                    if let Some(t) = target {
-                        // Target table exists but has no PK (neither DDL nor catalog).
-                        return Err(Box::<dyn std::error::Error>::from(format!(
-                            "Table '{}' has no PRIMARY KEY. \
-                         Specify referenced columns explicitly: REFERENCES {}(col).",
-                            t.alias, t.alias
-                        )));
-                    }
-                    // Target not found -- old-format JSON or graph issue.
-                    return Err(Box::<dyn std::error::Error>::from(
-                        "This semantic view was created with an older version. \
-                     Please recreate it with the new DDL syntax.",
-                    ));
-                }
-            }
-
-            // Validate relationship graph before persisting (Phase 26).
-            // Catches cycles, diamonds, self-references, orphans, FK reference validation.
-            crate::graph::validate_graph(&def)
-                .map_err(|e| Box::<dyn std::error::Error>::from(e))?;
-
-            // Validate facts: source table reachability, cycles, unknown refs (Phase 29).
-            crate::graph::validate_facts(&def)
-                .map_err(|e| Box::<dyn std::error::Error>::from(e))?;
-
-            // Validate derived metrics: cycles, unknown refs, aggregate prohibition (Phase 30).
-            crate::graph::validate_derived_metrics(&def)
-                .map_err(|e| Box::<dyn std::error::Error>::from(e))?;
-
-            // Validate USING relationship references on metrics (Phase 32).
-            crate::graph::validate_using_relationships(&def)
-                .map_err(|e| Box::<dyn std::error::Error>::from(e))?;
-
-            // Capture metadata: timestamp, database_name, schema_name.
-            // Uses catalog_conn which is always available (file-backed AND in-memory).
-            let metadata_sql = "SELECT strftime(now(), '%Y-%m-%dT%H:%M:%SZ'), \
-                            current_database(), current_schema()";
-            let metadata_result = unsafe {
-                crate::query::table_function::execute_sql_raw(state.catalog_conn, metadata_sql)
-            };
-            if let Ok(mut result) = metadata_result {
-                unsafe {
-                    let ts_ptr = ffi::duckdb_value_varchar(&mut result, 0, 0);
-                    if !ts_ptr.is_null() {
-                        def.created_on =
-                            Some(CStr::from_ptr(ts_ptr).to_string_lossy().into_owned());
-                        ffi::duckdb_free(ts_ptr as *mut std::ffi::c_void);
-                    }
-                    let db_ptr = ffi::duckdb_value_varchar(&mut result, 1, 0);
-                    if !db_ptr.is_null() {
-                        def.database_name =
-                            Some(CStr::from_ptr(db_ptr).to_string_lossy().into_owned());
-                        ffi::duckdb_free(db_ptr as *mut std::ffi::c_void);
-                    }
-                    let schema_ptr = ffi::duckdb_value_varchar(&mut result, 2, 0);
-                    if !schema_ptr.is_null() {
-                        def.schema_name =
-                            Some(CStr::from_ptr(schema_ptr).to_string_lossy().into_owned());
-                        ffi::duckdb_free(schema_ptr as *mut std::ffi::c_void);
-                    }
-                    ffi::duckdb_destroy_result(&mut result);
-                }
-            }
-
-            // DDL-time type inference (file-backed databases only).
-            // Runs LIMIT 0 on the expanded SQL via the persist connection.
-            if let Some(conn) = state.persist_conn {
-                let req_all = crate::expand::QueryRequest {
-                    dimensions: def
-                        .dimensions
-                        .iter()
-                        .map(|d| crate::expand::DimensionName::new(d.name.clone()))
-                        .collect(),
-                    metrics: def
-                        .metrics
-                        .iter()
-                        .map(|m| crate::expand::MetricName::new(m.name.clone()))
-                        .collect(),
-                    facts: vec![],
-                };
-                if let Ok(expanded_for_inference) = crate::expand::expand(&name, &def, &req_all) {
-                    let limit0_sql = format!("{expanded_for_inference} LIMIT 0");
-                    if let Some((names, types)) =
-                        unsafe { crate::query::table_function::try_infer_schema(conn, &limit0_sql) }
-                    {
-                        def.column_type_names = names;
-                        def.column_types_inferred = types
-                            .iter()
-                            .map(|t| crate::query::table_function::normalize_type_id(*t as u32))
-                            .collect();
-                    }
-                }
-
-                // Map inferred types back to dimension/metric output_type fields.
-                if !def.column_type_names.is_empty() {
-                    let type_map: std::collections::HashMap<String, u32> = def
-                        .column_type_names
-                        .iter()
-                        .zip(def.column_types_inferred.iter())
-                        .map(|(name, &tid)| (name.to_ascii_lowercase(), tid))
-                        .collect();
-
-                    for dim in &mut def.dimensions {
-                        if dim.output_type.is_none() {
-                            if let Some(&tid) = type_map.get(&dim.name.to_ascii_lowercase()) {
-                                dim.output_type =
-                                    crate::query::table_function::type_id_to_display_name(tid)
-                                        .map(|s| s.to_string());
-                            }
-                        }
-                    }
-                    for met in &mut def.metrics {
-                        if met.output_type.is_none() {
-                            if let Some(&tid) = type_map.get(&met.name.to_ascii_lowercase()) {
-                                met.output_type =
-                                    crate::query::table_function::type_id_to_display_name(tid)
-                                        .map(|s| s.to_string());
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Fact type inference: use typeof(expr) to determine fact output types.
-            // Best-effort -- if typeof() fails, output_type stays None (graceful degradation).
-            if !def.facts.is_empty() {
-                let alias_to_table: std::collections::HashMap<String, String> = def
-                    .tables
-                    .iter()
-                    .map(|t| (t.alias.to_ascii_lowercase(), t.table.clone()))
-                    .collect();
-
-                let type_conn = state.persist_conn.unwrap_or(state.catalog_conn);
-                let fallback_table = def.base_table().to_string();
-
-                for fact in &mut def.facts {
-                    let alias = fact.source_table.as_deref().unwrap_or("");
-                    let table_name = fact
-                        .source_table
-                        .as_ref()
-                        .and_then(|a| alias_to_table.get(&a.to_ascii_lowercase()).cloned())
-                        .unwrap_or_else(|| fallback_table.clone());
-
-                    // Include AS alias so expressions like `li.price` resolve correctly.
-                    let from_clause = if alias.is_empty() {
-                        format!("\"{}\"", table_name.replace('"', "\"\""))
-                    } else {
-                        format!("\"{}\" AS {}", table_name.replace('"', "\"\""), alias)
-                    };
-                    let sql = format!("SELECT typeof({}) FROM {} LIMIT 1", fact.expr, from_clause);
-                    if let Ok(mut result) =
-                        unsafe { crate::query::table_function::execute_sql_raw(type_conn, &sql) }
-                    {
-                        let row_count = unsafe { ffi::duckdb_row_count(&mut result) };
-                        if row_count > 0 {
-                            let val_ptr = unsafe { ffi::duckdb_value_varchar(&mut result, 0, 0) };
-                            if !val_ptr.is_null() {
-                                let type_name = unsafe {
-                                    CStr::from_ptr(val_ptr).to_string_lossy().into_owned()
-                                };
-                                unsafe { ffi::duckdb_free(val_ptr as *mut std::ffi::c_void) };
-                                fact.output_type = Some(type_name);
-                            }
-                        }
-                        unsafe { ffi::duckdb_destroy_result(&mut result) };
-                    }
-                }
-            }
-
-            let json_out = serde_json::to_string(&def)
-                .map_err(|e| Box::<dyn std::error::Error>::from(e.to_string()))?;
+            // Run shared enrichment (PK resolution → cardinality → graph
+            // validations → metadata capture → type inference → fact typing).
+            // `persist_conn.is_some()` mirrors the v0.7.1 file-backed gate for
+            // LIMIT 0 type inference; in-memory DBs skip it.
+            let infer_types = state.persist_conn.is_some();
+            let json_out =
+                enrich_definition_for_create(&name, def, state.catalog_conn, infer_types)
+                    .map_err(Box::<dyn std::error::Error>::from)?;
 
             // Persist to `_definitions`. File-backed DBs use the dedicated
             // persist_conn; in-memory falls back to catalog_conn.

--- a/src/ddl/define.rs
+++ b/src/ddl/define.rs
@@ -7,23 +7,22 @@ use duckdb::{
 use libduckdb_sys as ffi;
 use std::ffi::CStr;
 
-use crate::catalog::{catalog_insert, catalog_upsert, CatalogState};
-
-/// Shared state for `create_semantic_view` and `create_or_replace_semantic_view`.
+/// Shared state for the legacy `create_semantic_view_from_json` table-function
+/// fallback (still reachable for direct user calls; the v0.8.0 native CREATE
+/// path runs via `parser_override` and writes directly on the caller's
+/// connection).
 ///
-/// `persist_conn` is `Some` for file-backed databases -- it is a separate
+/// `persist_conn` is `Some` for file-backed databases — it is a separate
 /// `duckdb_connection` created at init time and used to execute INSERT into
 /// `semantic_layer._definitions` from within bind (avoids deadlock with
-/// the main connection's execution lock). For in-memory databases,
-/// `persist_conn` is `None` and the HashMap is the sole source of truth.
+/// the main connection's execution lock). For in-memory databases via the
+/// legacy fallback there is no separate write connection: writes go through
+/// `catalog_conn` instead.
 #[derive(Clone)]
 pub struct DefineState {
-    pub catalog: CatalogState,
     pub persist_conn: Option<ffi::duckdb_connection>,
-    /// Connection for catalog queries (e.g., `duckdb_constraints()` lookups).
-    /// Always set -- created at init time from the database handle.
-    /// Distinct from `persist_conn` (which is file-backed only) and the main
-    /// connection (which holds execution locks during bind).
+    /// Connection for catalog queries (e.g., `duckdb_constraints()` lookups)
+    /// and for legacy in-memory writes when `persist_conn` is `None`.
     pub catalog_conn: ffi::duckdb_connection,
     /// When true, uses INSERT OR REPLACE (upsert); when false, errors on duplicate.
     pub or_replace: bool,
@@ -37,22 +36,32 @@ pub struct DefineState {
 unsafe impl Send for DefineState {}
 unsafe impl Sync for DefineState {}
 
-/// Persist a view definition to `semantic_layer._definitions` using the separate
-/// persist_conn. This avoids deadlocking with the main connection's execution lock
-/// (context_lock is non-reentrant; a second duckdb_connection has its own context).
+/// Whether a semantic view already exists in `semantic_layer._definitions`.
+fn view_exists(conn: ffi::duckdb_connection, name: &str) -> Result<bool, String> {
+    crate::catalog::CatalogReader::new(conn).exists(name)
+}
+
+/// Persist a view definition to `semantic_layer._definitions`.
 ///
-/// Uses the Rust ffi::duckdb_query which goes through function pointers (loadable-
-/// extension compatible) rather than direct symbol references.
-///
-/// Returns Ok(()) on success, Err on failure.
-fn persist_define(conn: ffi::duckdb_connection, name: &str, json: &str) -> Result<(), String> {
+/// `or_replace=true` → `INSERT OR REPLACE` (overwrite existing row).
+/// `or_replace=false` → plain `INSERT`; caller is expected to have already
+/// checked for existing rows so that the failure mode of a duplicate row is
+/// surfaced as the friendly "already exists" error rather than a raw
+/// constraint violation.
+fn persist_define(
+    conn: ffi::duckdb_connection,
+    name: &str,
+    json: &str,
+    or_replace: bool,
+) -> Result<(), String> {
+    let sql = if or_replace {
+        "INSERT OR REPLACE INTO semantic_layer._definitions (name, definition) VALUES ($1, $2)"
+    } else {
+        "INSERT INTO semantic_layer._definitions (name, definition) VALUES ($1, $2)"
+    };
     unsafe {
-        super::persist::execute_parameterized(
-            conn,
-            "INSERT OR REPLACE INTO semantic_layer._definitions (name, definition) VALUES ($1, $2)",
-            &[name, json],
-        )
-        .map_err(|e| format!("failed to persist semantic view '{name}' to catalog table: {e}"))
+        super::persist::execute_parameterized(conn, sql, &[name, json])
+            .map_err(|e| format!("failed to persist semantic view '{name}' to catalog table: {e}"))
     }
 }
 
@@ -364,25 +373,29 @@ impl VTab for DefineFromJsonVTab {
             let json_out = serde_json::to_string(&def)
                 .map_err(|e| Box::<dyn std::error::Error>::from(e.to_string()))?;
 
-            // Persist to DuckDB table first (file-backed databases only).
-            if let Some(conn) = state.persist_conn {
-                persist_define(conn, &name, &json_out)
-                    .map_err(|e| Box::<dyn std::error::Error>::from(e))?;
-            }
+            // Persist to `_definitions`. File-backed DBs use the dedicated
+            // persist_conn; in-memory falls back to catalog_conn.
+            let write_conn = state.persist_conn.unwrap_or(state.catalog_conn);
 
-            // Update in-memory catalog.
             if state.or_replace {
-                catalog_upsert(&state.catalog, &name, &json_out)?;
-            } else if state.if_not_exists {
-                match catalog_insert(&state.catalog, &name, &json_out) {
-                    Ok(()) => {}
-                    Err(e) if e.to_string().contains("already exists") => {
-                        // Silently succeed -- view exists, no replacement needed.
-                    }
-                    Err(e) => return Err(e),
-                }
+                persist_define(write_conn, &name, &json_out, true)
+                    .map_err(Box::<dyn std::error::Error>::from)?;
             } else {
-                catalog_insert(&state.catalog, &name, &json_out)?;
+                let already =
+                    view_exists(write_conn, &name).map_err(Box::<dyn std::error::Error>::from)?;
+                if already {
+                    if state.if_not_exists {
+                        // Silently succeed -- view exists, no replacement needed.
+                    } else {
+                        return Err(format!(
+                            "semantic view '{name}' already exists; use CREATE OR REPLACE SEMANTIC VIEW to overwrite"
+                        )
+                        .into());
+                    }
+                } else {
+                    persist_define(write_conn, &name, &json_out, false)
+                        .map_err(Box::<dyn std::error::Error>::from)?;
+                }
             }
 
             Ok(DefineBindData { name })

--- a/src/ddl/describe.rs
+++ b/src/ddl/describe.rs
@@ -7,7 +7,7 @@ use duckdb::{
 
 use std::collections::HashMap;
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::model::{AccessModifier, SemanticViewDefinition};
 
 /// A single property row in the DESCRIBE output.
@@ -520,20 +520,16 @@ impl VTab for DescribeSemanticViewVTab {
             // Read the name parameter.
             let name = bind.get_parameter(0).to_string();
 
-            // Access the shared catalog state injected via extra_info.
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
-
-            let json_str = guard
-                .get(&name)
+            // Access the shared catalog reader injected via extra_info.
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let json_str = reader
+                .lookup(&name)
+                .map_err(Box::<dyn std::error::Error>::from)?
                 .ok_or_else(|| format!("semantic view '{name}' does not exist"))?;
 
             // Parse the stored JSON into the model.
-            let def = SemanticViewDefinition::from_json(&name, json_str)?;
+            let def = SemanticViewDefinition::from_json(&name, &json_str)?;
 
             // Build alias->table map and compute base table name.
             let alias_map = def.alias_to_table_map();

--- a/src/ddl/drop.rs
+++ b/src/ddl/drop.rs
@@ -6,13 +6,16 @@ use duckdb::{
 };
 use libduckdb_sys as ffi;
 
-use crate::catalog::{catalog_delete, catalog_delete_if_exists, CatalogState};
+use crate::catalog::CatalogReader;
 
 /// Shared state for `drop_semantic_view` and `drop_semantic_view_if_exists`.
 /// See [`crate::ddl::define::DefineState`] for the persist_conn pattern.
 #[derive(Clone)]
 pub struct DropState {
-    pub catalog: CatalogState,
+    /// Read handle for `_definitions` (used for the existence check).
+    pub catalog: CatalogReader,
+    /// Write connection for `DELETE FROM _definitions`. File-backed DBs use
+    /// the dedicated `persist_conn`; in-memory uses the catalog connection.
     pub persist_conn: Option<ffi::duckdb_connection>,
     /// When true, silently succeeds if the view does not exist.
     pub if_exists: bool,
@@ -78,30 +81,18 @@ impl VTab for DropSemanticViewVTab {
             let state = unsafe { &*state_ptr };
 
             // Check catalog first -- gives better error messages than the SQL DELETE.
-            let exists = {
-                let guard = state
-                    .catalog
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?;
-                guard.contains_key(&name)
-            };
+            let exists = state
+                .catalog
+                .exists(&name)
+                .map_err(Box::<dyn std::error::Error>::from)?;
 
             if !exists && !state.if_exists {
                 return Err(format!("semantic view '{name}' does not exist").into());
             }
 
             if exists {
-                // 1. Delete from DuckDB table FIRST (write-first for consistency).
-                if let Some(conn) = state.persist_conn {
-                    persist_drop(conn, &name);
-                }
-
-                // 2. Remove from in-memory catalog.
-                if state.if_exists {
-                    catalog_delete_if_exists(&state.catalog, &name);
-                } else {
-                    catalog_delete(&state.catalog, &name)?;
-                }
+                let conn = state.persist_conn.unwrap_or(state.catalog.raw());
+                persist_drop(conn, &name);
             }
 
             Ok(DropBindData { name })

--- a/src/ddl/get_ddl.rs
+++ b/src/ddl/get_ddl.rs
@@ -10,14 +10,14 @@ use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
 use duckdb::vtab::arrow::WritableVector;
 use libduckdb_sys::duckdb_string_t;
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::model::SemanticViewDefinition;
 use crate::render_ddl::render_create_ddl;
 
 pub struct GetDdlScalar;
 
 impl VScalar for GetDdlScalar {
-    type State = CatalogState;
+    type State = CatalogReader;
 
     unsafe fn invoke(
         state: &Self::State,
@@ -44,13 +44,11 @@ impl VScalar for GetDdlScalar {
                     .into());
                 }
 
-                let guard = state
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?;
-                let json = guard
-                    .get(&name)
+                let json = state
+                    .lookup(&name)
+                    .map_err(Box::<dyn std::error::Error>::from)?
                     .ok_or_else(|| format!("semantic view '{}' does not exist", name))?;
-                let def: SemanticViewDefinition = serde_json::from_str(json)?;
+                let def: SemanticViewDefinition = serde_json::from_str(&json)?;
                 let ddl =
                     render_create_ddl(&name, &def).map_err(|e| -> Box<dyn std::error::Error> {
                         format!("GET_DDL error: {e}").into()

--- a/src/ddl/list.rs
+++ b/src/ddl/list.rs
@@ -5,7 +5,7 @@ use duckdb::{
     vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab},
 };
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::model::SemanticViewDefinition;
 
 /// A single row in the SHOW SEMANTIC VIEWS output.
@@ -70,15 +70,14 @@ impl VTab for ListSemanticViewsVTab {
             );
             bind.add_result_column("comment", LogicalTypeHandle::from(LogicalTypeId::Varchar));
 
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let entries = reader
+                .list_all()
+                .map_err(Box::<dyn std::error::Error>::from)?;
 
-            let mut rows = Vec::with_capacity(guard.len());
-            for (name, json) in guard.iter() {
+            let mut rows = Vec::with_capacity(entries.len());
+            for (name, json) in &entries {
                 let def = SemanticViewDefinition::from_json(name, json).ok();
                 let (created_on, database_name, schema_name, comment) = match &def {
                     Some(d) => (
@@ -203,15 +202,14 @@ impl VTab for ListTerseSemanticViewsVTab {
                 LogicalTypeHandle::from(LogicalTypeId::Varchar),
             );
 
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let entries = reader
+                .list_all()
+                .map_err(Box::<dyn std::error::Error>::from)?;
 
-            let mut rows = Vec::with_capacity(guard.len());
-            for (name, json) in guard.iter() {
+            let mut rows = Vec::with_capacity(entries.len());
+            for (name, json) in &entries {
                 let def = SemanticViewDefinition::from_json(name, json).ok();
                 let (created_on, database_name, schema_name) = match &def {
                     Some(d) => (

--- a/src/ddl/read_yaml.rs
+++ b/src/ddl/read_yaml.rs
@@ -12,7 +12,7 @@ use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
 use duckdb::vtab::arrow::WritableVector;
 use libduckdb_sys::duckdb_string_t;
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::model::SemanticViewDefinition;
 use crate::render_yaml::render_yaml_export;
 
@@ -25,7 +25,7 @@ fn resolve_bare_name(input: &str) -> &str {
 pub struct ReadYamlFromSemanticViewScalar;
 
 impl VScalar for ReadYamlFromSemanticViewScalar {
-    type State = CatalogState;
+    type State = CatalogReader;
 
     unsafe fn invoke(
         state: &Self::State,
@@ -42,13 +42,11 @@ impl VScalar for ReadYamlFromSemanticViewScalar {
                 let raw_name = DuckString::new(&mut { names[i] }).as_str().to_string();
                 let bare_name = resolve_bare_name(&raw_name);
 
-                let guard = state
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?;
-                let json = guard
-                    .get(bare_name)
+                let json = state
+                    .lookup(bare_name)
+                    .map_err(Box::<dyn std::error::Error>::from)?
                     .ok_or_else(|| format!("semantic view '{}' does not exist", bare_name))?;
-                let def: SemanticViewDefinition = serde_json::from_str(json)?;
+                let def: SemanticViewDefinition = serde_json::from_str(&json)?;
                 let yaml = render_yaml_export(&def)
                     .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
                 out_vec.insert(i, yaml.as_str());

--- a/src/ddl/show_columns.rs
+++ b/src/ddl/show_columns.rs
@@ -5,7 +5,7 @@ use duckdb::{
     vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab},
 };
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::model::{AccessModifier, SemanticViewDefinition};
 
 /// A single row in the SHOW COLUMNS IN SEMANTIC VIEW output.
@@ -143,18 +143,14 @@ impl VTab for ShowColumnsInSemanticViewVTab {
 
             let view_name = bind.get_parameter(0).to_string();
 
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
-
-            let json = guard
-                .get(&view_name)
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let json = reader
+                .lookup(&view_name)
+                .map_err(Box::<dyn std::error::Error>::from)?
                 .ok_or_else(|| format!("Semantic view '{view_name}' not found"))?;
 
-            let def = SemanticViewDefinition::from_json(&view_name, json)?;
+            let def = SemanticViewDefinition::from_json(&view_name, &json)?;
             let rows = collect_column_rows(&def, &view_name);
 
             Ok(ShowColumnsBindData { rows })

--- a/src/ddl/show_dims.rs
+++ b/src/ddl/show_dims.rs
@@ -5,7 +5,7 @@ use duckdb::{
     vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab},
 };
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::ddl::describe::format_json_array;
 use crate::model::SemanticViewDefinition;
 
@@ -151,18 +151,14 @@ impl VTab for ShowSemanticDimensionsVTab {
             bind_output_columns(bind);
 
             let view_name = bind.get_parameter(0).to_string();
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
-
-            let json = guard
-                .get(&view_name)
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let json = reader
+                .lookup(&view_name)
+                .map_err(Box::<dyn std::error::Error>::from)?
                 .ok_or_else(|| format!("semantic view '{view_name}' does not exist"))?;
 
-            let mut rows = collect_dims(&view_name, json);
+            let mut rows = collect_dims(&view_name, &json);
             rows.sort_by(|a, b| a.name.cmp(&b.name));
 
             Ok(ShowDimsBindData { rows })
@@ -204,15 +200,14 @@ impl VTab for ShowSemanticDimensionsAllVTab {
         crate::util::catch_unwind_to_result(std::panic::AssertUnwindSafe(|| {
             bind_output_columns(bind);
 
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let entries = reader
+                .list_all()
+                .map_err(Box::<dyn std::error::Error>::from)?;
 
             let mut rows = Vec::new();
-            for (name, json) in guard.iter() {
+            for (name, json) in &entries {
                 rows.extend(collect_dims(name, json));
             }
             rows.sort_by(|a, b| {

--- a/src/ddl/show_dims_for_metric.rs
+++ b/src/ddl/show_dims_for_metric.rs
@@ -6,7 +6,7 @@ use duckdb::{
     vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab},
 };
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::expand::{ancestors_to_root, collect_derived_metric_source_tables};
 use crate::graph::RelationshipGraph;
 use crate::model::{Cardinality, Dimension, SemanticViewDefinition};
@@ -180,26 +180,30 @@ impl VTab for ShowDimensionsForMetricVTab {
             let view_name = bind.get_parameter(0).to_string();
             let metric_name = bind.get_parameter(1).to_string();
 
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let json = match reader
+                .lookup(&view_name)
+                .map_err(Box::<dyn std::error::Error>::from)?
+            {
+                Some(j) => j,
+                None => {
+                    let available = reader
+                        .list_names()
+                        .map_err(Box::<dyn std::error::Error>::from)?;
+                    let msg = if let Some(suggestion) = suggest_closest(&view_name, &available) {
+                        format!(
+                            "semantic view '{}' does not exist. Did you mean '{}'?",
+                            view_name, suggestion
+                        )
+                    } else {
+                        format!("semantic view '{}' does not exist", view_name)
+                    };
+                    return Err(msg.into());
+                }
             };
 
-            let json = guard.get(&view_name).ok_or_else(|| {
-                let available: Vec<String> = guard.keys().cloned().collect();
-                if let Some(suggestion) = suggest_closest(&view_name, &available) {
-                    format!(
-                        "semantic view '{}' does not exist. Did you mean '{}'?",
-                        view_name, suggestion
-                    )
-                } else {
-                    format!("semantic view '{}' does not exist", view_name)
-                }
-            })?;
-
-            let def = SemanticViewDefinition::from_json(&view_name, json)?;
+            let def = SemanticViewDefinition::from_json(&view_name, &json)?;
 
             // Find the metric (case-insensitive)
             let metric_lower = metric_name.to_ascii_lowercase();

--- a/src/ddl/show_facts.rs
+++ b/src/ddl/show_facts.rs
@@ -5,7 +5,7 @@ use duckdb::{
     vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab},
 };
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::ddl::describe::format_json_array;
 use crate::model::SemanticViewDefinition;
 
@@ -151,18 +151,14 @@ impl VTab for ShowSemanticFactsVTab {
             bind_output_columns(bind);
 
             let view_name = bind.get_parameter(0).to_string();
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
-
-            let json = guard
-                .get(&view_name)
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let json = reader
+                .lookup(&view_name)
+                .map_err(Box::<dyn std::error::Error>::from)?
                 .ok_or_else(|| format!("semantic view '{view_name}' does not exist"))?;
 
-            let mut rows = collect_facts(&view_name, json);
+            let mut rows = collect_facts(&view_name, &json);
             rows.sort_by(|a, b| a.name.cmp(&b.name));
 
             Ok(ShowFactsBindData { rows })
@@ -204,15 +200,14 @@ impl VTab for ShowSemanticFactsAllVTab {
         crate::util::catch_unwind_to_result(std::panic::AssertUnwindSafe(|| {
             bind_output_columns(bind);
 
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let entries = reader
+                .list_all()
+                .map_err(Box::<dyn std::error::Error>::from)?;
 
             let mut rows = Vec::new();
-            for (name, json) in guard.iter() {
+            for (name, json) in &entries {
                 rows.extend(collect_facts(name, json));
             }
             rows.sort_by(|a, b| {

--- a/src/ddl/show_materializations.rs
+++ b/src/ddl/show_materializations.rs
@@ -5,7 +5,7 @@ use duckdb::{
     vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab},
 };
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::ddl::describe::format_json_array;
 use crate::model::SemanticViewDefinition;
 
@@ -138,18 +138,14 @@ impl VTab for ShowSemanticMaterializationsVTab {
             bind_output_columns(bind);
 
             let view_name = bind.get_parameter(0).to_string();
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
-
-            let json = guard
-                .get(&view_name)
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let json = reader
+                .lookup(&view_name)
+                .map_err(Box::<dyn std::error::Error>::from)?
                 .ok_or_else(|| format!("semantic view '{view_name}' does not exist"))?;
 
-            let mut rows = collect_mats(&view_name, json);
+            let mut rows = collect_mats(&view_name, &json);
             rows.sort_by(|a, b| a.name.cmp(&b.name));
 
             Ok(ShowMatBindData { rows })
@@ -191,15 +187,14 @@ impl VTab for ShowSemanticMaterializationsAllVTab {
         crate::util::catch_unwind_to_result(std::panic::AssertUnwindSafe(|| {
             bind_output_columns(bind);
 
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let entries = reader
+                .list_all()
+                .map_err(Box::<dyn std::error::Error>::from)?;
 
             let mut rows = Vec::new();
-            for (name, json) in guard.iter() {
+            for (name, json) in &entries {
                 rows.extend(collect_mats(name, json));
             }
             rows.sort_by(|a, b| {

--- a/src/ddl/show_metrics.rs
+++ b/src/ddl/show_metrics.rs
@@ -5,7 +5,7 @@ use duckdb::{
     vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab},
 };
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::ddl::describe::format_json_array;
 use crate::model::SemanticViewDefinition;
 
@@ -153,18 +153,14 @@ impl VTab for ShowSemanticMetricsVTab {
             bind_output_columns(bind);
 
             let view_name = bind.get_parameter(0).to_string();
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
-
-            let json = guard
-                .get(&view_name)
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let json = reader
+                .lookup(&view_name)
+                .map_err(Box::<dyn std::error::Error>::from)?
                 .ok_or_else(|| format!("semantic view '{view_name}' does not exist"))?;
 
-            let mut rows = collect_metrics(&view_name, json);
+            let mut rows = collect_metrics(&view_name, &json);
             rows.sort_by(|a, b| a.name.cmp(&b.name));
 
             Ok(ShowMetricsBindData { rows })
@@ -206,15 +202,14 @@ impl VTab for ShowSemanticMetricsAllVTab {
         crate::util::catch_unwind_to_result(std::panic::AssertUnwindSafe(|| {
             bind_output_columns(bind);
 
-            let state_ptr = bind.get_extra_info::<CatalogState>();
-            let guard = unsafe {
-                (*state_ptr)
-                    .read()
-                    .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?
-            };
+            let state_ptr = bind.get_extra_info::<CatalogReader>();
+            let reader = unsafe { *state_ptr };
+            let entries = reader
+                .list_all()
+                .map_err(Box::<dyn std::error::Error>::from)?;
 
             let mut rows = Vec::new();
-            for (name, json) in guard.iter() {
+            for (name, json) in &entries {
                 rows.extend(collect_metrics(name, json));
             }
             rows.sort_by(|a, b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,7 @@ mod extension {
         fn sv_register_parser_hooks(
             db_handle: ffi::duckdb_database,
             ddl_conn: ffi::duckdb_connection,
+            out_db_token: *mut u64,
         ) -> bool;
     }
 
@@ -386,9 +387,32 @@ mod extension {
         }
         let catalog_reader = crate::catalog::CatalogReader::new(catalog_conn);
 
+        // Create the DDL connection early so we can register parser hooks and
+        // capture the per-load `db_token` before any other code path needs it.
+        // The hook needs to be in place AND mapped to the right catalog reader
+        // BEFORE table functions are registered (table-function registration
+        // can itself trigger parsing on some DuckDB versions).
+        let mut ddl_conn: ffi::duckdb_connection = ptr::null_mut();
+        let rc = unsafe { ffi::duckdb_connect(db_handle, &mut ddl_conn) };
+        if rc != ffi::DuckDBSuccess {
+            return Err("Failed to create DDL connection for parser hook".into());
+        }
+
+        let mut db_token: u64 = 0;
+        if !unsafe { sv_register_parser_hooks(db_handle, ddl_conn, &mut db_token) } {
+            return Err("Failed to register parser hooks via C++ helper".into());
+        }
+
         // v0.8.0: install the catalog handle the parser_override callback
-        // uses for DROP / ALTER existence checks and JSON read-modify-write.
-        crate::parse::set_catalog_for_parser_override(catalog_reader);
+        // uses for CREATE/DROP/ALTER existence checks and JSON read-modify-
+        // write, keyed by the token the C++ shim assigned at registration.
+        // `is_file_backed` mirrors the legacy `persist_conn.is_some()` gate so
+        // DDL-time type inference fires only for file-backed DBs.
+        crate::parse::set_catalog_for_parser_override(
+            db_token,
+            catalog_reader,
+            persist_conn.is_some(),
+        );
 
         let define_state = DefineState {
             persist_conn,
@@ -607,25 +631,10 @@ mod extension {
             &query_state,
         )?;
 
-        // Create a dedicated DDL connection for the parser hook path.
-        // This connection is ALWAYS created (even for in-memory databases) because
-        // the native DDL path rewrites to `SELECT * FROM create_semantic_view(...)`
-        // which needs a separate connection to avoid deadlocking the ClientContext
-        // lock held during plan/bind. This is distinct from persist_conn (which
-        // writes to the _definitions catalog table for file-backed databases).
-        let mut ddl_conn: ffi::duckdb_connection = ptr::null_mut();
-        let rc = unsafe { ffi::duckdb_connect(db_handle, &mut ddl_conn) };
-        if rc != ffi::DuckDBSuccess {
-            return Err("Failed to create DDL connection for parser hook".into());
-        }
-
-        // Register parser hooks via C++ helper.
-        // The C++ shim extracts DatabaseInstance& from the duckdb_database handle
-        // and registers ParserExtension hooks on DBConfig. This requires C++ types
-        // that are only available via the duckdb.hpp amalgamation header.
-        if !unsafe { sv_register_parser_hooks(db_handle, ddl_conn) } {
-            return Err("Failed to register parser hooks via C++ helper".into());
-        }
+        // Parser hooks (sv_register_parser_hooks) and the per-load ddl_conn
+        // were created earlier in init_extension so the parser_override
+        // catalog map can be populated before any registration triggers a
+        // parse on the connection.
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,15 +356,15 @@ mod extension {
             }
         };
 
-        // Initialize the catalog.
-        let catalog_state = init_catalog(con, &db_path)?;
+        // Initialize the persistent catalog (schema + table + companion-file migration).
+        init_catalog(con, &db_path)?;
 
-        // Create a separate connection for DDL persistence.
-        // Only created for file-backed databases — in-memory DBs use HashMap only.
-        // This connection is used by define_semantic_view / drop_semantic_view via FFI
-        // to write to semantic_layer._definitions without deadlocking the main
-        // connection's execution lock (context_lock is non-reentrant; a second
-        // duckdb_connection has its own context).
+        // Create a separate connection for DDL persistence on file-backed
+        // databases. The legacy table-function DDL path uses this connection
+        // to write to `semantic_layer._definitions` without deadlocking the
+        // main connection's execution lock (context_lock is non-reentrant;
+        // a second duckdb_connection has its own context). For in-memory
+        // databases the catalog connection serves the same purpose.
         let persist_conn: Option<ffi::duckdb_connection> = if db_path.as_ref() != ":memory:" {
             let mut conn: ffi::duckdb_connection = ptr::null_mut();
             let rc = unsafe { ffi::duckdb_connect(db_handle, &mut conn) };
@@ -376,19 +376,17 @@ mod extension {
             None
         };
 
-        // Register create_semantic_view_from_json(name, json) -- target for native DDL.
-        // The native DDL path (CREATE SEMANTIC VIEW ... AS ...) rewrites to a call to
-        // these _from_json table functions. Three variants cover the 3 CREATE forms.
-        // Create a dedicated connection for catalog queries (duckdb_constraints() lookups).
-        // Always created for both file-backed and in-memory databases.
+        // Dedicated connection for catalog queries (`duckdb_constraints()`
+        // lookups, `_definitions` reads, etc.). Always created for both
+        // file-backed and in-memory databases.
         let mut catalog_conn: ffi::duckdb_connection = ptr::null_mut();
         let rc = unsafe { ffi::duckdb_connect(db_handle, &mut catalog_conn) };
         if rc != ffi::DuckDBSuccess {
-            return Err("Failed to create catalog connection for PK resolution".into());
+            return Err("Failed to create catalog connection".into());
         }
+        let catalog_reader = crate::catalog::CatalogReader::new(catalog_conn);
 
         let define_state = DefineState {
-            catalog: catalog_state.clone(),
             persist_conn,
             catalog_conn,
             or_replace: false,
@@ -400,7 +398,6 @@ mod extension {
         )?;
 
         let define_or_replace_state = DefineState {
-            catalog: catalog_state.clone(),
             persist_conn,
             catalog_conn,
             or_replace: true,
@@ -412,7 +409,6 @@ mod extension {
         )?;
 
         let define_if_not_exists_state = DefineState {
-            catalog: catalog_state.clone(),
             persist_conn,
             catalog_conn,
             or_replace: false,
@@ -425,7 +421,7 @@ mod extension {
 
         // Register drop_semantic_view(name) table function.
         let drop_state = DropState {
-            catalog: catalog_state.clone(),
+            catalog: catalog_reader,
             persist_conn,
             if_exists: false,
         };
@@ -436,7 +432,7 @@ mod extension {
 
         // Register drop_semantic_view_if_exists(name) table function.
         let drop_if_exists_state = DropState {
-            catalog: catalog_state.clone(),
+            catalog: catalog_reader,
             persist_conn,
             if_exists: true,
         };
@@ -447,7 +443,7 @@ mod extension {
 
         // Register alter_semantic_view_rename(old, new) table function.
         let alter_state = AlterRenameState {
-            catalog: catalog_state.clone(),
+            catalog: catalog_reader,
             persist_conn,
             if_exists: false,
         };
@@ -458,7 +454,7 @@ mod extension {
 
         // Register alter_semantic_view_rename_if_exists(old, new) table function.
         let alter_if_exists_state = AlterRenameState {
-            catalog: catalog_state.clone(),
+            catalog: catalog_reader,
             persist_conn,
             if_exists: true,
         };
@@ -469,7 +465,7 @@ mod extension {
 
         // Register alter_semantic_view_set_comment(name, comment) table function.
         let alter_set_comment_state = AlterCommentState {
-            catalog: catalog_state.clone(),
+            catalog: catalog_reader,
             persist_conn,
             if_exists: false,
         };
@@ -480,7 +476,7 @@ mod extension {
 
         // Register alter_semantic_view_set_comment_if_exists(name, comment) table function.
         let alter_set_comment_if_exists_state = AlterCommentState {
-            catalog: catalog_state.clone(),
+            catalog: catalog_reader,
             persist_conn,
             if_exists: true,
         };
@@ -491,7 +487,7 @@ mod extension {
 
         // Register alter_semantic_view_unset_comment(name) table function.
         let alter_unset_comment_state = AlterCommentState {
-            catalog: catalog_state.clone(),
+            catalog: catalog_reader,
             persist_conn,
             if_exists: false,
         };
@@ -502,7 +498,7 @@ mod extension {
 
         // Register alter_semantic_view_unset_comment_if_exists(name) table function.
         let alter_unset_comment_if_exists_state = AlterCommentState {
-            catalog: catalog_state.clone(),
+            catalog: catalog_reader,
             persist_conn,
             if_exists: true,
         };
@@ -514,74 +510,74 @@ mod extension {
         // Register table DDL read functions (list_semantic_views, describe_semantic_view).
         con.register_table_function_with_extra_info::<ListSemanticViewsVTab, _>(
             "list_semantic_views",
-            &catalog_state,
+            &catalog_reader,
         )?;
         con.register_table_function_with_extra_info::<ListTerseSemanticViewsVTab, _>(
             "list_terse_semantic_views",
-            &catalog_state,
+            &catalog_reader,
         )?;
         con.register_table_function_with_extra_info::<ShowColumnsInSemanticViewVTab, _>(
             "show_columns_in_semantic_view",
-            &catalog_state,
+            &catalog_reader,
         )?;
         con.register_table_function_with_extra_info::<DescribeSemanticViewVTab, _>(
             "describe_semantic_view",
-            &catalog_state,
+            &catalog_reader,
         )?;
 
         // SHOW SEMANTIC DIMENSIONS
         con.register_table_function_with_extra_info::<ShowSemanticDimensionsVTab, _>(
             "show_semantic_dimensions",
-            &catalog_state,
+            &catalog_reader,
         )?;
         con.register_table_function_with_extra_info::<ShowSemanticDimensionsAllVTab, _>(
             "show_semantic_dimensions_all",
-            &catalog_state,
+            &catalog_reader,
         )?;
 
         // SHOW SEMANTIC DIMENSIONS FOR METRIC
         con.register_table_function_with_extra_info::<ShowDimensionsForMetricVTab, _>(
             "show_semantic_dimensions_for_metric",
-            &catalog_state,
+            &catalog_reader,
         )?;
 
         // SHOW SEMANTIC METRICS
         con.register_table_function_with_extra_info::<ShowSemanticMetricsVTab, _>(
             "show_semantic_metrics",
-            &catalog_state,
+            &catalog_reader,
         )?;
         con.register_table_function_with_extra_info::<ShowSemanticMetricsAllVTab, _>(
             "show_semantic_metrics_all",
-            &catalog_state,
+            &catalog_reader,
         )?;
 
         // SHOW SEMANTIC FACTS
         con.register_table_function_with_extra_info::<ShowSemanticFactsVTab, _>(
             "show_semantic_facts",
-            &catalog_state,
+            &catalog_reader,
         )?;
         con.register_table_function_with_extra_info::<ShowSemanticFactsAllVTab, _>(
             "show_semantic_facts_all",
-            &catalog_state,
+            &catalog_reader,
         )?;
 
         // SHOW SEMANTIC MATERIALIZATIONS
         con.register_table_function_with_extra_info::<ShowSemanticMaterializationsVTab, _>(
             "show_semantic_materializations",
-            &catalog_state,
+            &catalog_reader,
         )?;
         con.register_table_function_with_extra_info::<ShowSemanticMaterializationsAllVTab, _>(
             "show_semantic_materializations_all",
-            &catalog_state,
+            &catalog_reader,
         )?;
 
         // Register GET_DDL scalar function.
-        con.register_scalar_function_with_state::<GetDdlScalar>("get_ddl", &catalog_state)?;
+        con.register_scalar_function_with_state::<GetDdlScalar>("get_ddl", &catalog_reader)?;
 
         // Register READ_YAML_FROM_SEMANTIC_VIEW scalar function.
         con.register_scalar_function_with_state::<ReadYamlFromSemanticViewScalar>(
             "read_yaml_from_semantic_view",
-            &catalog_state,
+            &catalog_reader,
         )?;
 
         // Create a NEW connection for the semantic_view table function.
@@ -593,7 +589,7 @@ mod extension {
 
         // Register the semantic_view table function.
         let query_state = QueryState {
-            catalog: catalog_state.clone(),
+            catalog: catalog_reader,
             conn: query_conn,
         };
         con.register_table_function_with_extra_info::<SemanticViewVTab, _>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,10 @@ mod extension {
         }
         let catalog_reader = crate::catalog::CatalogReader::new(catalog_conn);
 
+        // v0.8.0: install the catalog handle the parser_override callback
+        // uses for DROP / ALTER existence checks and JSON read-modify-write.
+        crate::parse::set_catalog_for_parser_override(catalog_reader);
+
         let define_state = DefineState {
             persist_conn,
             catalog_conn,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -28,22 +28,49 @@ use crate::model::{Cardinality, Join, TableRef};
 // CREATE-then-ALTER is the documented v0.8.0 limitation.
 #[cfg(feature = "extension")]
 mod parser_override_catalog {
-    use std::sync::OnceLock;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
 
     use crate::catalog::CatalogReader;
 
-    static CATALOG: OnceLock<CatalogReader> = OnceLock::new();
-
-    /// Install the catalog reader used by parser_override DROP/ALTER rewrites.
-    /// Called once from `init_extension`. Subsequent calls are no-ops.
-    pub fn set(reader: CatalogReader) {
-        let _ = CATALOG.set(reader);
+    /// Catalog handle plus a `is_file_backed` flag (matches the legacy
+    /// `DefineState::persist_conn.is_some()` test) that gates DDL-time type
+    /// inference. Type inference uses `LIMIT 0` probes that depend on user
+    /// tables having been committed; for in-memory DBs we follow the v0.7.1
+    /// behaviour and skip inference entirely.
+    #[derive(Clone, Copy)]
+    pub struct OverrideContext {
+        pub catalog: CatalogReader,
+        pub is_file_backed: bool,
     }
 
-    /// Fetch the catalog reader. Returns `None` if `set` has not been called
-    /// (e.g. unit tests not running the extension entry point).
-    pub fn get() -> Option<CatalogReader> {
-        CATALOG.get().copied()
+    // Per-extension-load context map, keyed by the `db_token` the C++ shim
+    // assigns at registration time. A process can load the extension against
+    // multiple databases sequentially (Python integration tests do this) — a
+    // single global slot would let the first load's stale `catalog_conn` leak
+    // into later parser_override invocations on a different DB.
+    static CONTEXTS: Mutex<Option<HashMap<u64, OverrideContext>>> = Mutex::new(None);
+
+    /// Install the parser_override context for `db_token`. Called once per
+    /// `init_extension`. Subsequent calls for the same token overwrite (the
+    /// extension being re-loaded against the same DB is benign).
+    pub fn set(db_token: u64, catalog: CatalogReader, is_file_backed: bool) {
+        let mut guard = CONTEXTS.lock().expect("parser_override_catalog poisoned");
+        guard.get_or_insert_with(HashMap::new).insert(
+            db_token,
+            OverrideContext {
+                catalog,
+                is_file_backed,
+            },
+        );
+    }
+
+    /// Fetch the parser_override context for `db_token`. Returns `None` if
+    /// `set` has not been called for that token (e.g. unit tests not running
+    /// the extension entry point, or a stale token).
+    pub fn get(db_token: u64) -> Option<OverrideContext> {
+        let guard = CONTEXTS.lock().expect("parser_override_catalog poisoned");
+        guard.as_ref().and_then(|m| m.get(&db_token).copied())
     }
 }
 
@@ -1701,23 +1728,24 @@ pub extern "C" fn sv_rewrite_ddl_rust(
 // the parser_override callback to fall through to DuckDB's default parser
 // (and from there the legacy parse_function fallback for non-postgres DDL):
 //
+//   * CREATE / CREATE OR REPLACE / CREATE IF NOT EXISTS  (extension feature only)
 //   * DROP / DROP IF EXISTS                              (extension feature only)
 //   * ALTER ... RENAME TO / SET COMMENT / UNSET COMMENT  (extension feature only)
 //
-// DROP and ALTER need a `CatalogReader` for existence checks and JSON
-// read-modify-write; that handle is `OnceLock`-installed at extension load,
-// so under `cargo test` (no extension feature) these forms still defer to
-// the legacy path.
+// All three need a `CatalogReader` for existence checks; CREATE additionally
+// uses it to run catalog-side queries during enrichment (PK lookup, LIMIT 0
+// type inference, fact typing). The handle is `OnceLock`-installed at
+// extension load, so under `cargo test` (no extension feature) these forms
+// still defer to the legacy path.
 //
-// Forms NOT rewritten (legacy path retains v0.7.x non-transactional behaviour
-// for these — documented as a v0.8.0 limitation):
-//   * CREATE / CREATE OR REPLACE / CREATE IF NOT EXISTS  — DefineFromJsonVTab::bind
-//     enriches the JSON with database_name / schema_name / created_on, runs
-//     LIMIT 0 type inference, and validates the relationship graph. Emitting a
-//     bare INSERT here would skip all of that and write an under-populated row.
-//   * CREATE ... FROM YAML FILE '/path/...'  (sentinel needs C++ file read)
-//   * DESCRIBE / SHOW *                       (read-only; transactionality not relevant)
-pub fn rewrite_to_native_sql(query: &str) -> Result<Option<String>, ParseError> {
+// Forms NOT rewritten:
+//   * CREATE ... FROM YAML FILE '/path/...'  (sentinel needs C++ file read;
+//     once the C++ shim has resolved the file the result re-enters this
+//     module as a regular CREATE through DefineFromJsonVTab::bind, which
+//     calls the same shared `enrich_definition_for_create` helper but runs
+//     in non-transactional auto-commit — documented v0.8.0 limitation).
+//   * DESCRIBE / SHOW *  (read-only; transactionality not relevant).
+pub fn rewrite_to_native_sql(db_token: u64, query: &str) -> Result<Option<String>, ParseError> {
     let Some(tf_sql) = validate_and_rewrite(query)? else {
         return Ok(None);
     };
@@ -1739,21 +1767,18 @@ pub fn rewrite_to_native_sql(query: &str) -> Result<Option<String>, ParseError> 
     // re-embedded as single-quoted strings without further processing.
     let args = &call.args;
     match call.fn_name.as_str() {
-        // CREATE: deferred to the legacy DefineFromJsonVTab::bind path, which
-        // performs metadata enrichment that has to happen before the row is
-        // written — capturing database_name / schema_name / created_on, running
-        // LIMIT 0 type inference, and validating the relationship graph. None
-        // of that work has been moved out of bind() yet, so emitting INSERT
-        // here would write an under-populated row and break SHOW / DESCRIBE.
-        // CREATE remains non-transactional (the legacy path uses persist_conn,
-        // which auto-commits) — documented v0.8.0 limitation.
+        // CREATE forms: enrich the JSON (metadata + type inference + graph
+        // validation) against the catalog connection, then emit native INSERT
+        // on the caller's connection. See `rewrite_create` (extension-only).
         "create_semantic_view_from_json"
         | "create_or_replace_semantic_view_from_json"
-        | "create_semantic_view_if_not_exists_from_json" => Ok(None),
+        | "create_semantic_view_if_not_exists_from_json" => {
+            rewrite_create(db_token, call.fn_name.as_str(), args)
+        }
         // DROP / ALTER need catalog access for existence checks and JSON
         // read-modify-write. See `rewrite_drop_or_alter` (extension-only).
         // DESCRIBE / SHOW are read-only — defer to legacy path.
-        _ => rewrite_drop_or_alter(call.fn_name.as_str(), args),
+        _ => rewrite_drop_or_alter(db_token, call.fn_name.as_str(), args),
     }
 }
 
@@ -1763,17 +1788,26 @@ pub fn rewrite_to_native_sql(query: &str) -> Result<Option<String>, ParseError> 
 /// and ALTER fall back through the legacy `parse_function` path.
 #[cfg(not(feature = "extension"))]
 #[allow(clippy::unnecessary_wraps)] // matches the extension-feature signature
-fn rewrite_drop_or_alter(_fn_name: &str, _args: &[String]) -> Result<Option<String>, ParseError> {
+fn rewrite_drop_or_alter(
+    _db_token: u64,
+    _fn_name: &str,
+    _args: &[String],
+) -> Result<Option<String>, ParseError> {
     Ok(None)
 }
 
 #[cfg(feature = "extension")]
-fn rewrite_drop_or_alter(fn_name: &str, args: &[String]) -> Result<Option<String>, ParseError> {
-    // Without an installed CatalogReader (e.g. extension loaded but
-    // set_catalog_for_parser_override not yet called) defer to legacy path.
-    let Some(catalog) = parser_override_catalog::get() else {
+fn rewrite_drop_or_alter(
+    db_token: u64,
+    fn_name: &str,
+    args: &[String],
+) -> Result<Option<String>, ParseError> {
+    // Without an installed parser_override context for this DB token defer to
+    // the legacy path.
+    let Some(ctx) = parser_override_catalog::get(db_token) else {
         return Ok(None);
     };
+    let catalog = ctx.catalog;
 
     match (fn_name, args.len()) {
         ("drop_semantic_view", 1) => rewrite_drop(&catalog, &args[0], false),
@@ -1799,6 +1833,107 @@ fn rewrite_drop_or_alter(fn_name: &str, args: &[String]) -> Result<Option<String
         // Read-only or unknown — defer to legacy.
         _ => Ok(None),
     }
+}
+
+/// CREATE-side native-SQL emission, gated on the extension feature: needs the
+/// runtime `CatalogReader` for existence checks AND for catalog-side queries
+/// performed by `enrich_definition_for_create` (PK lookup, type inference,
+/// fact typing). Under `cargo test` (no extension feature) returns `Ok(None)`
+/// so CREATE forms fall back through the legacy `parse_function` /
+/// `DefineFromJsonVTab::bind` path.
+#[cfg(not(feature = "extension"))]
+#[allow(clippy::unnecessary_wraps)] // matches the extension-feature signature
+fn rewrite_create(
+    _db_token: u64,
+    _fn_name: &str,
+    _args: &[String],
+) -> Result<Option<String>, ParseError> {
+    Ok(None)
+}
+
+#[cfg(feature = "extension")]
+fn rewrite_create(
+    db_token: u64,
+    fn_name: &str,
+    args: &[String],
+) -> Result<Option<String>, ParseError> {
+    // Without an installed parser_override context for this DB token defer to
+    // the legacy path (e.g. extension loaded but set_catalog_for_parser_override
+    // not called for this token).
+    let Some(ctx) = parser_override_catalog::get(db_token) else {
+        return Ok(None);
+    };
+
+    if args.len() != 2 {
+        return Ok(None);
+    }
+    let name_escaped = &args[0];
+    let json_escaped = &args[1];
+    let name = unescape_sql_arg(name_escaped);
+    let json = unescape_sql_arg(json_escaped);
+
+    let (or_replace, if_not_exists) = match fn_name {
+        "create_semantic_view_from_json" => (false, false),
+        "create_or_replace_semantic_view_from_json" => (true, false),
+        "create_semantic_view_if_not_exists_from_json" => (false, true),
+        _ => return Ok(None),
+    };
+
+    // Existence pre-check (committed state). Same-txn CREATE-then-CREATE for
+    // the same name is the documented v0.8.0 limitation: the second CREATE
+    // sees committed state, not the in-flight INSERT.
+    let exists = ctx.catalog.exists(&name).map_err(|e| ParseError {
+        message: format!("catalog lookup failed: {e}"),
+        position: None,
+    })?;
+
+    if exists && !or_replace {
+        if if_not_exists {
+            // Silent no-op with the legacy single-column schema.
+            return Ok(Some(format!(
+                "SELECT '{name_escaped}'::VARCHAR AS view_name WHERE 1 = 0"
+            )));
+        }
+        return Err(ParseError {
+            message: format!(
+                "semantic view '{name}' already exists; use CREATE OR REPLACE \
+                 SEMANTIC VIEW to overwrite"
+            ),
+            position: None,
+        });
+    }
+
+    // Deserialize, run shared enrichment against the catalog connection, and
+    // serialize back. Errors here surface as parser_override validation errors.
+    // `is_file_backed` matches the legacy `DefineState::persist_conn.is_some()`
+    // behaviour: type inference runs only for file-backed DBs (v0.7.1 design).
+    let def =
+        crate::model::SemanticViewDefinition::from_json(&name, &json).map_err(|e| ParseError {
+            message: e,
+            position: None,
+        })?;
+    let enriched_json = crate::ddl::define::enrich_definition_for_create(
+        &name,
+        def,
+        ctx.catalog.raw(),
+        ctx.is_file_backed,
+    )
+    .map_err(|e| ParseError {
+        message: e,
+        position: None,
+    })?;
+    let enriched_escaped = escape_sql_arg(&enriched_json);
+
+    let verb = if or_replace {
+        "INSERT OR REPLACE"
+    } else {
+        "INSERT"
+    };
+    Ok(Some(format!(
+        "{verb} INTO semantic_layer._definitions (name, definition) \
+         VALUES ('{name_escaped}', '{enriched_escaped}') \
+         RETURNING name AS view_name"
+    )))
 }
 
 /// Undo the SQL `''`-escaping retained in `parse_table_function_call`'s args.
@@ -2059,6 +2194,7 @@ fn strip_outer_quotes(s: &str) -> Option<&str> {
 #[cfg(feature = "extension")]
 #[no_mangle]
 pub extern "C" fn sv_parser_override_rust(
+    db_token: u64,
     query_ptr: *const u8,
     query_len: usize,
     sql_out: *mut u8,
@@ -2075,7 +2211,7 @@ pub extern "C" fn sv_parser_override_rust(
             std::str::from_utf8_unchecked(std::slice::from_raw_parts(query_ptr, query_len))
         };
 
-        match rewrite_to_native_sql(query) {
+        match rewrite_to_native_sql(db_token, query) {
             Ok(Some(sql)) => {
                 unsafe { write_to_buffer(sql_out, sql_out_len, &sql) };
                 0 // success — native SQL written

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -13,6 +13,43 @@ use crate::body_parser::parse_keyword_body;
 use crate::errors::ParseError;
 use crate::model::{Cardinality, Join, TableRef};
 
+// ---------------------------------------------------------------------------
+// v0.8.0: catalog handle for parser_override DROP/ALTER existence checks.
+// ---------------------------------------------------------------------------
+//
+// DROP without IF EXISTS and every ALTER form need to know whether a view
+// exists (and, for SET/UNSET COMMENT, what its current JSON definition is)
+// before we can emit native SQL with friendly errors. The parser_override
+// callback runs in a context with no access to the caller's catalog, so we
+// stash a dedicated `CatalogReader` (populated at extension load) in a
+// process-wide `OnceLock` and read it from the Rust FFI thunk.
+//
+// The reader sees committed state only — by design. Same-transaction
+// CREATE-then-ALTER is the documented v0.8.0 limitation.
+#[cfg(feature = "extension")]
+mod parser_override_catalog {
+    use std::sync::OnceLock;
+
+    use crate::catalog::CatalogReader;
+
+    static CATALOG: OnceLock<CatalogReader> = OnceLock::new();
+
+    /// Install the catalog reader used by parser_override DROP/ALTER rewrites.
+    /// Called once from `init_extension`. Subsequent calls are no-ops.
+    pub fn set(reader: CatalogReader) {
+        let _ = CATALOG.set(reader);
+    }
+
+    /// Fetch the catalog reader. Returns `None` if `set` has not been called
+    /// (e.g. unit tests not running the extension entry point).
+    pub fn get() -> Option<CatalogReader> {
+        CATALOG.get().copied()
+    }
+}
+
+#[cfg(feature = "extension")]
+pub use parser_override_catalog::set as set_catalog_for_parser_override;
+
 /// Not our statement -- return `DISPLAY_ORIGINAL_ERROR`.
 pub const PARSE_NOT_OURS: u8 = 0;
 /// Detected a semantic view DDL statement -- return `PARSE_SUCCESSFUL`.
@@ -1664,14 +1701,22 @@ pub extern "C" fn sv_rewrite_ddl_rust(
 // the parser_override callback to fall through to DuckDB's default parser
 // (and from there the legacy parse_function fallback for non-postgres DDL):
 //
-//   * CREATE / CREATE OR REPLACE / CREATE IF NOT EXISTS  (AS body and inline YAML)
+//   * DROP / DROP IF EXISTS                              (extension feature only)
+//   * ALTER ... RENAME TO / SET COMMENT / UNSET COMMENT  (extension feature only)
 //
-// Forms NOT yet rewritten (legacy path retains its v0.7.x non-transactional
-// behaviour for these — documented as a v0.8.0 limitation):
+// DROP and ALTER need a `CatalogReader` for existence checks and JSON
+// read-modify-write; that handle is `OnceLock`-installed at extension load,
+// so under `cargo test` (no extension feature) these forms still defer to
+// the legacy path.
+//
+// Forms NOT rewritten (legacy path retains v0.7.x non-transactional behaviour
+// for these — documented as a v0.8.0 limitation):
+//   * CREATE / CREATE OR REPLACE / CREATE IF NOT EXISTS  — DefineFromJsonVTab::bind
+//     enriches the JSON with database_name / schema_name / created_on, runs
+//     LIMIT 0 type inference, and validates the relationship graph. Emitting a
+//     bare INSERT here would skip all of that and write an under-populated row.
 //   * CREATE ... FROM YAML FILE '/path/...'  (sentinel needs C++ file read)
-//   * DROP / DROP IF EXISTS  (need error-on-missing semantics for non-IF-EXISTS form)
-//   * ALTER *  (RENAME needs error-on-missing; SET/UNSET COMMENT needs JSON read+modify+write)
-//   * DESCRIBE / SHOW *  (read-only; transactionality not relevant)
+//   * DESCRIBE / SHOW *                       (read-only; transactionality not relevant)
 pub fn rewrite_to_native_sql(query: &str) -> Result<Option<String>, ParseError> {
     let Some(tf_sql) = validate_and_rewrite(query)? else {
         return Ok(None);
@@ -1693,31 +1738,213 @@ pub fn rewrite_to_native_sql(query: &str) -> Result<Option<String>, ParseError> 
     // produced by validate_and_rewrite (single quotes doubled). They can be
     // re-embedded as single-quoted strings without further processing.
     let args = &call.args;
-    let sql = match call.fn_name.as_str() {
-        "create_semantic_view_from_json" if args.len() == 2 => format!(
-            "INSERT INTO semantic_layer._definitions (name, definition) \
-             VALUES ('{}', '{}') RETURNING name AS view_name",
-            args[0], args[1]
-        ),
-        "create_or_replace_semantic_view_from_json" if args.len() == 2 => format!(
-            "INSERT OR REPLACE INTO semantic_layer._definitions (name, definition) \
-             VALUES ('{}', '{}') RETURNING name AS view_name",
-            args[0], args[1]
-        ),
-        "create_semantic_view_if_not_exists_from_json" if args.len() == 2 => format!(
-            "INSERT OR IGNORE INTO semantic_layer._definitions (name, definition) \
-             VALUES ('{}', '{}') RETURNING name AS view_name",
-            args[0], args[1]
-        ),
-        // DROP, ALTER, DESCRIBE, SHOW * → defer to legacy path.
-        // DROP without IF EXISTS needs error-on-missing semantics that a plain
-        // DELETE doesn't provide; ALTER SET/UNSET COMMENT needs JSON modification.
-        // Both can be added in a follow-up commit once the error semantics are
-        // worked out (likely via a CTE with error() or a two-step validate+mutate).
-        _ => return Ok(None),
+    match call.fn_name.as_str() {
+        // CREATE: deferred to the legacy DefineFromJsonVTab::bind path, which
+        // performs metadata enrichment that has to happen before the row is
+        // written — capturing database_name / schema_name / created_on, running
+        // LIMIT 0 type inference, and validating the relationship graph. None
+        // of that work has been moved out of bind() yet, so emitting INSERT
+        // here would write an under-populated row and break SHOW / DESCRIBE.
+        // CREATE remains non-transactional (the legacy path uses persist_conn,
+        // which auto-commits) — documented v0.8.0 limitation.
+        "create_semantic_view_from_json"
+        | "create_or_replace_semantic_view_from_json"
+        | "create_semantic_view_if_not_exists_from_json" => Ok(None),
+        // DROP / ALTER need catalog access for existence checks and JSON
+        // read-modify-write. See `rewrite_drop_or_alter` (extension-only).
+        // DESCRIBE / SHOW are read-only — defer to legacy path.
+        _ => rewrite_drop_or_alter(call.fn_name.as_str(), args),
+    }
+}
+
+/// DROP / ALTER native-SQL emission, gated on the extension feature because it
+/// needs the runtime `CatalogReader` for existence checks and JSON read-modify-
+/// write. Under `cargo test` (no extension feature) returns `Ok(None)` so DROP
+/// and ALTER fall back through the legacy `parse_function` path.
+#[cfg(not(feature = "extension"))]
+#[allow(clippy::unnecessary_wraps)] // matches the extension-feature signature
+fn rewrite_drop_or_alter(_fn_name: &str, _args: &[String]) -> Result<Option<String>, ParseError> {
+    Ok(None)
+}
+
+#[cfg(feature = "extension")]
+fn rewrite_drop_or_alter(fn_name: &str, args: &[String]) -> Result<Option<String>, ParseError> {
+    // Without an installed CatalogReader (e.g. extension loaded but
+    // set_catalog_for_parser_override not yet called) defer to legacy path.
+    let Some(catalog) = parser_override_catalog::get() else {
+        return Ok(None);
     };
 
-    Ok(Some(sql))
+    match (fn_name, args.len()) {
+        ("drop_semantic_view", 1) => rewrite_drop(&catalog, &args[0], false),
+        ("drop_semantic_view_if_exists", 1) => rewrite_drop(&catalog, &args[0], true),
+        ("alter_semantic_view_rename", 2) => {
+            rewrite_alter_rename(&catalog, &args[0], &args[1], false)
+        }
+        ("alter_semantic_view_rename_if_exists", 2) => {
+            rewrite_alter_rename(&catalog, &args[0], &args[1], true)
+        }
+        ("alter_semantic_view_set_comment", 2) => {
+            rewrite_alter_comment(&catalog, &args[0], Some(&args[1]), false)
+        }
+        ("alter_semantic_view_set_comment_if_exists", 2) => {
+            rewrite_alter_comment(&catalog, &args[0], Some(&args[1]), true)
+        }
+        ("alter_semantic_view_unset_comment", 1) => {
+            rewrite_alter_comment(&catalog, &args[0], None, false)
+        }
+        ("alter_semantic_view_unset_comment_if_exists", 1) => {
+            rewrite_alter_comment(&catalog, &args[0], None, true)
+        }
+        // Read-only or unknown — defer to legacy.
+        _ => Ok(None),
+    }
+}
+
+/// Undo the SQL `''`-escaping retained in `parse_table_function_call`'s args.
+#[cfg(feature = "extension")]
+fn unescape_sql_arg(s: &str) -> String {
+    s.replace("''", "'")
+}
+
+/// Re-escape a string for embedding in single-quoted SQL.
+#[cfg(feature = "extension")]
+fn escape_sql_arg(s: &str) -> String {
+    s.replace('\'', "''")
+}
+
+#[cfg(feature = "extension")]
+fn rewrite_drop(
+    catalog: &crate::catalog::CatalogReader,
+    name_escaped: &str,
+    if_exists: bool,
+) -> Result<Option<String>, ParseError> {
+    let name = unescape_sql_arg(name_escaped);
+    let exists = catalog.exists(&name).map_err(|e| ParseError {
+        message: format!("catalog lookup failed: {e}"),
+        position: None,
+    })?;
+
+    if !exists {
+        if if_exists {
+            // Silent no-op, but emit a SELECT that returns the same one-row
+            // schema (`view_name VARCHAR`) the legacy path produces.
+            return Ok(Some(format!(
+                "SELECT '{name_escaped}'::VARCHAR AS view_name WHERE 1 = 0"
+            )));
+        }
+        return Err(ParseError {
+            message: format!("semantic view '{name}' does not exist"),
+            position: None,
+        });
+    }
+
+    Ok(Some(format!(
+        "DELETE FROM semantic_layer._definitions WHERE name = '{name_escaped}' \
+         RETURNING name AS view_name"
+    )))
+}
+
+#[cfg(feature = "extension")]
+fn rewrite_alter_rename(
+    catalog: &crate::catalog::CatalogReader,
+    old_escaped: &str,
+    new_escaped: &str,
+    if_exists: bool,
+) -> Result<Option<String>, ParseError> {
+    let old_name = unescape_sql_arg(old_escaped);
+    let new_name = unescape_sql_arg(new_escaped);
+
+    let exists = catalog.exists(&old_name).map_err(|e| ParseError {
+        message: format!("catalog lookup failed: {e}"),
+        position: None,
+    })?;
+
+    if !exists {
+        if if_exists {
+            // Silent no-op with the legacy two-column schema.
+            return Ok(Some(format!(
+                "SELECT '{old_escaped}'::VARCHAR AS old_name, \
+                 '{new_escaped}'::VARCHAR AS new_name WHERE 1 = 0"
+            )));
+        }
+        return Err(ParseError {
+            message: format!("semantic view '{old_name}' does not exist"),
+            position: None,
+        });
+    }
+
+    if catalog.exists(&new_name).map_err(|e| ParseError {
+        message: format!("catalog lookup failed: {e}"),
+        position: None,
+    })? {
+        return Err(ParseError {
+            message: format!("semantic view '{new_name}' already exists"),
+            position: None,
+        });
+    }
+
+    // PK update: DuckDB validates uniqueness; the pre-check above gives us
+    // a friendlier error. RETURNING projects the old/new pair from constants.
+    Ok(Some(format!(
+        "UPDATE semantic_layer._definitions SET name = '{new_escaped}' \
+         WHERE name = '{old_escaped}' \
+         RETURNING '{old_escaped}'::VARCHAR AS old_name, name AS new_name"
+    )))
+}
+
+#[cfg(feature = "extension")]
+fn rewrite_alter_comment(
+    catalog: &crate::catalog::CatalogReader,
+    name_escaped: &str,
+    new_comment_escaped: Option<&str>,
+    if_exists: bool,
+) -> Result<Option<String>, ParseError> {
+    let name = unescape_sql_arg(name_escaped);
+
+    let json_str = catalog.lookup(&name).map_err(|e| ParseError {
+        message: format!("catalog lookup failed: {e}"),
+        position: None,
+    })?;
+
+    let Some(json_str) = json_str else {
+        if if_exists {
+            // Silent no-op with the legacy (name, status) schema.
+            return Ok(Some(format!(
+                "SELECT '{name_escaped}'::VARCHAR AS name, 'no-op'::VARCHAR AS status \
+                 WHERE 1 = 0"
+            )));
+        }
+        return Err(ParseError {
+            message: format!("semantic view '{name}' does not exist"),
+            position: None,
+        });
+    };
+
+    let mut def: crate::model::SemanticViewDefinition =
+        serde_json::from_str(&json_str).map_err(|e| ParseError {
+            message: format!("failed to parse stored definition: {e}"),
+            position: None,
+        })?;
+
+    let status_label = if new_comment_escaped.is_some() {
+        "comment set"
+    } else {
+        "comment unset"
+    };
+    def.comment = new_comment_escaped.map(unescape_sql_arg);
+
+    let new_json = serde_json::to_string(&def).map_err(|e| ParseError {
+        message: format!("failed to serialize updated definition: {e}"),
+        position: None,
+    })?;
+    let new_json_escaped = escape_sql_arg(&new_json);
+
+    Ok(Some(format!(
+        "UPDATE semantic_layer._definitions SET definition = '{new_json_escaped}' \
+         WHERE name = '{name_escaped}' \
+         RETURNING name, '{status_label}'::VARCHAR AS status"
+    )))
 }
 
 /// Result of parsing a `SELECT * FROM <fn>('arg1'[, 'arg2'])` SQL string.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1998,10 +1998,11 @@ fn emit_native_create_sql(
 ) -> Result<Option<String>, ParseError> {
     let name_escaped = escape_sql_arg(name);
 
-    // Same-txn CREATE-then-CREATE for the same name is the documented v0.8.0
-    // limitation: the second CREATE sees committed state, not the in-flight
-    // INSERT, so the duplicate ends up as a PK violation at execute time
-    // rather than a friendly "already exists" parse error.
+    // Parse-time existence check: fast path for the committed-state case.
+    // Same-txn CREATE-then-CREATE slips past this (the catalog connection
+    // only sees committed rows), so the generated SQL below also guards
+    // against the in-flight case via a CASE+error() / WHERE NOT EXISTS
+    // pattern that runs on the caller's transaction.
     let exists = ctx.catalog.exists(name).map_err(|e| ParseError {
         message: format!("catalog lookup failed: {e}"),
         position: None,
@@ -2036,16 +2037,45 @@ fn emit_native_create_sql(
     })?;
     let enriched_escaped = escape_sql_arg(&enriched_json);
 
-    let verb = if or_replace {
-        "INSERT OR REPLACE"
+    // The generated SQL runs on the caller's connection, so its EXISTS
+    // subqueries see in-flight INSERTs from the same transaction. Three
+    // shapes:
+    //   - OR REPLACE: straight INSERT OR REPLACE, no guard needed.
+    //   - IF NOT EXISTS: WHERE NOT EXISTS guard so a same-txn duplicate
+    //     silently no-ops (mirrors the committed-state SELECT WHERE 1=0
+    //     fast path above).
+    //   - Plain CREATE: CASE+error() raises the friendly "already exists"
+    //     message before the INSERT can fire, replacing what would
+    //     otherwise be a generic PK constraint violation.
+    let sql = if or_replace {
+        format!(
+            "INSERT OR REPLACE INTO semantic_layer._definitions (name, definition) \
+             VALUES ('{name_escaped}', '{enriched_escaped}') \
+             RETURNING name AS view_name"
+        )
+    } else if if_not_exists {
+        format!(
+            "INSERT INTO semantic_layer._definitions (name, definition) \
+             SELECT '{name_escaped}', '{enriched_escaped}' \
+             WHERE NOT EXISTS (SELECT 1 FROM semantic_layer._definitions \
+                               WHERE name = '{name_escaped}') \
+             RETURNING name AS view_name"
+        )
     } else {
-        "INSERT"
+        format!(
+            "INSERT INTO semantic_layer._definitions (name, definition) \
+             SELECT \
+               CASE WHEN EXISTS (SELECT 1 FROM semantic_layer._definitions \
+                                 WHERE name = '{name_escaped}') \
+                    THEN error('semantic view ''{name_escaped}'' already exists; \
+                                use CREATE OR REPLACE SEMANTIC VIEW to overwrite') \
+                    ELSE '{name_escaped}' \
+               END, \
+               '{enriched_escaped}' \
+             RETURNING name AS view_name"
+        )
     };
-    Ok(Some(format!(
-        "{verb} INTO semantic_layer._definitions (name, definition) \
-         VALUES ('{name_escaped}', '{enriched_escaped}') \
-         RETURNING name AS view_name"
-    )))
+    Ok(Some(sql))
 }
 
 /// Read the FROM YAML FILE sentinel produced by `rewrite_ddl_yaml_file_body`,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1646,6 +1646,224 @@ pub extern "C" fn sv_rewrite_ddl_rust(
     }
 }
 
+// ---------------------------------------------------------------------------
+// v0.8.0: native-SQL rewrite for parser_override (transactional DDL)
+// ---------------------------------------------------------------------------
+//
+// Converts the table-function-call SQL produced by `validate_and_rewrite` into
+// native SQL (INSERT / DELETE / UPDATE against semantic_layer._definitions) so
+// that DuckDB executes it on the caller's connection — making writes participate
+// in the caller's transaction (the v0.8.0 fix for ADBC autocommit=false).
+//
+// The legacy table-function path stays the source of truth for validation and
+// JSON serialization. This function post-processes its output rather than
+// duplicating the rewrite logic. The format coupling is internal — both ends
+// of the conversion live in this file.
+//
+// Currently rewrites these forms; everything else returns Ok(None), causing
+// the parser_override callback to fall through to DuckDB's default parser
+// (and from there the legacy parse_function fallback for non-postgres DDL):
+//
+//   * CREATE / CREATE OR REPLACE / CREATE IF NOT EXISTS  (AS body and inline YAML)
+//
+// Forms NOT yet rewritten (legacy path retains its v0.7.x non-transactional
+// behaviour for these — documented as a v0.8.0 limitation):
+//   * CREATE ... FROM YAML FILE '/path/...'  (sentinel needs C++ file read)
+//   * DROP / DROP IF EXISTS  (need error-on-missing semantics for non-IF-EXISTS form)
+//   * ALTER *  (RENAME needs error-on-missing; SET/UNSET COMMENT needs JSON read+modify+write)
+//   * DESCRIBE / SHOW *  (read-only; transactionality not relevant)
+pub fn rewrite_to_native_sql(query: &str) -> Result<Option<String>, ParseError> {
+    let Some(tf_sql) = validate_and_rewrite(query)? else {
+        return Ok(None);
+    };
+
+    // YAML FILE produces a sentinel string starting with `__SV_YAML_FILE__`,
+    // not a SELECT. Defer to legacy path.
+    if tf_sql.starts_with("__SV_YAML_FILE__") {
+        return Ok(None);
+    }
+
+    let Some(call) = parse_table_function_call(&tf_sql) else {
+        // Not in `SELECT * FROM <fn>(...)` form (e.g. SHOW with WHERE clauses).
+        // Read-only forms — defer to legacy path.
+        return Ok(None);
+    };
+
+    // The args returned by parse_table_function_call retain the SQL escaping
+    // produced by validate_and_rewrite (single quotes doubled). They can be
+    // re-embedded as single-quoted strings without further processing.
+    let args = &call.args;
+    let sql = match call.fn_name.as_str() {
+        "create_semantic_view_from_json" if args.len() == 2 => format!(
+            "INSERT INTO semantic_layer._definitions (name, definition) \
+             VALUES ('{}', '{}') RETURNING name AS view_name",
+            args[0], args[1]
+        ),
+        "create_or_replace_semantic_view_from_json" if args.len() == 2 => format!(
+            "INSERT OR REPLACE INTO semantic_layer._definitions (name, definition) \
+             VALUES ('{}', '{}') RETURNING name AS view_name",
+            args[0], args[1]
+        ),
+        "create_semantic_view_if_not_exists_from_json" if args.len() == 2 => format!(
+            "INSERT OR IGNORE INTO semantic_layer._definitions (name, definition) \
+             VALUES ('{}', '{}') RETURNING name AS view_name",
+            args[0], args[1]
+        ),
+        // DROP, ALTER, DESCRIBE, SHOW * → defer to legacy path.
+        // DROP without IF EXISTS needs error-on-missing semantics that a plain
+        // DELETE doesn't provide; ALTER SET/UNSET COMMENT needs JSON modification.
+        // Both can be added in a follow-up commit once the error semantics are
+        // worked out (likely via a CTE with error() or a two-step validate+mutate).
+        _ => return Ok(None),
+    };
+
+    Ok(Some(sql))
+}
+
+/// Result of parsing a `SELECT * FROM <fn>('arg1'[, 'arg2'])` SQL string.
+///
+/// `args` retains the original SQL escaping (single quotes doubled), so they
+/// can be substituted back into a new single-quoted SQL string verbatim.
+struct TableFunctionCall {
+    fn_name: String,
+    args: Vec<String>,
+}
+
+/// Parse a `SELECT * FROM <fn_name>('arg1'[, 'arg2'])` SQL string.
+///
+/// Returns `None` for SQL that doesn't match this exact shape (e.g. SHOW forms
+/// with WHERE/LIMIT, or unrecognized prefixes). Handles SQL `''` escaping
+/// inside single-quoted args; preserves the `''` form in the returned strings
+/// so callers can re-embed them in new single-quoted SQL without re-escaping.
+fn parse_table_function_call(sql: &str) -> Option<TableFunctionCall> {
+    const PREFIX: &str = "SELECT * FROM ";
+    let rest = sql.strip_prefix(PREFIX)?;
+
+    // Read the function name up to '('.
+    let paren_pos = rest.find('(')?;
+    let fn_name = rest[..paren_pos].trim().to_string();
+    if fn_name.is_empty() || fn_name.contains(char::is_whitespace) {
+        return None;
+    }
+
+    // Body after the opening paren up to the matching closing paren.
+    // The body is a comma-separated list of single-quoted strings; we walk it
+    // tracking quote state so commas inside strings don't split args.
+    let body = &rest[paren_pos + 1..];
+    let mut args: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut in_quote = false;
+    let mut chars = body.char_indices();
+    let mut closing_pos: Option<usize> = None;
+
+    while let Some((i, ch)) = chars.next() {
+        if in_quote {
+            current.push(ch);
+            if ch == '\'' {
+                // Lookahead for `''` doubled-quote escape.
+                let mut peek = body[i + ch.len_utf8()..].chars();
+                if peek.next() == Some('\'') {
+                    // Consume the second '
+                    current.push('\'');
+                    chars.next();
+                } else {
+                    in_quote = false;
+                }
+            }
+        } else {
+            match ch {
+                '\'' => {
+                    in_quote = true;
+                    current.push(ch);
+                }
+                ',' => {
+                    args.push(strip_outer_quotes(current.trim())?.to_string());
+                    current.clear();
+                }
+                ')' => {
+                    closing_pos = Some(i);
+                    break;
+                }
+                c if c.is_whitespace() => {} // ignore between args
+                _ => return None,            // unexpected non-whitespace, non-quote
+            }
+        }
+    }
+
+    let _ = closing_pos?; // must have found a closing paren
+
+    // Push trailing arg if present (handles single-arg and multi-arg cases).
+    let trailing = current.trim();
+    if !trailing.is_empty() {
+        args.push(strip_outer_quotes(trailing)?.to_string());
+    }
+
+    // Anything after the closing paren must be empty or whitespace.
+    let after = &body[closing_pos? + 1..];
+    if !after.trim().is_empty() {
+        return None;
+    }
+
+    Some(TableFunctionCall { fn_name, args })
+}
+
+/// Strip the outer pair of single quotes, leaving doubled-quote escaping intact.
+fn strip_outer_quotes(s: &str) -> Option<&str> {
+    let inner = s.strip_prefix('\'')?.strip_suffix('\'')?;
+    Some(inner)
+}
+
+/// FFI entry point for parser_override. Validates and rewrites recognized
+/// semantic-view DDL into native SQL (INSERT / DELETE / UPDATE against
+/// `semantic_layer._definitions`) suitable for re-parsing through DuckDB's
+/// own parser and execution on the caller's connection.
+///
+/// Return values match the protocol used by sv_parse_stub:
+///   0 = success: native SQL written to `sql_out`
+///   1 = validation error: error written to `error_out`
+///   2 = not ours / not yet handled: caller should defer to default parser
+///       (which falls through to the legacy parse_function fallback path)
+///
+/// # Safety
+///
+/// - `query_ptr` must point to valid UTF-8 bytes of length `query_len`.
+/// - `sql_out` must point to a writable buffer of `sql_out_len` bytes.
+/// - `error_out` must point to a writable buffer of `error_out_len` bytes.
+#[cfg(feature = "extension")]
+#[no_mangle]
+pub extern "C" fn sv_parser_override_rust(
+    query_ptr: *const u8,
+    query_len: usize,
+    sql_out: *mut u8,
+    sql_out_len: usize,
+    error_out: *mut u8,
+    error_out_len: usize,
+) -> u8 {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if query_ptr.is_null() || query_len == 0 {
+            return 2_u8; // not ours
+        }
+        // SAFETY: guaranteed valid UTF-8 by the caller (DuckDB query text).
+        let query = unsafe {
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(query_ptr, query_len))
+        };
+
+        match rewrite_to_native_sql(query) {
+            Ok(Some(sql)) => {
+                unsafe { write_to_buffer(sql_out, sql_out_len, &sql) };
+                0 // success — native SQL written
+            }
+            Ok(None) => 2, // not ours, or a form we defer to the legacy path
+            Err(err) => {
+                unsafe { write_to_buffer(error_out, error_out_len, &err.message) };
+                1 // validation error
+            }
+        }
+    }));
+
+    result.unwrap_or(2) // on panic: not ours
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1750,10 +1750,13 @@ pub fn rewrite_to_native_sql(db_token: u64, query: &str) -> Result<Option<String
         return Ok(None);
     };
 
-    // YAML FILE produces a sentinel string starting with `__SV_YAML_FILE__`,
-    // not a SELECT. Defer to legacy path.
-    if tf_sql.starts_with("__SV_YAML_FILE__") {
-        return Ok(None);
+    // YAML FILE produces a sentinel string starting with `__SV_YAML_FILE__`
+    // (path + kind + name + comment). Read the file and route through the
+    // shared CREATE emission path so the INSERT runs on the caller's
+    // connection. Falls back to the legacy C++ shim path if the parser_override
+    // context isn't installed (cargo test, no extension feature).
+    if let Some(payload) = tf_sql.strip_prefix("__SV_YAML_FILE__") {
+        return rewrite_yaml_file_create(db_token, payload);
     }
 
     let Some(call) = parse_table_function_call(&tf_sql) else {
@@ -1867,10 +1870,8 @@ fn rewrite_create(
     if args.len() != 2 {
         return Ok(None);
     }
-    let name_escaped = &args[0];
-    let json_escaped = &args[1];
-    let name = unescape_sql_arg(name_escaped);
-    let json = unescape_sql_arg(json_escaped);
+    let name = unescape_sql_arg(&args[0]);
+    let json = unescape_sql_arg(&args[1]);
 
     let (or_replace, if_not_exists) = match fn_name {
         "create_semantic_view_from_json" => (false, false),
@@ -1879,17 +1880,49 @@ fn rewrite_create(
         _ => return Ok(None),
     };
 
-    // Existence pre-check (committed state). Same-txn CREATE-then-CREATE for
-    // the same name is the documented v0.8.0 limitation: the second CREATE
-    // sees committed state, not the in-flight INSERT.
-    let exists = ctx.catalog.exists(&name).map_err(|e| ParseError {
+    let def =
+        crate::model::SemanticViewDefinition::from_json(&name, &json).map_err(|e| ParseError {
+            message: e,
+            position: None,
+        })?;
+
+    emit_native_create_sql(&ctx, &name, def, or_replace, if_not_exists)
+}
+
+/// Shared CREATE-emission helper used by both the table-function-style CREATE
+/// path (`rewrite_create`) and the FROM YAML FILE path (`rewrite_yaml_file_create`).
+///
+/// Steps:
+/// 1. Existence pre-check on committed state (skipped for OR REPLACE).
+/// 2. Run `enrich_definition_for_create` against the catalog connection (PK
+///    resolution, validation, metadata capture, type inference, fact typing).
+/// 3. Emit `INSERT [OR REPLACE] INTO semantic_layer._definitions ...
+///    RETURNING name AS view_name` so DuckDB executes the write on the
+///    caller's connection inside the caller's transaction.
+///
+/// Returns the legacy 0-row `SELECT ... WHERE 1 = 0` shape for IF NOT EXISTS
+/// when the view already exists; errors plain CREATE on an existing view.
+#[cfg(feature = "extension")]
+fn emit_native_create_sql(
+    ctx: &parser_override_catalog::OverrideContext,
+    name: &str,
+    def: crate::model::SemanticViewDefinition,
+    or_replace: bool,
+    if_not_exists: bool,
+) -> Result<Option<String>, ParseError> {
+    let name_escaped = escape_sql_arg(name);
+
+    // Same-txn CREATE-then-CREATE for the same name is the documented v0.8.0
+    // limitation: the second CREATE sees committed state, not the in-flight
+    // INSERT, so the duplicate ends up as a PK violation at execute time
+    // rather than a friendly "already exists" parse error.
+    let exists = ctx.catalog.exists(name).map_err(|e| ParseError {
         message: format!("catalog lookup failed: {e}"),
         position: None,
     })?;
 
     if exists && !or_replace {
         if if_not_exists {
-            // Silent no-op with the legacy single-column schema.
             return Ok(Some(format!(
                 "SELECT '{name_escaped}'::VARCHAR AS view_name WHERE 1 = 0"
             )));
@@ -1903,17 +1936,10 @@ fn rewrite_create(
         });
     }
 
-    // Deserialize, run shared enrichment against the catalog connection, and
-    // serialize back. Errors here surface as parser_override validation errors.
     // `is_file_backed` matches the legacy `DefineState::persist_conn.is_some()`
     // behaviour: type inference runs only for file-backed DBs (v0.7.1 design).
-    let def =
-        crate::model::SemanticViewDefinition::from_json(&name, &json).map_err(|e| ParseError {
-            message: e,
-            position: None,
-        })?;
     let enriched_json = crate::ddl::define::enrich_definition_for_create(
-        &name,
+        name,
         def,
         ctx.catalog.raw(),
         ctx.is_file_backed,
@@ -1934,6 +1960,114 @@ fn rewrite_create(
          VALUES ('{name_escaped}', '{enriched_escaped}') \
          RETURNING name AS view_name"
     )))
+}
+
+/// Read the FROM YAML FILE sentinel produced by `rewrite_ddl_yaml_file_body`,
+/// fetch the file via `read_text()` on the catalog connection (preserves
+/// `DuckDB`'s filesystem support — local paths, `https://`, S3 via httpfs,
+/// etc.), parse the YAML into a `SemanticViewDefinition`, then emit a
+/// transactional INSERT through `emit_native_create_sql` so the write
+/// participates in the caller's transaction.
+///
+/// Returns `Ok(None)` when no `parser_override` context is installed for this
+/// `db_token` so the legacy C++ shim path (auto-commit) handles it.
+#[cfg(not(feature = "extension"))]
+#[allow(clippy::unnecessary_wraps)]
+fn rewrite_yaml_file_create(_db_token: u64, _payload: &str) -> Result<Option<String>, ParseError> {
+    Ok(None)
+}
+
+#[cfg(feature = "extension")]
+fn rewrite_yaml_file_create(db_token: u64, payload: &str) -> Result<Option<String>, ParseError> {
+    use std::ffi::CStr;
+    use std::os::raw::c_void;
+
+    use libduckdb_sys as ffi;
+
+    let Some(ctx) = parser_override_catalog::get(db_token) else {
+        return Ok(None);
+    };
+
+    // Sentinel format: `<path>\x01<kind>\x01<name>\x01<comment>` (the
+    // `__SV_YAML_FILE__` prefix has already been stripped by the caller).
+    let mut parts = payload.splitn(4, '\x01');
+    let file_path = parts.next().ok_or_else(|| ParseError {
+        message: "Internal error: malformed YAML FILE sentinel (missing path)".to_string(),
+        position: None,
+    })?;
+    let kind_str = parts.next().ok_or_else(|| ParseError {
+        message: "Internal error: malformed YAML FILE sentinel (missing kind)".to_string(),
+        position: None,
+    })?;
+    let name = parts.next().ok_or_else(|| ParseError {
+        message: "Internal error: malformed YAML FILE sentinel (missing name)".to_string(),
+        position: None,
+    })?;
+    let comment = parts.next().unwrap_or("");
+
+    let (or_replace, if_not_exists) = match kind_str {
+        "0" => (false, false),
+        "1" => (true, false),
+        "2" => (false, true),
+        _ => {
+            return Err(ParseError {
+                message: format!("Internal error: unknown YAML FILE kind '{kind_str}'"),
+                position: None,
+            });
+        }
+    };
+
+    // Read file via read_text(); this is one DuckDB statement on the catalog
+    // connection so the user's transaction state is untouched.
+    let path_escaped = file_path.replace('\'', "''");
+    let read_sql = format!("SELECT content FROM read_text('{path_escaped}')");
+    let mut result =
+        unsafe { crate::query::table_function::execute_sql_raw(ctx.catalog.raw(), &read_sql) }
+            .map_err(|e| ParseError {
+                message: format!("FROM YAML FILE failed: {e}"),
+                position: None,
+            })?;
+    let row_count = unsafe { ffi::duckdb_row_count(&mut result) };
+    if row_count == 0 {
+        unsafe { ffi::duckdb_destroy_result(&mut result) };
+        return Err(ParseError {
+            message: format!("FROM YAML FILE failed: no content returned from '{file_path}'"),
+            position: None,
+        });
+    }
+    let yaml_content = unsafe {
+        let val_ptr = ffi::duckdb_value_varchar(&mut result, 0, 0);
+        if val_ptr.is_null() {
+            ffi::duckdb_destroy_result(&mut result);
+            return Err(ParseError {
+                message: format!("FROM YAML FILE failed: NULL content from '{file_path}'"),
+                position: None,
+            });
+        }
+        let s = CStr::from_ptr(val_ptr).to_string_lossy().into_owned();
+        ffi::duckdb_free(val_ptr.cast::<c_void>());
+        ffi::duckdb_destroy_result(&mut result);
+        s
+    };
+
+    let mut def =
+        crate::model::SemanticViewDefinition::from_yaml_with_size_cap(name, &yaml_content)
+            .map_err(|e| ParseError {
+                message: e,
+                position: None,
+            })?;
+
+    if !comment.is_empty() {
+        def.comment = Some(comment.to_string());
+    }
+
+    // Cardinality inference runs against PK declarations in the YAML; the
+    // shared enrichment helper re-runs it after catalog PK resolution but
+    // we still need this initial pass to populate cardinality where the YAML
+    // already specifies PKs.
+    infer_cardinality(&def.tables, &mut def.joins)?;
+
+    emit_native_create_sql(&ctx, name, def, or_replace, if_not_exists)
 }
 
 /// Undo the SQL `''`-escaping retained in `parse_table_function_call`'s args.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1556,7 +1556,9 @@ pub(crate) fn infer_cardinality(
 /// FFI entry point for DDL validation with error reporting.
 ///
 /// Validates a semantic view DDL statement and returns a tri-state result:
-/// - 0 = success: rewritten SQL written to `sql_out`
+/// - 0 = success: DDL recognised and validated (caller carries the original
+///   query text forward; the rewritten SQL is computed only to surface
+///   validation errors and is discarded)
 /// - 1 = error: error message written to `error_out`, position to `*position_out`
 /// - 2 = not ours: no output written
 ///
@@ -1565,7 +1567,6 @@ pub(crate) fn infer_cardinality(
 /// # Safety
 ///
 /// - `query_ptr` must point to valid UTF-8 bytes of length `query_len`.
-/// - `sql_out` must point to a writable buffer of `sql_out_len` bytes.
 /// - `error_out` must point to a writable buffer of `error_out_len` bytes.
 /// - `position_out` must point to a writable `u32`.
 #[cfg(feature = "extension")]
@@ -1573,8 +1574,6 @@ pub(crate) fn infer_cardinality(
 pub extern "C" fn sv_validate_ddl_rust(
     query_ptr: *const u8,
     query_len: usize,
-    sql_out: *mut u8,
-    sql_out_len: usize,
     error_out: *mut u8,
     error_out_len: usize,
     position_out: *mut u32,
@@ -1589,14 +1588,11 @@ pub extern "C" fn sv_validate_ddl_rust(
         };
 
         match validate_and_rewrite(query) {
-            Ok(Some(sql)) => {
-                unsafe { write_to_buffer(sql_out, sql_out_len, &sql) };
-                0 // success
-            }
+            Ok(Some(_sql)) => 0, // success — rewritten SQL discarded; caller uses original query
             Ok(None) => {
                 // Not a recognized DDL -- check for near-miss
                 if let Some(err) = detect_near_miss(query) {
-                    unsafe { write_to_buffer(error_out, error_out_len, &err.message) };
+                    unsafe { write_error_to_buffer(error_out, error_out_len, &err.message) };
                     unsafe {
                         write_position(position_out, err.position);
                     }
@@ -1606,7 +1602,7 @@ pub extern "C" fn sv_validate_ddl_rust(
                 }
             }
             Err(err) => {
-                unsafe { write_to_buffer(error_out, error_out_len, &err.message) };
+                unsafe { write_error_to_buffer(error_out, error_out_len, &err.message) };
                 unsafe {
                     write_position(position_out, err.position);
                 }
@@ -1634,13 +1630,19 @@ unsafe fn write_position(position_out: *mut u32, position: Option<usize>) {
     }
 }
 
-/// Write a string into a raw byte buffer, null-terminated and truncated to `len - 1`.
+/// Write an error message into a fixed-size, caller-owned byte buffer.
+/// Null-terminated, truncated to `len - 1` bytes.
+///
+/// Use only for short, bounded strings (error messages). For unboundedly
+/// large outputs (rewritten SQL) use `leak_string_to_c_buffer` +
+/// `sv_free_buffer` instead — silently truncating SQL produced confusing
+/// downstream parser errors (see v0.8.0 buffer-truncation fix).
 ///
 /// # Safety
 ///
 /// `buf` must point to a writable buffer of at least `len` bytes.
 #[cfg(feature = "extension")]
-unsafe fn write_to_buffer(buf: *mut u8, len: usize, s: &str) {
+unsafe fn write_error_to_buffer(buf: *mut u8, len: usize, s: &str) {
     if buf.is_null() || len == 0 {
         return;
     }
@@ -1650,26 +1652,108 @@ unsafe fn write_to_buffer(buf: *mut u8, len: usize, s: &str) {
     *buf.add(copy_len) = 0; // null terminate
 }
 
+/// Convert an owned `String` into a heap-allocated byte buffer that the C++
+/// caller takes ownership of. Caller must release via `sv_free_buffer`.
+///
+/// Returns `(ptr, len)`. The buffer is **not** NUL-terminated — the C++
+/// side reads exactly `len` bytes. This avoids any silent truncation cap
+/// regardless of how large the rewritten SQL becomes.
+#[cfg_attr(not(any(feature = "extension", test)), allow(dead_code))]
+fn leak_string_to_c_buffer(s: String) -> (*mut u8, usize) {
+    let mut bytes = s.into_bytes();
+    bytes.shrink_to_fit();
+    debug_assert_eq!(bytes.len(), bytes.capacity());
+    let len = bytes.len();
+    let ptr = bytes.as_mut_ptr();
+    std::mem::forget(bytes);
+    (ptr, len)
+}
+
+/// Reclaim a buffer produced by `leak_string_to_c_buffer`.
+///
+/// # Safety
+///
+/// `ptr`/`len` must be the exact pair returned by an earlier call to
+/// `leak_string_to_c_buffer` (or its FFI exports), and may only be released
+/// once.
+#[cfg_attr(not(any(feature = "extension", test)), allow(dead_code))]
+// Clippy warns that `Vec::from_raw_parts(p, n, n)` looks suspicious — but
+// here the matching `leak_string_to_c_buffer` deliberately calls
+// `shrink_to_fit` so len == capacity holds. Keeping this shape
+// (vs. Box::from_raw on a *mut [u8]) preserves the symmetry with the
+// allocator that produced the buffer.
+#[allow(clippy::same_length_and_capacity)]
+unsafe fn reclaim_c_buffer(ptr: *mut u8, len: usize) {
+    if ptr.is_null() {
+        return;
+    }
+    drop(Vec::from_raw_parts(ptr, len, len));
+}
+
+/// FFI export: free a heap buffer produced by an earlier
+/// `sv_parser_override_rust` / `sv_rewrite_ddl_rust` success return.
+///
+/// Safe to call with a null pointer (no-op).
+///
+/// # Safety
+///
+/// `ptr`/`len` must be the exact pair the Rust side returned via its
+/// `sql_out_ptr` / `sql_out_len` out-parameters. Calling with any other
+/// pair (or twice on the same pair) is undefined behaviour.
+#[cfg(feature = "extension")]
+#[no_mangle]
+pub unsafe extern "C" fn sv_free_buffer(ptr: *mut u8, len: usize) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        reclaim_c_buffer(ptr, len);
+    }));
+}
+
+/// Internal helper: publish an owned `String` to the FFI out-parameters.
+/// On null out-pointers the buffer is dropped instead of leaked, so a
+/// misbehaving C++ caller cannot induce a memory leak through us.
+///
+/// # Safety
+///
+/// Either both `sql_out_ptr` and `sql_out_len` must point to writable
+/// `*mut u8` / `usize` slots, or both must be null. Mixed null is treated
+/// as "drop and skip writing."
+#[cfg(feature = "extension")]
+unsafe fn publish_owned_sql(sql: String, sql_out_ptr: *mut *mut u8, sql_out_len: *mut usize) {
+    if sql_out_ptr.is_null() || sql_out_len.is_null() {
+        return; // dropping `sql` here releases the heap allocation
+    }
+    let (ptr, len) = leak_string_to_c_buffer(sql);
+    *sql_out_ptr = ptr;
+    *sql_out_len = len;
+}
+
 /// FFI entry point for DDL rewriting (no execution), called from C++ `sv_ddl_bind`.
 ///
 /// Rewrites a semantic view DDL statement into the corresponding function call
 /// SQL string. The caller (C++) is responsible for executing it.
 ///
-/// On success: writes the rewritten SQL to `sql_out` (null-terminated), returns 0.
-/// On failure: writes the error message to `error_out` (null-terminated), returns 1.
+/// On success: returns 0 and writes a heap-owned byte buffer pointer +
+/// length to `*sql_out_ptr` / `*sql_out_len`. The caller takes ownership and
+/// must release the buffer via `sv_free_buffer`. The buffer is **not**
+/// NUL-terminated; read exactly `*sql_out_len` bytes.
+///
+/// On failure: returns 1, writes the error message into the caller-owned
+/// `error_out` buffer (truncated to `error_out_len - 1`), and leaves
+/// `*sql_out_ptr` untouched (typically null).
 ///
 /// # Safety
 ///
 /// - `query_ptr` must point to valid UTF-8 bytes of length `query_len`.
-/// - `sql_out` must point to a writable buffer of `sql_out_len` bytes.
+/// - `sql_out_ptr` must point to a writable `*mut u8` slot, or be null.
+/// - `sql_out_len` must point to a writable `usize` slot, or be null.
 /// - `error_out` must point to a writable buffer of `error_out_len` bytes.
 #[cfg(feature = "extension")]
 #[no_mangle]
 pub extern "C" fn sv_rewrite_ddl_rust(
     query_ptr: *const u8,
     query_len: usize,
-    sql_out: *mut u8,
-    sql_out_len: usize,
+    sql_out_ptr: *mut *mut u8,
+    sql_out_len: *mut usize,
     error_out: *mut u8,
     error_out_len: usize,
 ) -> u8 {
@@ -1696,15 +1780,17 @@ pub extern "C" fn sv_rewrite_ddl_rust(
 
     match result {
         Ok(Ok(sql)) => {
-            unsafe { write_to_buffer(sql_out, sql_out_len, &sql) };
+            unsafe { publish_owned_sql(sql, sql_out_ptr, sql_out_len) };
             0 // success
         }
         Ok(Err(err)) => {
-            unsafe { write_to_buffer(error_out, error_out_len, &err) };
+            unsafe { write_error_to_buffer(error_out, error_out_len, &err) };
             1 // failure
         }
         Err(_panic) => {
-            unsafe { write_to_buffer(error_out, error_out_len, "Internal panic in DDL rewrite") };
+            unsafe {
+                write_error_to_buffer(error_out, error_out_len, "Internal panic in DDL rewrite");
+            }
             1 // failure
         }
     }
@@ -2315,7 +2401,10 @@ fn strip_outer_quotes(s: &str) -> Option<&str> {
 /// own parser and execution on the caller's connection.
 ///
 /// Return values match the protocol used by sv_parse_stub:
-///   0 = success: native SQL written to `sql_out`
+///   0 = success: heap-owned native SQL pointer + length written to
+///       `*sql_out_ptr` / `*sql_out_len`. Caller takes ownership and must
+///       release via `sv_free_buffer`. The buffer is **not** NUL-terminated;
+///       read exactly `*sql_out_len` bytes.
 ///   1 = validation error: error written to `error_out`
 ///   2 = not ours / not yet handled: caller should defer to default parser
 ///       (which falls through to the legacy parse_function fallback path)
@@ -2323,7 +2412,8 @@ fn strip_outer_quotes(s: &str) -> Option<&str> {
 /// # Safety
 ///
 /// - `query_ptr` must point to valid UTF-8 bytes of length `query_len`.
-/// - `sql_out` must point to a writable buffer of `sql_out_len` bytes.
+/// - `sql_out_ptr` must point to a writable `*mut u8` slot, or be null.
+/// - `sql_out_len` must point to a writable `usize` slot, or be null.
 /// - `error_out` must point to a writable buffer of `error_out_len` bytes.
 #[cfg(feature = "extension")]
 #[no_mangle]
@@ -2331,8 +2421,8 @@ pub extern "C" fn sv_parser_override_rust(
     db_token: u64,
     query_ptr: *const u8,
     query_len: usize,
-    sql_out: *mut u8,
-    sql_out_len: usize,
+    sql_out_ptr: *mut *mut u8,
+    sql_out_len: *mut usize,
     error_out: *mut u8,
     error_out_len: usize,
 ) -> u8 {
@@ -2347,12 +2437,12 @@ pub extern "C" fn sv_parser_override_rust(
 
         match rewrite_to_native_sql(db_token, query) {
             Ok(Some(sql)) => {
-                unsafe { write_to_buffer(sql_out, sql_out_len, &sql) };
-                0 // success — native SQL written
+                unsafe { publish_owned_sql(sql, sql_out_ptr, sql_out_len) };
+                0 // success — native SQL handed to caller
             }
             Ok(None) => 2, // not ours, or a form we defer to the legacy path
             Err(err) => {
-                unsafe { write_to_buffer(error_out, error_out_len, &err.message) };
+                unsafe { write_error_to_buffer(error_out, error_out_len, &err.message) };
                 1 // validation error
             }
         }
@@ -2364,6 +2454,51 @@ pub extern "C" fn sv_parser_override_rust(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ===================================================================
+    // FFI heap-buffer round-trip — guards against the v0.8.0 silent-
+    // truncation regression. Pre-fix the SQL output went through a
+    // fixed 64 KB buffer; we now hand the C++ caller an owned heap
+    // pointer + length, released via sv_free_buffer.
+    // ===================================================================
+
+    #[test]
+    fn leak_and_reclaim_round_trips_arbitrary_string() {
+        let original = "INSERT INTO _definitions VALUES ('x', '...');".repeat(4096);
+        assert!(
+            original.len() > 64 * 1024,
+            "test input should exceed legacy cap"
+        );
+
+        let original_clone = original.clone();
+        let (ptr, len) = leak_string_to_c_buffer(original);
+        assert!(!ptr.is_null());
+        assert_eq!(len, original_clone.len());
+
+        // Read back exactly `len` bytes (no NUL terminator assumption).
+        let recovered = unsafe { std::slice::from_raw_parts(ptr.cast_const(), len) };
+        assert_eq!(recovered, original_clone.as_bytes());
+
+        // Free.
+        unsafe { reclaim_c_buffer(ptr, len) };
+    }
+
+    #[test]
+    fn reclaim_null_pointer_is_safe() {
+        // sv_free_buffer must accept null pointers as a no-op so the C++
+        // RAII guard can be unconditionally invoked even when the FFI
+        // call returned an error path.
+        unsafe { reclaim_c_buffer(std::ptr::null_mut(), 0) };
+        unsafe { reclaim_c_buffer(std::ptr::null_mut(), 99) };
+    }
+
+    #[test]
+    fn leak_handles_empty_string() {
+        let (ptr, len) = leak_string_to_c_buffer(String::new());
+        assert_eq!(len, 0);
+        // Empty Vec may have dangling-but-aligned ptr; reclaim must not crash.
+        unsafe { reclaim_c_buffer(ptr, len) };
+    }
 
     // ===================================================================
     // detect_semantic_view_ddl tests (multi-prefix detection)

--- a/src/query/explain.rs
+++ b/src/query/explain.rs
@@ -147,24 +147,26 @@ impl VTab for ExplainSemanticViewVTab {
             // 3. Look up view definition in the catalog.
             let state_ptr = bind.get_extra_info::<QueryState>();
             let state = unsafe { &*state_ptr };
-            let catalog_guard = state
+            let json_str = match state
                 .catalog
-                .read()
-                .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?;
-
-            let json_str = if let Some(j) = catalog_guard.get(&view_name) {
-                j.clone()
-            } else {
-                let available: Vec<String> = catalog_guard.keys().cloned().collect();
-                let suggestion = suggest_closest(&view_name, &available);
-                let err: Box<dyn std::error::Error> = Box::new(QueryError::ViewNotFound {
-                    name: view_name,
-                    suggestion,
-                    available,
-                });
-                return Err(err);
+                .lookup(&view_name)
+                .map_err(Box::<dyn std::error::Error>::from)?
+            {
+                Some(j) => j,
+                None => {
+                    let available = state
+                        .catalog
+                        .list_names()
+                        .map_err(Box::<dyn std::error::Error>::from)?;
+                    let suggestion = suggest_closest(&view_name, &available);
+                    let err: Box<dyn std::error::Error> = Box::new(QueryError::ViewNotFound {
+                        name: view_name,
+                        suggestion,
+                        available,
+                    });
+                    return Err(err);
+                }
             };
-            drop(catalog_guard);
 
             // 4. Parse definition, expand wildcards, and expand.
             let def = SemanticViewDefinition::from_json(&view_name, &json_str)

--- a/src/query/table_function.rs
+++ b/src/query/table_function.rs
@@ -9,7 +9,7 @@ use duckdb::{
 };
 use libduckdb_sys as ffi;
 
-use crate::catalog::CatalogState;
+use crate::catalog::CatalogReader;
 use crate::expand::wildcard::{expand_wildcards, WildcardItemType};
 use crate::expand::{expand, QueryRequest};
 use crate::model::SemanticViewDefinition;
@@ -23,15 +23,15 @@ use super::error::QueryError;
 
 /// Shared state for the `semantic_query` table function.
 ///
-/// Carries the catalog (in-memory view definitions) and a raw `duckdb_connection`
-/// handle for executing expanded SQL via the C API. The connection is created
-/// independently of the host connection by calling `duckdb_connect` on the same
-/// database handle, avoiding lock conflicts with the host during query execution.
-///
-/// For the connection handle extraction strategy, see `extract_query_conn` in lib.rs.
+/// Carries a catalog reader (queries `semantic_layer._definitions` via a
+/// dedicated catalog connection) and a raw `duckdb_connection` handle for
+/// executing expanded SQL via the C API. Both connections are created
+/// independently of the host connection by calling `duckdb_connect` on the
+/// same database handle, avoiding lock conflicts with the host during query
+/// execution.
 #[derive(Clone)]
 pub struct QueryState {
-    pub catalog: CatalogState,
+    pub catalog: CatalogReader,
     /// Raw connection handle for SQL execution.
     pub conn: ffi::duckdb_connection,
 }
@@ -507,15 +507,17 @@ impl VTab for SemanticViewVTab {
             // 4. Look up view definition in the catalog.
             let state_ptr = bind.get_extra_info::<QueryState>();
             let state = unsafe { &*state_ptr };
-            let catalog_guard = state
+            let json_str = match state
                 .catalog
-                .read()
-                .map_err(|_| Box::<dyn std::error::Error>::from("catalog lock poisoned"))?;
-
-            let json_str = match catalog_guard.get(&view_name) {
-                Some(j) => j.clone(),
+                .lookup(&view_name)
+                .map_err(Box::<dyn std::error::Error>::from)?
+            {
+                Some(j) => j,
                 None => {
-                    let available: Vec<String> = catalog_guard.keys().cloned().collect();
+                    let available = state
+                        .catalog
+                        .list_names()
+                        .map_err(Box::<dyn std::error::Error>::from)?;
                     let suggestion = suggest_closest(&view_name, &available);
                     let err: Box<dyn std::error::Error> = Box::new(QueryError::ViewNotFound {
                         name: view_name,
@@ -525,8 +527,6 @@ impl VTab for SemanticViewVTab {
                     return Err(err);
                 }
             };
-            // Release the catalog lock before proceeding.
-            drop(catalog_guard);
 
             // 5. Parse definition, expand wildcards, and expand.
             let def = SemanticViewDefinition::from_json(&view_name, &json_str)

--- a/test/integration/test_adbc_transactions.py
+++ b/test/integration/test_adbc_transactions.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "duckdb==1.5.2",
+#   "adbc-driver-manager>=1.10",
+#   "pyarrow>=16",
+# ]
+# requires-python = ">=3.10"
+# ///
+"""
+ADBC end-to-end transactional DDL test for the semantic_views extension.
+
+Verifies that CREATE / DROP / ALTER SEMANTIC VIEW participate in the caller's
+transaction when the connection is driven via ADBC's DBAPI 2.0 facade. ADBC's
+DBAPI defaults to ``autocommit=False`` — every statement runs inside an
+implicit transaction that is finalised by an explicit ``commit()`` or
+``rollback()``. This was the original motivating bug for v0.8.0: pre-v0.8.0
+the extension persisted DDL on its own auto-commit ``persist_conn`` /
+``ddl_conn``, so an ADBC client that issued a DDL statement followed by
+``rollback()`` would still find the view in the catalog after rollback.
+
+After v0.8.0 the parser_override hook rewrites DDL into native SQL that runs
+on the caller's connection, so commit/rollback honour the transaction
+boundary.
+
+This test exercises:
+    1. CREATE inline AS-body, then rollback() — view absent
+    2. CREATE inline AS-body, then commit() — view present
+    3. CREATE FROM YAML FILE, then rollback() — view absent
+    4. CREATE FROM YAML FILE, then commit() — view present
+    5. ALTER RENAME, then rollback() — original name still present
+    6. DROP, then rollback() — view still present
+
+Usage:
+    just test-adbc
+
+Exit codes:
+    0 = all assertions passed
+    1 = test failure
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_ducklake_helpers import get_ext_dir, get_extension_path
+
+import adbc_driver_duckdb
+import adbc_driver_manager
+import adbc_driver_manager.dbapi
+
+
+def _connect_adbc(db_path: str, extension_dir: str):
+    """
+    Open an ADBC DBAPI connection to a DuckDB file with ``allow_unsigned_extensions``
+    and a project-local extension directory pre-set on the underlying DBConfig.
+
+    The high-level ``adbc_driver_duckdb.dbapi.connect`` does not expose DBConfig
+    options, so we drop down to ``adbc_driver_manager.AdbcDatabase`` directly and
+    pass arbitrary keyword arguments — DuckDB's ADBC driver routes any key it
+    does not recognise specifically through ``duckdb_set_config``.
+
+    ``autocommit=False`` is the ADBC DBAPI default; we set it explicitly here so
+    the intent is visible in the test.
+    """
+    db = adbc_driver_manager.AdbcDatabase(
+        driver=adbc_driver_duckdb.driver_path(),
+        entrypoint="duckdb_adbc_init",
+        path=db_path,
+        allow_unsigned_extensions="true",
+        extension_directory=extension_dir,
+    )
+    conn = adbc_driver_manager.AdbcConnection(db)
+    return adbc_driver_manager.dbapi.Connection(db, conn, autocommit=False)
+
+
+def _execute(conn, sql: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(sql)
+
+
+def _scalar(conn, sql: str):
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        row = cur.fetchone()
+    return None if row is None else row[0]
+
+
+def run_tests() -> int:
+    extension_path = get_extension_path()
+    if not extension_path.exists():
+        print(f"ERROR: extension not found at {extension_path}")
+        print("Run `just build` first.")
+        return 1
+
+    ext_dir = get_ext_dir()
+    passed = 0
+    failed = 0
+
+    with tempfile.TemporaryDirectory(prefix="sv_adbc_") as tmp:
+        tmp_path = Path(tmp)
+        db_path = str(tmp_path / "adbc.duckdb")
+        yaml_path = tmp_path / "view.yaml"
+        yaml_path.write_text(
+            "tables:\n"
+            "  - alias: o\n"
+            "    table: adbc_orders\n"
+            "    pk_columns:\n"
+            "      - id\n"
+            "dimensions:\n"
+            "  - name: region\n"
+            "    expr: o.region\n"
+            "    source_table: o\n"
+            "metrics:\n"
+            "  - name: total\n"
+            "    expr: SUM(o.amount)\n"
+            "    source_table: o\n"
+        )
+
+        conn = _connect_adbc(db_path, ext_dir)
+        try:
+            # Load the extension via SQL. The connection is in a transaction
+            # the moment we issue any statement; commit so subsequent DDL/DML
+            # tests start from a clean transactional slate.
+            _execute(conn, f"INSTALL '{extension_path}'")
+            _execute(conn, "LOAD semantic_views")
+            _execute(
+                conn,
+                "CREATE TABLE adbc_orders (id INTEGER PRIMARY KEY, "
+                "amount DECIMAL(10,2), region VARCHAR)",
+            )
+            _execute(
+                conn,
+                "INSERT INTO adbc_orders VALUES (1, 100.00, 'US'), (2, 200.00, 'EU')",
+            )
+            conn.commit()
+
+            create_inline = """
+                CREATE SEMANTIC VIEW adbc_inline AS
+                  TABLES (o AS adbc_orders PRIMARY KEY (id))
+                  DIMENSIONS (o.region AS o.region)
+                  METRICS (o.total AS SUM(o.amount))
+            """
+
+            # ---- Test 1: CREATE inline + rollback ----
+            print("Test 1: CREATE (inline) + rollback() — view must not persist")
+            try:
+                _execute(conn, create_inline)
+                conn.rollback()
+                count = _scalar(
+                    conn,
+                    "SELECT count(*) FROM list_semantic_views() WHERE name = 'adbc_inline'",
+                )
+                assert count == 0, f"expected 0 views after rollback, got {count}"
+                conn.commit()
+                print("  PASS")
+                passed += 1
+            except Exception as e:
+                print(f"  FAIL: {e}")
+                conn.rollback()
+                failed += 1
+
+            # ---- Test 2: CREATE inline + commit ----
+            print("Test 2: CREATE (inline) + commit() — view must persist")
+            try:
+                _execute(conn, create_inline)
+                conn.commit()
+                count = _scalar(
+                    conn,
+                    "SELECT count(*) FROM list_semantic_views() WHERE name = 'adbc_inline'",
+                )
+                assert count == 1, f"expected 1 view after commit, got {count}"
+                conn.commit()
+                print("  PASS")
+                passed += 1
+            except Exception as e:
+                print(f"  FAIL: {e}")
+                conn.rollback()
+                failed += 1
+
+            create_yaml = (
+                f"CREATE SEMANTIC VIEW adbc_yaml FROM YAML FILE '{yaml_path}'"
+            )
+
+            # ---- Test 3: CREATE FROM YAML FILE + rollback ----
+            print("Test 3: CREATE FROM YAML FILE + rollback() — view must not persist")
+            try:
+                _execute(conn, create_yaml)
+                conn.rollback()
+                count = _scalar(
+                    conn,
+                    "SELECT count(*) FROM list_semantic_views() WHERE name = 'adbc_yaml'",
+                )
+                assert count == 0, f"expected 0 views after rollback, got {count}"
+                conn.commit()
+                print("  PASS")
+                passed += 1
+            except Exception as e:
+                print(f"  FAIL: {e}")
+                conn.rollback()
+                failed += 1
+
+            # ---- Test 4: CREATE FROM YAML FILE + commit ----
+            print("Test 4: CREATE FROM YAML FILE + commit() — view must persist")
+            try:
+                _execute(conn, create_yaml)
+                conn.commit()
+                count = _scalar(
+                    conn,
+                    "SELECT count(*) FROM list_semantic_views() WHERE name = 'adbc_yaml'",
+                )
+                assert count == 1, f"expected 1 view after commit, got {count}"
+                conn.commit()
+                print("  PASS")
+                passed += 1
+            except Exception as e:
+                print(f"  FAIL: {e}")
+                conn.rollback()
+                failed += 1
+
+            # ---- Test 5: ALTER RENAME + rollback ----
+            print("Test 5: ALTER RENAME + rollback() — original name must remain")
+            try:
+                _execute(
+                    conn, "ALTER SEMANTIC VIEW adbc_inline RENAME TO adbc_renamed"
+                )
+                conn.rollback()
+                src = _scalar(
+                    conn,
+                    "SELECT count(*) FROM list_semantic_views() WHERE name = 'adbc_inline'",
+                )
+                dst = _scalar(
+                    conn,
+                    "SELECT count(*) FROM list_semantic_views() WHERE name = 'adbc_renamed'",
+                )
+                assert src == 1 and dst == 0, (
+                    f"expected src=1, dst=0 after rollback; got src={src}, dst={dst}"
+                )
+                conn.commit()
+                print("  PASS")
+                passed += 1
+            except Exception as e:
+                print(f"  FAIL: {e}")
+                conn.rollback()
+                failed += 1
+
+            # ---- Test 6: DROP + rollback ----
+            print("Test 6: DROP + rollback() — view must remain")
+            try:
+                _execute(conn, "DROP SEMANTIC VIEW adbc_inline")
+                conn.rollback()
+                count = _scalar(
+                    conn,
+                    "SELECT count(*) FROM list_semantic_views() WHERE name = 'adbc_inline'",
+                )
+                assert count == 1, f"expected 1 view after rollback, got {count}"
+                conn.commit()
+                print("  PASS")
+                passed += 1
+            except Exception as e:
+                print(f"  FAIL: {e}")
+                conn.rollback()
+                failed += 1
+        finally:
+            conn.close()
+
+    print()
+    print(f"Results: {passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+def main() -> None:
+    sys.exit(run_tests())
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_adbc_transactions.py
+++ b/test/integration/test_adbc_transactions.py
@@ -7,6 +7,10 @@
 # ]
 # requires-python = ">=3.10"
 # ///
+# Note: `import adbc_driver_duckdb` resolves to the module bundled inside
+# the `duckdb` wheel (see duckdb-1.5.x dist-info/RECORD). There is no
+# separate `adbc-driver-duckdb` package on PyPI, so it does not appear in
+# the dependencies list above.
 """
 ADBC end-to-end transactional DDL test for the semantic_views extension.
 
@@ -125,7 +129,7 @@ def run_tests() -> int:
             # Load the extension via SQL. The connection is in a transaction
             # the moment we issue any statement; commit so subsequent DDL/DML
             # tests start from a clean transactional slate.
-            _execute(conn, f"INSTALL '{extension_path}'")
+            _execute(conn, f"FORCE INSTALL '{extension_path}'")
             _execute(conn, "LOAD semantic_views")
             _execute(
                 conn,

--- a/test/integration/test_large_view_rewrite.py
+++ b/test/integration/test_large_view_rewrite.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = ["duckdb==1.5.2"]
+# requires-python = ">=3.10"
+# ///
+"""
+Regression test for the v0.8.0 silent-truncation bug in the parser_override
+buffer path.
+
+Pre-fix the C++ shim allocated a fixed 64 KB std::string for the rewritten
+SQL emitted by sv_parser_override_rust, and the Rust-side `write_to_buffer`
+helper silently truncated anything over the cap. For semantic views with
+many metrics / dimensions, the rewritten
+``INSERT INTO semantic_layer._definitions VALUES ('<name>', '<json>')``
+exceeded 64 KB, the C++ side reparsed a truncated SQL string, and DuckDB
+surfaced a confusing ``Parser Error: syntax error at or near …`` instead
+of either succeeding or producing a real diagnostic.
+
+Post-fix the FFI hands the C++ caller a heap-owned byte buffer (no cap),
+released via ``sv_free_buffer`` through an RAII guard.
+
+This test creates a view with enough metrics to push the rewritten INSERT
+well past 64 KB, runs it inside a transaction (exercising the
+parser_override path that the fix targets), and verifies it commits
+cleanly and produces the expected metric count.
+
+Usage:
+    uv run test/integration/test_large_view_rewrite.py
+
+Exit codes:
+    0 = passed
+    1 = failed
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_ducklake_helpers import get_ext_dir, get_extension_path
+
+
+def build_large_view_sql(view_name: str, num_metrics: int) -> str:
+    """Compose a CREATE SEMANTIC VIEW with enough metrics + long comments
+    that the enriched JSON definition exceeds 64 KB once rewritten as
+    ``INSERT INTO _definitions VALUES ('<name>', '<json>')``.
+
+    Each metric carries a ~600-byte comment; 200 metrics × 600 bytes is
+    ~120 KB of comment text alone, comfortably past the legacy cap.
+    """
+    long_comment = "x" * 600
+    metrics = ",\n            ".join(
+        f"o.metric_{i:04d} AS SUM(o.amount) COMMENT = '{long_comment}'"
+        for i in range(num_metrics)
+    )
+    return f"""
+        CREATE SEMANTIC VIEW {view_name} AS
+          TABLES (o AS large_orders PRIMARY KEY (id))
+          DIMENSIONS (o.region AS o.region)
+          METRICS (
+            {metrics}
+          )
+    """
+
+
+def run_test() -> int:
+    import duckdb
+
+    ext_dir = get_ext_dir()
+    ext_path = get_extension_path()
+    if not ext_path.exists():
+        print(f"ERROR: extension not found at {ext_path}")
+        print("Run `just build` first.")
+        return 1
+
+    conn = duckdb.connect(
+        config={
+            "allow_unsigned_extensions": "true",
+            "extension_directory": ext_dir,
+        }
+    )
+    conn.execute(f"FORCE INSTALL '{ext_path}'")
+    conn.execute("LOAD semantic_views")
+
+    conn.execute(
+        "CREATE TABLE large_orders ("
+        "id INTEGER PRIMARY KEY, region VARCHAR, amount DECIMAL(10,2))"
+    )
+    conn.execute("INSERT INTO large_orders VALUES (1, 'US', 100.00)")
+
+    num_metrics = 200
+    create_sql = build_large_view_sql("large_view", num_metrics)
+    # The rewritten SQL is roughly: outer INSERT (~80 bytes of fixed text)
+    # + the enriched-JSON definition. The enriched JSON serialises every
+    # metric (name + expr + comment + access_modifier + ...). The original
+    # CREATE statement itself is already >120 KB once we factor in
+    # comments × num_metrics — confirm this is well past the legacy cap.
+    print(f"CREATE statement length: {len(create_sql)} bytes")
+    assert len(create_sql) > 64 * 1024, (
+        f"Test input ({len(create_sql)} bytes) does not exceed the legacy "
+        "64 KB cap; bump num_metrics or comment length."
+    )
+
+    # Exercise the transactional parser_override path (the fix's primary site).
+    print("Running BEGIN; CREATE SEMANTIC VIEW (large) ; COMMIT …")
+    try:
+        conn.execute("BEGIN")
+        conn.execute(create_sql)
+        conn.execute("COMMIT")
+    except Exception as e:
+        print(f"  FAIL: CREATE raised {type(e).__name__}: {e}")
+        return 1
+
+    # Verify the view was actually persisted and that all metrics survived
+    # the round-trip (silent truncation would have either failed parse or
+    # produced a damaged metrics list).
+    (count,) = conn.execute(
+        "SELECT count(*) FROM list_semantic_views() WHERE name = 'large_view'"
+    ).fetchone()
+    if count != 1:
+        print(f"  FAIL: list_semantic_views() returned {count}, expected 1")
+        return 1
+
+    (metric_count,) = conn.execute(
+        "SELECT count(*) FROM show_semantic_metrics('large_view')"
+    ).fetchone()
+    if metric_count != num_metrics:
+        print(f"  FAIL: show_semantic_metrics() returned {metric_count}, "
+              f"expected {num_metrics}")
+        return 1
+
+    # And confirm a query round-trip works on a representative metric.
+    sample = conn.execute(
+        "SELECT * FROM semantic_view('large_view', "
+        "dimensions := ['region'], metrics := ['metric_0000', 'metric_0199'])"
+    ).fetchall()
+    if not sample:
+        print("  FAIL: semantic_view query returned no rows")
+        return 1
+
+    # Cleanup so reruns are idempotent against a freshly-attached file.
+    conn.execute("DROP SEMANTIC VIEW large_view")
+
+    print(
+        f"  PASS: created view with {num_metrics} metrics "
+        f"({len(create_sql)}-byte CREATE), commit/round-trip succeeded"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_test())

--- a/test/integration/test_multi_db_isolation.py
+++ b/test/integration/test_multi_db_isolation.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = ["duckdb==1.5.2"]
+# requires-python = ">=3.10"
+# ///
+"""
+Multi-database isolation regression test for the semantic_views extension.
+
+Loading the extension into more than one database in the same process must
+keep each database's DDL routing isolated. Pre-fix the C++ shim held a
+single file-static `sv_ddl_conn`; the second LOAD overwrote it, so any
+DESCRIBE / SHOW SEMANTIC * statement on the first database silently
+executed against the second database's connection.
+
+After the fix, the per-load `ddl_conn` lives on `SemanticViewsParserInfo`
+and is threaded through `TableFunction::function_info` to `sv_ddl_bind`,
+so every DDL routes to the correct database.
+
+Test scenario:
+  1. Create two file-backed databases with distinct semantic views.
+  2. Run DESCRIBE / list_semantic_views on each connection.
+  3. Assert each connection sees its own view and only its own view.
+
+Without the fix, DESCRIBE on the first connection would either return the
+second DB's view metadata or raise a confusing error.
+
+Exit codes:
+    0 = all tests passed
+    1 = at least one test failed
+"""
+
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_ducklake_helpers import get_ext_dir, get_extension_path
+
+
+EXT_DIR = get_ext_dir()
+EXT_PATH = get_extension_path()
+
+
+def make_connection(db_path: str):
+    import duckdb
+
+    conn = duckdb.connect(
+        db_path,
+        config={
+            "allow_unsigned_extensions": "true",
+            "extension_directory": EXT_DIR,
+        },
+    )
+    conn.execute(f"FORCE INSTALL '{EXT_PATH}'")
+    conn.execute("LOAD semantic_views")
+    return conn
+
+
+def setup_db(conn, view_name: str, region_value: str):
+    conn.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, "
+        "amount DECIMAL(10,2), region VARCHAR)"
+    )
+    conn.execute(f"INSERT INTO orders VALUES (1, 100.00, '{region_value}')")
+    conn.execute(
+        f"""
+        CREATE SEMANTIC VIEW {view_name} AS
+          TABLES (o AS orders PRIMARY KEY (id))
+          DIMENSIONS (o.region AS o.region)
+          METRICS (o.total AS SUM(o.amount))
+        """
+    )
+
+
+def run_test(name, test_fn):
+    print(f"\n{'=' * 60}")
+    print(f"TEST: {name}")
+    print(f"{'=' * 60}")
+    try:
+        test_fn()
+        print("  RESULT: PASS")
+        return True
+    except AssertionError as e:
+        print(f"  RESULT: FAIL\n  {e}")
+        return False
+    except Exception as e:
+        print(f"  RESULT: ERROR\n  {type(e).__name__}: {e}")
+        traceback.print_exc()
+        return False
+
+
+def test_multi_db_isolation():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db1_path = str(Path(tmpdir) / "db1.duckdb")
+        db2_path = str(Path(tmpdir) / "db2.duckdb")
+
+        con1 = make_connection(db1_path)
+        con2 = make_connection(db2_path)
+        try:
+            setup_db(con1, "view_db1", "US")
+            setup_db(con2, "view_db2", "EU")
+
+            # list_semantic_views on each connection should only see its own view.
+            db1_views = {row[0] for row in con1.execute(
+                "SELECT name FROM list_semantic_views()"
+            ).fetchall()}
+            db2_views = {row[0] for row in con2.execute(
+                "SELECT name FROM list_semantic_views()"
+            ).fetchall()}
+            assert db1_views == {"view_db1"}, (
+                f"db1 should see only view_db1, got: {db1_views}"
+            )
+            assert db2_views == {"view_db2"}, (
+                f"db2 should see only view_db2, got: {db2_views}"
+            )
+
+            # DESCRIBE goes through the legacy parse_function/sv_ddl_bind
+            # path — this is the path that was broken pre-fix.
+            db1_desc = con1.execute("DESCRIBE SEMANTIC VIEW view_db1").fetchall()
+            assert len(db1_desc) > 0, "db1 DESCRIBE returned no rows"
+
+            db2_desc = con2.execute("DESCRIBE SEMANTIC VIEW view_db2").fetchall()
+            assert len(db2_desc) > 0, "db2 DESCRIBE returned no rows"
+
+            # Cross-DB DESCRIBE must error: each view is local to its own DB.
+            try:
+                con1.execute("DESCRIBE SEMANTIC VIEW view_db2").fetchall()
+                raise AssertionError(
+                    "con1 should not see view_db2 (cross-DB leak)"
+                )
+            except AssertionError:
+                raise
+            except Exception:
+                pass  # expected — view_db2 doesn't exist in db1
+
+            try:
+                con2.execute("DESCRIBE SEMANTIC VIEW view_db1").fetchall()
+                raise AssertionError(
+                    "con2 should not see view_db1 (cross-DB leak)"
+                )
+            except AssertionError:
+                raise
+            except Exception:
+                pass
+
+            # Issuing SHOW SEMANTIC VIEWS alternately on both connections
+            # exercises the per-call function_info routing through the
+            # legacy parse_function/sv_ddl_bind path. Column 1 of the
+            # SHOW result is `name` (column 0 is `created_on`).
+            for _ in range(3):
+                db1_now = {row[1] for row in con1.execute(
+                    "SHOW SEMANTIC VIEWS"
+                ).fetchall()}
+                db2_now = {row[1] for row in con2.execute(
+                    "SHOW SEMANTIC VIEWS"
+                ).fetchall()}
+                assert db1_now == {"view_db1"}, (
+                    f"db1 SHOW should see only view_db1, got: {db1_now}"
+                )
+                assert db2_now == {"view_db2"}, (
+                    f"db2 SHOW should see only view_db2, got: {db2_now}"
+                )
+        finally:
+            con1.close()
+            con2.close()
+
+
+def main():
+    print(f"Extension path: {EXT_PATH}")
+    print(f"Extension dir:  {EXT_DIR}")
+
+    if not Path(EXT_PATH).exists():
+        print(f"ERROR: Extension not found at {EXT_PATH}", file=sys.stderr)
+        print("Run `just build` first.", file=sys.stderr)
+        sys.exit(1)
+
+    results = [
+        run_test("multi-DB DDL isolation", test_multi_db_isolation),
+    ]
+
+    print(f"\n{'=' * 60}")
+    print(f"SUMMARY: {sum(results)}/{len(results)} passed")
+    print(f"{'=' * 60}")
+    sys.exit(0 if all(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/sql/TEST_LIST
+++ b/test/sql/TEST_LIST
@@ -35,3 +35,4 @@ test/sql/phase55_materialization_routing.test
 test/sql/phase56_yaml_export.test
 test/sql/phase57_introspection.test
 test/sql/quick_260430_vdz_leading_comments.test
+test/sql/v080_transactional_ddl.test

--- a/test/sql/peg_compat.test
+++ b/test/sql/peg_compat.test
@@ -6,16 +6,19 @@
 #
 # 1. parser_override (v0.8.0+): registered on ParserExtension and called
 #    BEFORE parsing. Parser-agnostic — works under both Bison and PEG. Used
-#    for CREATE / DROP / ALTER SEMANTIC VIEW. The callback returns native
-#    INSERT/DELETE/UPDATE SQL which whichever parser is active happily parses.
+#    for CREATE / DROP / ALTER SEMANTIC VIEW (all four CREATE forms: inline
+#    SQL keyword body, inline FROM YAML, FROM YAML FILE, and OR REPLACE /
+#    IF NOT EXISTS variants). The callback returns native INSERT/DELETE/UPDATE
+#    SQL which whichever parser is active happily parses.
 #
 # 2. parse_function fallback (Bison-era): the legacy parser_extensions hook,
-#    only consulted by Bison. Used for DESCRIBE / SHOW SEMANTIC * forms and
-#    for CREATE ... FROM YAML FILE. These forms therefore fail under PEG.
+#    only consulted by Bison. Used for DESCRIBE / SHOW SEMANTIC * forms.
+#    These forms therefore fail under PEG.
 #
 # This test documents the expected behavior:
 #   1. All DDL works under the default Bison parser
-#   2. Under PEG: CREATE / DROP / ALTER work (parser_override); DESCRIBE / SHOW fail
+#   2. Under PEG: CREATE (incl. FROM YAML FILE) / DROP / ALTER work
+#      (parser_override); DESCRIBE / SHOW fail
 #   3. Querying existing views works under PEG (semantic_view() is a table function)
 #   4. All DDL works again after disabling PEG parser
 #
@@ -68,6 +71,32 @@ METRICS (t2.total_val AS SUM(t2.val))
 # DROP also goes through parser_override.
 statement ok
 DROP SEMANTIC VIEW peg_under_peg
+
+# CREATE ... FROM YAML FILE also goes through parser_override (v0.8.0+):
+# the __SV_YAML_FILE__ sentinel is intercepted in parser_override, the file
+# is read on the catalog connection, and the resulting INSERT is routed
+# through the same native-SQL re-parse path as inline CREATE.
+statement ok
+COPY (SELECT 'tables:
+  - alias: t4
+    table: peg_test_data
+    pk_columns:
+      - id
+dimensions:
+  - name: dim_id
+    expr: t4.id
+    source_table: t4
+metrics:
+  - name: total_val
+    expr: SUM(t4.val)
+    source_table: t4' AS content)
+TO '__TEST_DIR__/peg_yaml_file.yaml' (FORMAT CSV, HEADER FALSE, QUOTE '');
+
+statement ok
+CREATE SEMANTIC VIEW peg_yaml_file FROM YAML FILE '__TEST_DIR__/peg_yaml_file.yaml'
+
+statement ok
+DROP SEMANTIC VIEW peg_yaml_file
 
 # DESCRIBE defers to the Bison-only parse_function fallback — fails under PEG.
 statement error

--- a/test/sql/peg_compat.test
+++ b/test/sql/peg_compat.test
@@ -1,17 +1,23 @@
 # PEG parser compatibility smoke test for DuckDB 1.5.0+.
 #
 # DuckDB 1.5.0 introduced an opt-in PEG parser (CALL enable_peg_parser()).
-# The semantic_views extension uses Bison-era parser_extensions hooks for DDL
-# interception (CREATE/ALTER/DROP/DESCRIBE/SHOW SEMANTIC VIEW). The PEG parser
-# does NOT consult parser_extensions, so DDL fails under PEG. However, querying
-# existing semantic views via semantic_view() table function works fine under
-# PEG because table functions are standard SQL.
+#
+# The extension uses two interception mechanisms with different PEG behaviour:
+#
+# 1. parser_override (v0.8.0+): registered on ParserExtension and called
+#    BEFORE parsing. Parser-agnostic — works under both Bison and PEG. Used
+#    for CREATE / DROP / ALTER SEMANTIC VIEW. The callback returns native
+#    INSERT/DELETE/UPDATE SQL which whichever parser is active happily parses.
+#
+# 2. parse_function fallback (Bison-era): the legacy parser_extensions hook,
+#    only consulted by Bison. Used for DESCRIBE / SHOW SEMANTIC * forms and
+#    for CREATE ... FROM YAML FILE. These forms therefore fail under PEG.
 #
 # This test documents the expected behavior:
-#   1. DDL works under the default Bison parser
-#   2. DDL fails under PEG parser with "Parser Error"
-#   3. Querying existing views works under PEG parser
-#   4. DDL works again after disabling PEG parser
+#   1. All DDL works under the default Bison parser
+#   2. Under PEG: CREATE / DROP / ALTER work (parser_override); DESCRIBE / SHOW fail
+#   3. Querying existing views works under PEG (semantic_view() is a table function)
+#   4. All DDL works again after disabling PEG parser
 #
 # Requirements covered:
 #   DKDB-05: PEG parser compatibility documented
@@ -45,22 +51,31 @@ SELECT * FROM semantic_view('peg_bison_test', dimensions := ['dim_id'], metrics 
 2	20.0
 
 # ============================================================
-# 3. Enable PEG parser: DDL fails, queries work
+# 3. Enable PEG parser: CREATE / DROP / ALTER work via parser_override;
+#    DESCRIBE / SHOW (parser_extensions fallback) fail.
 # ============================================================
 
 statement ok
 CALL enable_peg_parser();
 
-# DDL fails: PEG parser does not consult parser_extensions fallback hooks
-statement error
-CREATE SEMANTIC VIEW peg_fail_test AS
+# CREATE goes through parser_override (parser-agnostic) — works under PEG.
+statement ok
+CREATE SEMANTIC VIEW peg_under_peg AS
 TABLES (t2 AS peg_test_data PRIMARY KEY (id))
 DIMENSIONS (t2.dim_id AS t2.id)
 METRICS (t2.total_val AS SUM(t2.val))
+
+# DROP also goes through parser_override.
+statement ok
+DROP SEMANTIC VIEW peg_under_peg
+
+# DESCRIBE defers to the Bison-only parse_function fallback — fails under PEG.
+statement error
+DESCRIBE SEMANTIC VIEW peg_bison_test
 ----
 Parser Error
 
-# Querying existing views works: semantic_view() is a standard table function
+# Querying existing views works: semantic_view() is a standard table function.
 query IR
 SELECT * FROM semantic_view('peg_bison_test', dimensions := ['dim_id'], metrics := ['total_val']) ORDER BY dim_id;
 ----
@@ -85,6 +100,10 @@ SELECT * FROM semantic_view('peg_restored_test', dimensions := ['dim_id'], metri
 ----
 1	10.0
 2	20.0
+
+# DESCRIBE works again with Bison.
+statement ok
+DESCRIBE SEMANTIC VIEW peg_bison_test
 
 # ============================================================
 # 5. Cleanup

--- a/test/sql/peg_yaml_file.yaml
+++ b/test/sql/peg_yaml_file.yaml
@@ -1,0 +1,13 @@
+tables:
+  - alias: t4
+    table: peg_test_data
+    pk_columns:
+      - id
+dimensions:
+  - name: dim_id
+    expr: t4.id
+    source_table: t4
+metrics:
+  - name: total_val
+    expr: SUM(t4.val)
+    source_table: t4

--- a/test/sql/v080_transactional_ddl.test
+++ b/test/sql/v080_transactional_ddl.test
@@ -448,6 +448,61 @@ statement ok
 CREATE SEMANTIC VIEW IF NOT EXISTS v080_yaml_commit FROM YAML FILE '__TEST_DIR__/v080_yaml_file.yaml'
 
 # ------------------------------------------------------------------
+# Same-transaction duplicate CREATE produces the friendly "already exists"
+# error, not a raw PK constraint violation. The parse-time existence check
+# only sees committed rows; an in-flight CREATE within the same transaction
+# slips past it, so emit_native_create_sql guards the INSERT with a
+# CASE+error() that runs on the caller's connection (and therefore sees
+# the in-flight row).
+# ------------------------------------------------------------------
+
+statement ok
+BEGIN
+
+statement ok
+CREATE SEMANTIC VIEW v080_dup_check AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+statement error
+CREATE SEMANTIC VIEW v080_dup_check AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+----
+already exists
+
+statement ok
+ROLLBACK
+
+# IF NOT EXISTS in the same transaction is a silent no-op even when the
+# in-flight CREATE preceded it.
+statement ok
+BEGIN
+
+statement ok
+CREATE SEMANTIC VIEW v080_dup_ine AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+statement ok
+CREATE SEMANTIC VIEW IF NOT EXISTS v080_dup_ine AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+# Only one row, not two.
+query I
+SELECT count(*) FROM semantic_layer._definitions WHERE name = 'v080_dup_ine'
+----
+1
+
+statement ok
+ROLLBACK
+
+# ------------------------------------------------------------------
 # Cleanup
 # ------------------------------------------------------------------
 

--- a/test/sql/v080_transactional_ddl.test
+++ b/test/sql/v080_transactional_ddl.test
@@ -1,18 +1,13 @@
-# v0.8.0: transactional DROP / ALTER SEMANTIC VIEW
+# v0.8.0: transactional CREATE / DROP / ALTER SEMANTIC VIEW
 #
-# Verifies that DROP and ALTER writes participate in the caller's transaction.
-# The parser_override hook rewrites recognised DDL into native DELETE / UPDATE
-# against semantic_layer._definitions, which DuckDB then executes on the
-# caller's connection — so BEGIN / COMMIT / ROLLBACK behave as expected.
+# Verifies that all three write forms participate in the caller's transaction.
+# The parser_override hook rewrites recognised DDL into native
+# INSERT / DELETE / UPDATE against semantic_layer._definitions, which DuckDB
+# then executes on the caller's connection — so BEGIN / COMMIT / ROLLBACK
+# behave as expected.
 #
 # Pre-v0.8.0 these writes ran on a dedicated persist_conn (auto-commit), so
 # rollback left them behind; this test would have failed.
-#
-# CREATE is intentionally NOT covered here — it remains on the legacy
-# DefineFromJsonVTab path because its bind() performs metadata enrichment
-# (database_name / schema_name / created_on / type inference / graph
-# validation) that has not been moved out of bind() yet. Transactional CREATE
-# is a documented v0.8.0 limitation; revisit when the enrichment refactor lands.
 
 require semantic_views
 
@@ -218,6 +213,166 @@ statement ok
 ALTER SEMANTIC VIEW IF EXISTS v080_does_not_exist UNSET COMMENT
 
 # ------------------------------------------------------------------
+# CREATE inside a rolled-back transaction must NOT leave the view behind.
+# ------------------------------------------------------------------
+
+statement ok
+BEGIN
+
+statement ok
+CREATE SEMANTIC VIEW v080_create_rb AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+# Visible to the same connection inside the transaction (DuckDB MVCC sees
+# the uncommitted INSERT on the same connection).
+query I
+SELECT count(*) FROM semantic_layer._definitions WHERE name = 'v080_create_rb'
+----
+1
+
+statement ok
+ROLLBACK
+
+# After rollback the row is gone — pre-v0.8.0 the persist_conn auto-commit
+# would have left it behind.
+query I
+SELECT count(*) FROM semantic_layer._definitions WHERE name = 'v080_create_rb'
+----
+0
+
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_create_rb'
+----
+0
+
+# ------------------------------------------------------------------
+# CREATE + COMMIT persists.
+# ------------------------------------------------------------------
+
+statement ok
+BEGIN
+
+statement ok
+CREATE SEMANTIC VIEW v080_create_commit AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS COUNT(*))
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_create_commit'
+----
+1
+
+# Metadata enrichment ran (database_name / schema_name / created_on populated)
+# even though the INSERT was emitted via parser_override.
+query III
+SELECT
+  database_name IS NOT NULL,
+  schema_name IS NOT NULL,
+  created_on IS NOT NULL
+FROM list_semantic_views() WHERE name = 'v080_create_commit'
+----
+true	true	true
+
+# Type inference is gated to file-backed DBs (v0.7.1 design); this
+# sqllogictest runs in-memory so data_type stays empty. The metadata
+# IS NOT NULL checks above already prove the shared enrichment ran.
+
+# ------------------------------------------------------------------
+# Plain CREATE on existing view errors at parse_override time.
+# ------------------------------------------------------------------
+
+statement error
+CREATE SEMANTIC VIEW v080_create_commit AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+----
+already exists
+
+# ------------------------------------------------------------------
+# CREATE OR REPLACE upserts (transactionally).
+# ------------------------------------------------------------------
+
+statement ok
+CREATE OR REPLACE SEMANTIC VIEW v080_create_commit AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total_replaced AS COUNT(*))
+
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_create_commit'
+----
+1
+
+# Replaced metric is visible.
+query I
+SELECT count(*) FROM show_semantic_metrics('v080_create_commit')
+WHERE name = 'total_replaced'
+----
+1
+
+# CREATE OR REPLACE inside a rolled-back txn restores the prior version.
+statement ok
+BEGIN
+
+statement ok
+CREATE OR REPLACE SEMANTIC VIEW v080_create_commit AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.rolled_back_metric AS MAX(o.amount))
+
+statement ok
+ROLLBACK
+
+# Pre-rollback metric still present; rolled-back metric absent.
+query I
+SELECT count(*) FROM show_semantic_metrics('v080_create_commit')
+WHERE name = 'total_replaced'
+----
+1
+
+query I
+SELECT count(*) FROM show_semantic_metrics('v080_create_commit')
+WHERE name = 'rolled_back_metric'
+----
+0
+
+# ------------------------------------------------------------------
+# CREATE IF NOT EXISTS: silent no-op when the view exists.
+# ------------------------------------------------------------------
+
+statement ok
+CREATE SEMANTIC VIEW IF NOT EXISTS v080_create_commit AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.ignored AS COUNT(*))
+
+# Metric from the no-op CREATE is NOT present (the existing view was kept).
+query I
+SELECT count(*) FROM show_semantic_metrics('v080_create_commit')
+WHERE name = 'ignored'
+----
+0
+
+# CREATE IF NOT EXISTS for a fresh name actually creates it.
+statement ok
+CREATE SEMANTIC VIEW IF NOT EXISTS v080_create_ine AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_create_ine'
+----
+1
+
+# ------------------------------------------------------------------
 # Cleanup
 # ------------------------------------------------------------------
 
@@ -229,3 +384,9 @@ DROP SEMANTIC VIEW IF EXISTS v080_rename_conflict
 
 statement ok
 DROP SEMANTIC VIEW IF EXISTS v080_comment_view
+
+statement ok
+DROP SEMANTIC VIEW IF EXISTS v080_create_commit
+
+statement ok
+DROP SEMANTIC VIEW IF EXISTS v080_create_ine

--- a/test/sql/v080_transactional_ddl.test
+++ b/test/sql/v080_transactional_ddl.test
@@ -1,0 +1,231 @@
+# v0.8.0: transactional DROP / ALTER SEMANTIC VIEW
+#
+# Verifies that DROP and ALTER writes participate in the caller's transaction.
+# The parser_override hook rewrites recognised DDL into native DELETE / UPDATE
+# against semantic_layer._definitions, which DuckDB then executes on the
+# caller's connection — so BEGIN / COMMIT / ROLLBACK behave as expected.
+#
+# Pre-v0.8.0 these writes ran on a dedicated persist_conn (auto-commit), so
+# rollback left them behind; this test would have failed.
+#
+# CREATE is intentionally NOT covered here — it remains on the legacy
+# DefineFromJsonVTab path because its bind() performs metadata enrichment
+# (database_name / schema_name / created_on / type inference / graph
+# validation) that has not been moved out of bind() yet. Transactional CREATE
+# is a documented v0.8.0 limitation; revisit when the enrichment refactor lands.
+
+require semantic_views
+
+# ------------------------------------------------------------------
+# Setup
+# ------------------------------------------------------------------
+
+statement ok
+CREATE TABLE v080_orders (id INTEGER PRIMARY KEY, amount DECIMAL(10,2), region VARCHAR);
+
+statement ok
+INSERT INTO v080_orders VALUES (1, 100.00, 'US'), (2, 200.00, 'EU');
+
+# ------------------------------------------------------------------
+# DROP inside a rolled-back transaction must NOT remove the view.
+# ------------------------------------------------------------------
+
+statement ok
+CREATE SEMANTIC VIEW v080_drop_rb AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+statement ok
+BEGIN
+
+statement ok
+DROP SEMANTIC VIEW v080_drop_rb
+
+query I
+SELECT count(*) FROM semantic_layer._definitions WHERE name = 'v080_drop_rb'
+----
+0
+
+statement ok
+ROLLBACK
+
+# After rollback the row reappears.
+query I
+SELECT count(*) FROM semantic_layer._definitions WHERE name = 'v080_drop_rb'
+----
+1
+
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_drop_rb'
+----
+1
+
+# ------------------------------------------------------------------
+# DROP commit removes it for good.
+# ------------------------------------------------------------------
+
+statement ok
+BEGIN
+
+statement ok
+DROP SEMANTIC VIEW v080_drop_rb
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_drop_rb'
+----
+0
+
+# ------------------------------------------------------------------
+# DROP without IF EXISTS errors when the view is missing.
+# ------------------------------------------------------------------
+
+statement error
+DROP SEMANTIC VIEW v080_does_not_exist
+----
+does not exist
+
+# IF EXISTS is a silent no-op.
+statement ok
+DROP SEMANTIC VIEW IF EXISTS v080_does_not_exist
+
+# ------------------------------------------------------------------
+# ALTER RENAME inside a rolled-back transaction must not change the name.
+# ------------------------------------------------------------------
+
+statement ok
+CREATE SEMANTIC VIEW v080_rename_src AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+statement ok
+BEGIN
+
+statement ok
+ALTER SEMANTIC VIEW v080_rename_src RENAME TO v080_rename_dst
+
+statement ok
+ROLLBACK
+
+# Original name still present, target name absent.
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_rename_src'
+----
+1
+
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_rename_dst'
+----
+0
+
+# Commit a real rename.
+statement ok
+ALTER SEMANTIC VIEW v080_rename_src RENAME TO v080_rename_dst
+
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_rename_src'
+----
+0
+
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_rename_dst'
+----
+1
+
+# RENAME error path: missing source.
+statement error
+ALTER SEMANTIC VIEW v080_no_such_view RENAME TO v080_other
+----
+does not exist
+
+# IF EXISTS is silent for missing source.
+statement ok
+ALTER SEMANTIC VIEW IF EXISTS v080_no_such_view RENAME TO v080_other
+
+# RENAME error path: target already exists.
+statement ok
+CREATE SEMANTIC VIEW v080_rename_conflict AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+statement error
+ALTER SEMANTIC VIEW v080_rename_dst RENAME TO v080_rename_conflict
+----
+already exists
+
+# ------------------------------------------------------------------
+# ALTER SET / UNSET COMMENT under transactions.
+# ------------------------------------------------------------------
+
+statement ok
+CREATE SEMANTIC VIEW v080_comment_view
+  COMMENT = 'initial'
+AS
+  TABLES (o AS v080_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+statement ok
+BEGIN
+
+statement ok
+ALTER SEMANTIC VIEW v080_comment_view SET COMMENT = 'changed'
+
+statement ok
+ROLLBACK
+
+# Comment unchanged after rollback.
+query T
+SELECT comment FROM list_semantic_views() WHERE name = 'v080_comment_view'
+----
+initial
+
+# Commit a real change.
+statement ok
+ALTER SEMANTIC VIEW v080_comment_view SET COMMENT = 'changed'
+
+query T
+SELECT comment FROM list_semantic_views() WHERE name = 'v080_comment_view'
+----
+changed
+
+# UNSET clears it.
+statement ok
+ALTER SEMANTIC VIEW v080_comment_view UNSET COMMENT
+
+# list_semantic_views renders a NULL comment as the empty string.
+query T
+SELECT comment FROM list_semantic_views() WHERE name = 'v080_comment_view'
+----
+(empty)
+
+# Error path: SET COMMENT on missing view.
+statement error
+ALTER SEMANTIC VIEW v080_does_not_exist SET COMMENT = 'x'
+----
+does not exist
+
+# IF EXISTS silent no-op.
+statement ok
+ALTER SEMANTIC VIEW IF EXISTS v080_does_not_exist SET COMMENT = 'x'
+
+statement ok
+ALTER SEMANTIC VIEW IF EXISTS v080_does_not_exist UNSET COMMENT
+
+# ------------------------------------------------------------------
+# Cleanup
+# ------------------------------------------------------------------
+
+statement ok
+DROP SEMANTIC VIEW IF EXISTS v080_rename_dst
+
+statement ok
+DROP SEMANTIC VIEW IF EXISTS v080_rename_conflict
+
+statement ok
+DROP SEMANTIC VIEW IF EXISTS v080_comment_view

--- a/test/sql/v080_transactional_ddl.test
+++ b/test/sql/v080_transactional_ddl.test
@@ -373,6 +373,81 @@ SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_create_ine'
 1
 
 # ------------------------------------------------------------------
+# CREATE FROM YAML FILE participates in the caller's transaction.
+# Same enrichment helper as inline CREATE; the YAML file read happens on
+# the catalog connection inside the parser_override callback so the user's
+# transaction state is untouched, then the INSERT runs on the caller's
+# connection.
+# ------------------------------------------------------------------
+
+statement ok
+COPY (SELECT 'tables:
+  - alias: o
+    table: v080_orders
+    pk_columns:
+      - id
+dimensions:
+  - name: region
+    expr: o.region
+    source_table: o
+metrics:
+  - name: total
+    expr: SUM(o.amount)
+    source_table: o' AS content)
+TO '__TEST_DIR__/v080_yaml_file.yaml' (FORMAT CSV, HEADER FALSE, QUOTE '');
+
+statement ok
+BEGIN
+
+statement ok
+CREATE SEMANTIC VIEW v080_yaml_rb FROM YAML FILE '__TEST_DIR__/v080_yaml_file.yaml'
+
+# Visible to the same connection inside the transaction.
+query I
+SELECT count(*) FROM semantic_layer._definitions WHERE name = 'v080_yaml_rb'
+----
+1
+
+statement ok
+ROLLBACK
+
+# After rollback the row is gone — pre-v0.8.0 the C++ shim's auto-commit
+# ddl_conn would have left it behind.
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_yaml_rb'
+----
+0
+
+# CREATE FROM YAML FILE + COMMIT persists.
+statement ok
+BEGIN
+
+statement ok
+CREATE SEMANTIC VIEW v080_yaml_commit FROM YAML FILE '__TEST_DIR__/v080_yaml_file.yaml'
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM list_semantic_views() WHERE name = 'v080_yaml_commit'
+----
+1
+
+# Plain CREATE FROM YAML FILE on existing view errors at parse_override time.
+statement error
+CREATE SEMANTIC VIEW v080_yaml_commit FROM YAML FILE '__TEST_DIR__/v080_yaml_file.yaml'
+----
+already exists
+
+# CREATE OR REPLACE FROM YAML FILE upserts.
+statement ok
+CREATE OR REPLACE SEMANTIC VIEW v080_yaml_commit FROM YAML FILE '__TEST_DIR__/v080_yaml_file.yaml'
+
+# CREATE IF NOT EXISTS FROM YAML FILE is a silent no-op when present.
+statement ok
+CREATE SEMANTIC VIEW IF NOT EXISTS v080_yaml_commit FROM YAML FILE '__TEST_DIR__/v080_yaml_file.yaml'
+
+# ------------------------------------------------------------------
 # Cleanup
 # ------------------------------------------------------------------
 
@@ -390,3 +465,6 @@ DROP SEMANTIC VIEW IF EXISTS v080_create_commit
 
 statement ok
 DROP SEMANTIC VIEW IF EXISTS v080_create_ine
+
+statement ok
+DROP SEMANTIC VIEW IF EXISTS v080_yaml_commit

--- a/test/sql/v080_yaml_file.yaml
+++ b/test/sql/v080_yaml_file.yaml
@@ -1,0 +1,13 @@
+tables:
+  - alias: o
+    table: v080_orders
+    pk_columns:
+      - id
+dimensions:
+  - name: region
+    expr: o.region
+    source_table: o
+metrics:
+  - name: total
+    expr: SUM(o.amount)
+    source_table: o


### PR DESCRIPTION
## Summary

- Makes `CREATE` / `DROP` / `ALTER SEMANTIC VIEW` participate in the caller's transaction via a new `parser_override` extension hook — fixes the original ADBC `autocommit=false` rollback-leaves-view-behind bug across all four CREATE forms (inline AS-body, inline `FROM YAML $$ ... $$`, `FROM YAML FILE '<path>'`, and CREATE OR REPLACE / IF NOT EXISTS variants).
- Drops the in-memory `CatalogState` HashMap; all catalog reads go through a single shared `CatalogReader` against `semantic_layer._definitions`.
- Closes the milestone: ADBC integration test, `examples/transactional_ddl.py`, CHANGELOG v0.8.0 entry with two documented known limitations, version bump to 0.8.0.

## Changes

- `parser_override` registered on the existing `ParserExtension`; `allow_parser_override_extension=FALLBACK` in DBConfig. Recognised DDL is rewritten into native `INSERT` / `UPDATE` / `DELETE` against `_definitions` and runs on the caller's connection.
- Per-DB token plumbing (`Mutex<HashMap<u64, OverrideContext>>`) replaces the old global `OnceLock<CatalogReader>`, so multi-DB Python integration patterns work correctly.
- Compat header: full `Parser` class including the trailing `ParserOptions options` field — the missing field was silently corrupting `ParseQuery` and falling through to legacy parse_function.
- New regression tests: `peg_compat.test` (parser_override survives PEG transition) and `v080_transactional_ddl.test` (BEGIN/ROLLBACK + COMMIT for every form).

## Known limitations (documented in CHANGELOG)

- `semantic_view(...)` queries do not see uncommitted writes to user tables in the same transaction (expansion runs on a separate `query_conn`). Workaround: commit before querying. Will be revisited with DuckDB 2.0's PEG grammar-extension API.
- A `CREATE SEMANTIC VIEW` issued in an uncommitted txn is no longer visible to subsequent reads in that txn (the eager-HashMap behaviour is gone). Workaround: commit before reading.

## Test plan

- [x] `just ci` green locally — 822 Rust + sqllogictest + DuckLake-CI + vtab-crash 13/13 + caret + ADBC 6/6 + fuzz check + Sphinx docs.
- [ ] Confirm GitHub Actions CI passes on this branch.
- [ ] Post-merge: update `description.yml` `repo.ref` to the squash commit SHA on main, tag `v0.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)