### PR TITLE
v0.10.2 fix: allow passthrough facts named after their own column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### Fixed
+
+- **Passthrough facts named after their own column now work.** A fact whose expression references its own name — the natural 1:1 passthrough, e.g. `FACTS (s.unit_price AS s.unit_price)` — was rejected at `CREATE` time with `cycle detected in facts: unit_price -> unit_price`, and even when the expression differed slightly it expanded incorrectly. Two issues are fixed: (1) a fact's own name in its own expression is now treated as a reference to the physical column, not a self-cycle (genuine cycles between distinct facts are still rejected); and (2) fact-reference inlining replaced the qualified (`alias.name`) and unqualified (`name`) forms in two sequential passes, so for an identity fact the second pass re-scanned the first's output and produced corrupt SQL (`s.unit_price` → `(s.(s.unit_price))`) — replacement now happens in a single non-re-scanning pass. `DESCRIBE SELECT * FROM semantic_view('v', facts := ['unit_price'])` returns the declared fact name as the output column. Note: as in Snowflake, each clause entry reads `name AS expression` (logical name before `AS`, SQL expression after) — the reverse of a plain SQL `expression AS alias`.
 
 ## [0.10.1] - 2026-06-03
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ SELECT * FROM explain_semantic_view('analytics',
 
 Name common row-level calculations once and reference them in metrics. Facts are inlined into metric expressions at expansion time.
 
+> **Clause direction:** like Snowflake, each entry is `alias.<logical_name> AS <sql_expression>` —
+> the **name comes before `AS`**, the SQL expression after. This is the reverse of a plain SQL
+> `expression AS alias`. The logical name is what you query (`facts := ['net_price']`) and what
+> `DESCRIBE` returns as the column. A fact may be named after its own column —
+> `FACTS (s.unit_price AS s.unit_price)` defines a passthrough fact `unit_price`. The same
+> direction applies to `DIMENSIONS` and `METRICS`.
+
 ```sql
 CREATE SEMANTIC VIEW sales AS
 TABLES (

--- a/docs/reference/create-semantic-view.rst
+++ b/docs/reference/create-semantic-view.rst
@@ -221,19 +221,19 @@ Declares named row-level expressions. Facts are inlined into metric expressions 
 **Parameters:**
 
 - ``PRIVATE``, optional. When present, the fact cannot be queried directly via ``facts := [...]`` but can still be referenced in metric expressions.
-- ``<alias>.<fact_name>``, the table alias and fact name. Facts are scoped to a single table.
-- ``<row_level_expression>``, any SQL expression that operates on individual rows. Must not contain aggregate functions.
+- ``<alias>.<fact_name>``, the table alias and fact name, appearing **before** ``AS``. Facts are scoped to a single table. The fact name is what you query (``facts := ['net_price']``) and what ``DESCRIBE`` returns as the output column. As in Snowflake, the entry reads ``name AS expression`` — the reverse of a plain SQL ``expression AS alias``.
+- ``<row_level_expression>``, the SQL expression **after** ``AS``: any expression that operates on individual rows. Must not contain aggregate functions. A fact may be named after its own backing column (``s.unit_price AS s.unit_price``), giving a passthrough fact.
 - ``COMMENT = '<text>'``, optional. A human-readable description.
 - ``WITH SYNONYMS = ('<synonym>', ...)``, optional. Alternative names for discoverability.
 
 **Fact chaining:**
 
-Facts can reference other facts by name. The extension resolves dependencies in topological order and inlines them recursively. Circular references are rejected at define time.
+Facts can reference other facts by name. The extension resolves dependencies in topological order and inlines them recursively. Circular references between distinct facts are rejected at define time. A fact whose expression contains its *own* name (``s.unit_price AS s.unit_price``) is treated as a reference to the physical column, not a self-cycle.
 
 **Validation rules:**
 
 - Aggregate functions (``SUM``, ``COUNT``, ``AVG``, ``MIN``, ``MAX``, etc.) in fact expressions are rejected.
-- Circular fact references are rejected.
+- Circular references between distinct facts are rejected (a fact referencing its own name resolves to the physical column).
 
 
 .. _ref-create-dimensions:

--- a/src/expand/facts.rs
+++ b/src/expand/facts.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::model::Fact;
-use crate::util::{is_word_boundary_char, replace_word_boundary};
+use crate::util::{is_word_boundary_char, replace_word_boundary, replace_word_boundary_any};
 
 /// Maximum allowed nesting depth for derived metric resolution.
 /// Prevents stack overflow from deeply nested metric chains that pass
@@ -170,15 +170,18 @@ pub(super) fn inline_facts(expr: &str, facts: &[Fact], topo_order: &[usize]) -> 
         let fact = &facts[idx];
         let mut resolved_expr = fact.expr.clone();
 
-        // Inline any already-resolved facts into this fact's expression
+        // Inline any already-resolved facts into this fact's expression.
+        // Qualified (`alias.name`) and unqualified (`name`) forms are replaced in a
+        // single pass so a replacement containing the unqualified name is not
+        // re-scanned (see `replace_word_boundary_any`).
         for (name, replacement) in &resolved {
-            // Try qualified form: source_table.name
-            if let Some(ref st) = fact.source_table {
-                let qualified = format!("{st}.{name}");
-                resolved_expr = replace_word_boundary(&resolved_expr, &qualified, replacement);
+            let qualified = fact.source_table.as_ref().map(|st| format!("{st}.{name}"));
+            let mut needles: Vec<&str> = Vec::with_capacity(2);
+            if let Some(ref q) = qualified {
+                needles.push(q);
             }
-            // Unqualified form
-            resolved_expr = replace_word_boundary(&resolved_expr, name, replacement);
+            needles.push(name);
+            resolved_expr = replace_word_boundary_any(&resolved_expr, &needles, replacement);
         }
 
         // Store as parenthesized
@@ -192,13 +195,19 @@ pub(super) fn inline_facts(expr: &str, facts: &[Fact], topo_order: &[usize]) -> 
     for &idx in topo_order {
         let fact = &facts[idx];
         if let Some(replacement) = resolved.get(&fact.name) {
-            // Try qualified form first: source_table.name
-            if let Some(ref st) = fact.source_table {
-                let qualified = format!("{st}.{}", fact.name);
-                result = replace_word_boundary(&result, &qualified, replacement);
+            // Replace qualified (`alias.name`) and unqualified (`name`) forms in a
+            // single pass. Sequential calls would double-substitute an identity
+            // fact whose replacement contains its own unqualified name.
+            let qualified = fact
+                .source_table
+                .as_ref()
+                .map(|st| format!("{st}.{}", fact.name));
+            let mut needles: Vec<&str> = Vec::with_capacity(2);
+            if let Some(ref q) = qualified {
+                needles.push(q);
             }
-            // Unqualified form
-            result = replace_word_boundary(&result, &fact.name, replacement);
+            needles.push(&fact.name);
+            result = replace_word_boundary_any(&result, &needles, replacement);
         }
     }
 
@@ -713,6 +722,37 @@ mod tests {
         assert!(
             result.contains("price * (1 - discount)"),
             "Should replace qualified form o.net_price, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_inline_facts_identity_qualified_no_double_sub() {
+        // Identity passthrough: fact `unit_price` whose expression is the qualified
+        // column `s.unit_price`. The SELECT path passes the fact's own expr through
+        // inline_facts. It must NOT double-substitute into `(s.(s.unit_price))`.
+        let mut fact = make_fact("unit_price", "s.unit_price");
+        fact.source_table = Some("s".to_string());
+        let facts = vec![fact];
+        let topo = vec![0];
+        let result = inline_facts("s.unit_price", &facts, &topo);
+        assert_eq!(
+            result, "(s.unit_price)",
+            "Identity fact must resolve to its column once, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_inline_facts_identity_referenced_by_metric() {
+        // A metric referencing an identity fact by its qualified column must inline
+        // cleanly to a single column reference.
+        let mut fact = make_fact("unit_price", "s.unit_price");
+        fact.source_table = Some("s".to_string());
+        let facts = vec![fact];
+        let topo = vec![0];
+        let result = inline_facts("SUM(s.unit_price)", &facts, &topo);
+        assert_eq!(
+            result, "SUM((s.unit_price))",
+            "Metric over identity fact must inline once, got: {result}"
         );
     }
 

--- a/src/graph/facts.rs
+++ b/src/graph/facts.rs
@@ -73,7 +73,7 @@ pub fn validate_facts(def: &SemanticViewDefinition) -> Result<(), String> {
     let fact_names: Vec<&str> = def.facts.iter().map(|f| f.name.as_str()).collect();
 
     // 2. Build fact dependency DAG and check for cycles
-    let (edges, in_degree) = build_fact_dag(def, &fact_names)?;
+    let (edges, in_degree) = build_fact_dag(def, &fact_names);
 
     // 3. Check that all referenced facts exist
     check_fact_references_exist(&edges, &fact_names)?;
@@ -111,10 +111,10 @@ fn check_fact_source_tables(def: &SemanticViewDefinition) -> Result<(), String> 
 type FactDag<'a> = (HashMap<&'a str, Vec<&'a str>>, HashMap<&'a str, usize>);
 
 /// Build fact dependency DAG from expressions. Returns `(edges, in_degree)`.
-fn build_fact_dag<'a>(
-    def: &'a SemanticViewDefinition,
-    fact_names: &[&'a str],
-) -> Result<FactDag<'a>, String> {
+///
+/// A fact referencing its own name is treated as a column reference and produces no
+/// edge; genuine multi-fact cycles are detected later by [`check_fact_cycles`].
+fn build_fact_dag<'a>(def: &'a SemanticViewDefinition, fact_names: &[&'a str]) -> FactDag<'a> {
     let mut edges: HashMap<&str, Vec<&str>> = HashMap::new();
     let mut in_degree: HashMap<&str, usize> = HashMap::new();
 
@@ -126,10 +126,12 @@ fn build_fact_dag<'a>(
         let refs = find_fact_references(&fact.expr, fact_names);
         for &referenced in &refs {
             if referenced == fact.name.as_str() {
-                return Err(format!(
-                    "cycle detected in facts: {} -> {}",
-                    fact.name, fact.name
-                ));
+                // A fact's own name appearing in its own expression is a reference
+                // to the physical column, not a self-dependency — e.g. the identity
+                // passthrough fact `s.unit_price AS s.unit_price`. Skip the self-edge
+                // (mirrors `toposort_facts`, which already does `if dep_idx == i`).
+                // Genuine multi-fact cycles (A->B->A) are still caught below.
+                continue;
             }
             edges
                 .entry(fact.name.as_str())
@@ -139,7 +141,7 @@ fn build_fact_dag<'a>(
         }
     }
 
-    Ok((edges, in_degree))
+    (edges, in_degree)
 }
 
 /// Check that all fact names referenced in edges actually exist.
@@ -341,15 +343,41 @@ mod tests {
     }
 
     #[test]
-    fn validate_facts_self_reference_cycle() {
+    fn validate_facts_self_named_is_not_a_cycle() {
+        // A fact whose expression references its own name is NOT a self-cycle: the
+        // bare name resolves to the physical column at query time. This is the
+        // identity/passthrough shape, and an expression like `recursive + 1` simply
+        // reads column `recursive`. Validation must accept it.
         let def = make_def_with_facts(
             vec![("o", "orders")],
             vec![("recursive", "recursive + 1", "o")],
         );
-        let err = validate_facts(&def).unwrap_err();
         assert!(
-            err.contains("cycle detected in facts"),
-            "Expected self-reference cycle error, got: {err}"
+            validate_facts(&def).is_ok(),
+            "Self-named fact should be accepted (column reference, not self-cycle)"
+        );
+    }
+
+    #[test]
+    fn validate_facts_identity_passthrough() {
+        // The canonical passthrough: fact named after its backing column, both
+        // unqualified and qualified expression forms.
+        let def_unqualified = make_def_with_facts(
+            vec![("s", "sales")],
+            vec![("unit_price", "unit_price", "s")],
+        );
+        assert!(
+            validate_facts(&def_unqualified).is_ok(),
+            "Identity fact `s.unit_price AS unit_price` should validate"
+        );
+
+        let def_qualified = make_def_with_facts(
+            vec![("s", "sales")],
+            vec![("unit_price", "s.unit_price", "s")],
+        );
+        assert!(
+            validate_facts(&def_qualified).is_ok(),
+            "Identity fact `s.unit_price AS s.unit_price` should validate"
         );
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -68,6 +68,56 @@ pub fn replace_word_boundary(haystack: &str, needle: &str, replacement: &str) ->
     result
 }
 
+/// Replace word-boundary occurrences of *any* needle in `needles` with `replacement`,
+/// in a single left-to-right pass.
+///
+/// At each position the needles are tried in the given order — put the more specific
+/// (e.g. qualified `alias.name`) needle first so it wins over a shorter one (`name`).
+/// On a match the replacement is emitted and scanning resumes *after* the matched
+/// needle: the inserted replacement text is never re-scanned.
+///
+/// This matters when the replacement itself contains one of the needles. For an
+/// identity fact (`name` whose expression is the qualified column `alias.name`), two
+/// sequential [`replace_word_boundary`] calls — qualified then unqualified — would
+/// double-substitute (`alias.name` -> `(alias.name)` -> `(alias.(alias.name))`).
+/// A single combined pass avoids that.
+#[must_use]
+pub fn replace_word_boundary_any(haystack: &str, needles: &[&str], replacement: &str) -> String {
+    let h_bytes = haystack.as_bytes();
+    let mut result = String::with_capacity(haystack.len());
+    let mut i = 0;
+
+    while i < h_bytes.len() {
+        let mut matched = false;
+        for &needle in needles {
+            let n_bytes = needle.as_bytes();
+            let n_len = n_bytes.len();
+            if n_len == 0 || i + n_len > h_bytes.len() {
+                continue;
+            }
+            if &h_bytes[i..i + n_len] == n_bytes {
+                let before_ok = i == 0 || is_word_boundary_char(h_bytes[i - 1]);
+                let after_ok =
+                    i + n_len == h_bytes.len() || is_word_boundary_char(h_bytes[i + n_len]);
+                if before_ok && after_ok {
+                    result.push_str(replacement);
+                    i += n_len;
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if !matched {
+            // Advance by a full UTF-8 char so `i` stays on a char boundary.
+            let ch = haystack[i..].chars().next().unwrap();
+            result.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+
+    result
+}
+
 /// Check if a byte is a word-boundary character (NOT alphanumeric or underscore).
 #[must_use]
 pub fn is_word_boundary_char(b: u8) -> bool {
@@ -176,6 +226,55 @@ mod tests {
     fn replace_word_boundary_empty_needle() {
         let result = replace_word_boundary("abc", "", "x");
         assert_eq!(result, "abc");
+    }
+
+    // -------------------------------------------------------------------
+    // replace_word_boundary_any tests
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn replace_any_qualified_wins_over_unqualified() {
+        // Qualified needle is tried first; the unqualified `unit_price` inside the
+        // emitted replacement must NOT be re-scanned (no double substitution).
+        let result = replace_word_boundary_any(
+            "s.unit_price",
+            &["s.unit_price", "unit_price"],
+            "(s.unit_price)",
+        );
+        assert_eq!(result, "(s.unit_price)");
+    }
+
+    #[test]
+    fn replace_any_unqualified_fallback() {
+        // When only the unqualified form appears, it still matches.
+        let result =
+            replace_word_boundary_any("SUM(unit_price)", &["s.unit_price", "unit_price"], "(x)");
+        assert_eq!(result, "SUM((x))");
+    }
+
+    #[test]
+    fn replace_any_inside_qualified_metric() {
+        // Metric referencing an identity fact by its qualified column.
+        let result = replace_word_boundary_any(
+            "SUM(s.unit_price)",
+            &["s.unit_price", "unit_price"],
+            "(s.unit_price)",
+        );
+        assert_eq!(result, "SUM((s.unit_price))");
+    }
+
+    #[test]
+    fn replace_any_no_substring_match() {
+        let result =
+            replace_word_boundary_any("unit_price_total", &["s.unit_price", "unit_price"], "(x)");
+        assert_eq!(result, "unit_price_total");
+    }
+
+    #[test]
+    fn replace_any_utf8_passthrough() {
+        // Non-ASCII, non-matching content must not panic and must round-trip.
+        let result = replace_word_boundary_any("héllo + unit_price", &["unit_price"], "(x)");
+        assert_eq!(result, "héllo + (x)");
     }
 
     // -------------------------------------------------------------------

--- a/test/sql/TEST_LIST
+++ b/test/sql/TEST_LIST
@@ -58,3 +58,4 @@ test/sql/phase67_qualified_emission.test
 test/sql/phase67_quoted_source_tables.test
 test/sql/phase68_quoted_idents_non_additive.test
 test/sql/phase68_quoted_idents_window.test
+test/sql/identity_fact_passthrough.test

--- a/test/sql/identity_fact_passthrough.test
+++ b/test/sql/identity_fact_passthrough.test
@@ -1,0 +1,98 @@
+# Identity / passthrough fact: a fact named after its own backing column.
+#
+# Regression for v0.10.2: `FACTS (s.unit_price AS s.unit_price)` must
+#   1. CREATE (the self-name is a column reference, not a self-cycle), and
+#   2. expand to a single column reference, NOT the double-substituted
+#      `(s.(s.unit_price))`, so DESCRIBE returns the declared fact name.
+
+require semantic_views
+
+statement ok
+CREATE TABLE idf_sales (id INTEGER, unit_price INTEGER, region VARCHAR);
+
+statement ok
+INSERT INTO idf_sales VALUES (1, 100, 'East'), (2, 200, 'East'), (3, 150, 'West');
+
+# ============================================================
+# CREATE with an identity passthrough fact (qualified expression)
+# ============================================================
+
+statement ok
+CREATE SEMANTIC VIEW idf_v AS
+  TABLES (
+    s AS idf_sales PRIMARY KEY (id)
+  )
+  FACTS (
+    s.unit_price AS s.unit_price
+  )
+  DIMENSIONS (
+    s.region AS s.region
+  )
+  METRICS (
+    s.total_price AS SUM(s.unit_price)
+  );
+
+# ============================================================
+# DESCRIBE returns the declared fact name as the output column
+# ============================================================
+
+query T
+SELECT column_name FROM (DESCRIBE SELECT * FROM semantic_view('idf_v', facts := ['unit_price']));
+----
+unit_price
+
+# ============================================================
+# The fact query returns the underlying column values (unaggregated)
+# ============================================================
+
+query I
+FROM semantic_view('idf_v', facts := ['unit_price'])
+ORDER BY 1;
+----
+100
+150
+200
+
+# ============================================================
+# A metric referencing the identity fact aggregates correctly
+# (no expression corruption: SUM(s.unit_price), not SUM(s.(s.unit_price)))
+# ============================================================
+
+query TI rowsort
+SELECT * FROM semantic_view('idf_v', dimensions := ['region'], metrics := ['total_price']);
+----
+East	300
+West	150
+
+# ============================================================
+# CREATE also accepts the unqualified expression form
+# ============================================================
+
+statement ok
+CREATE SEMANTIC VIEW idf_v2 AS
+  TABLES (
+    s AS idf_sales PRIMARY KEY (id)
+  )
+  FACTS (
+    s.unit_price AS unit_price
+  )
+  DIMENSIONS (
+    s.region AS s.region
+  )
+  METRICS (
+    s.total_price AS SUM(s.unit_price)
+  );
+
+query I
+FROM semantic_view('idf_v2', facts := ['unit_price'])
+ORDER BY 1;
+----
+100
+150
+200
+
+statement ok
+DROP SEMANTIC VIEW idf_v2;
+
+statement ok
+DROP SEMANTIC VIEW idf_v;

--- a/test/sql/phase29_facts.test
+++ b/test/sql/phase29_facts.test
@@ -180,25 +180,27 @@ CREATE SEMANTIC VIEW p29_cycle AS
 cycle detected in facts
 
 # ============================================================
-# Test 7: Error -- fact self-reference
+# Test 7: A fact whose expression references its own name is a
+# column reference (identity passthrough), NOT a self-cycle.
 # ============================================================
 
-statement error
-CREATE SEMANTIC VIEW p29_self_ref AS
+statement ok
+CREATE SEMANTIC VIEW p29_self_named AS
   TABLES (
     o AS p29_orders PRIMARY KEY (id)
   )
   FACTS (
-    o.a AS o.a + 1
+    o.customer_id AS o.customer_id
   )
   DIMENSIONS (
     o.region AS o.region
   )
   METRICS (
-    o.total AS SUM(o.a)
+    o.total AS SUM(o.customer_id)
   );
-----
-cycle detected in facts
+
+statement ok
+DROP SEMANTIC VIEW p29_self_named;
 
 # ============================================================
 # Test 8: Error -- facts source table not in TABLES


### PR DESCRIPTION
A fact whose expression references its own name — the 1:1 passthrough shape, e.g. `FACTS (s.unit_price AS s.unit_price)` — was wrongly rejected at CREATE time as a self-cycle, and expanded to corrupt SQL when accepted.

Two root causes:

1. `build_fact_dag` (graph/facts.rs) treated a fact's own name appearing in its own expression as a self-dependency and errored (`cycle detected in facts: X -> X`). The expand-layer `toposort_facts` already skipped self; the CREATE validator now agrees. A self-name is a reference to the physical column, not a cycle. Multi-fact cycles (A->B->A) are still rejected.

2. `inline_facts` (expand/facts.rs) substituted the qualified (`alias.name`) then unqualified (`name`) reference forms in two sequential `replace_word_boundary` passes. For an identity fact the second pass re-scanned the first's output, double-substituting `s.unit_price` -> `(s.unit_price)` -> `(s.(s.unit_price))`. A new `replace_word_boundary_any` helper replaces both forms in a single left-to-right pass that never re-scans inserted text. This fixes both the fact-query SELECT and metrics referencing an identity fact.

DESCRIBE of a fact query returns the declared fact name as the output column, so downstream codegen reading those names gets stable identifiers.

Docs (README + reference) clarify the Snowflake-aligned `name AS expr` direction (name before AS), distinct from plain SQL `expr AS alias`.

Tests: unit coverage for the new helper and identity-fact validation/ inlining; new `identity_fact_passthrough.test` sqllogictest (CREATE + DESCRIBE column name + query values + metric over identity fact); phase29 self-reference test flipped from error to acceptance.