### PR TITLE
chore: release v0.10.3 (Windows MSVC build fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes yet._
 
+## [0.10.3] - 2026-06-13
+
+### Fixed
+
+- **Windows community-extension build fixed against the updated MSVC toolchain.** The vendored DuckDB amalgamation bundles `fmt` 6.1.2, which on MSVC selected `stdext::checked_array_iterator` (under `#ifdef _SECURE_SCL`). Recent Microsoft STL versions removed that symbol entirely, so the `windows-latest` build began failing to compile the amalgamation with `error C2653: 'stdext': is not a class or namespace name`. The Windows build-time patch applied to `duckdb.cpp` now disables that branch so `fmt` takes its portable raw-pointer path — the same code every non-Windows platform already compiled. No functional or API changes from 0.10.2; this only restores the Windows build so the community-extensions registry can keep producing a Windows binary as new DuckDB versions ship.
+
 ## [0.10.2] - 2026-06-04
 
 ### Fixed
@@ -309,7 +315,8 @@ Connection-lifecycle and ADBC fixes. Two downstream regressions reported against
 - `list_semantic_views()` and `describe_semantic_view()` introspection functions
 - Fuzz targets for FFI boundary testing
 
-[Unreleased]: https://github.com/anentropic/duckdb-semantic-views/compare/v0.10.2...HEAD
+[Unreleased]: https://github.com/anentropic/duckdb-semantic-views/compare/v0.10.3...HEAD
+[0.10.3]: https://github.com/anentropic/duckdb-semantic-views/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/anentropic/duckdb-semantic-views/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/anentropic/duckdb-semantic-views/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/anentropic/duckdb-semantic-views/compare/v0.9.0...v0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semantic_views"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "arbitrary",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic_views"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 description = "DuckDB extension providing semantic views — a declarative layer for dimensions, measures, and relationships"
 license = "MIT"


### PR DESCRIPTION
Patch release packaging the Windows build fix from #42 into a tagged version.

## Why a release

The fix in #42 is build-only (no runtime change), and the published v0.10.2 Windows binary is fine today. But the community-extensions registry rebuilds from `description.yml`'s pinned `ref` (currently `3bc8433`, **pre-fix**) every time a new DuckDB version ships — the next such rebuild would hit the same MSVC `stdext::checked_array_iterator` compile failure on Windows. Cutting v0.10.3 moves the CE ref onto a commit containing the fix, keeping the Windows binary buildable going forward.

## Contents

- `Cargo.toml` / `Cargo.lock`: `0.10.2` → `0.10.3`
- `CHANGELOG.md`: `[0.10.3]` section (Fixed — Windows MSVC build), Unreleased + link refs updated

No functional or API changes from 0.10.2.

## After merge (release steps)

1. Tag `v0.10.3` at the merge commit on `main`.
2. Run `just release` — bumps `description.yml` (`version` + `ref`), pushes `main`, opens the community-extensions PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)