### PR TITLE
ci: automate changelog entry on DuckDB bump + gated extension publish

### DIFF
--- a/.github/workflows/DuckDBVersionMonitor.yml
+++ b/.github/workflows/DuckDBVersionMonitor.yml
@@ -93,6 +93,15 @@ jobs:
           # Download new amalgamation
           just update-headers
 
+      - name: Record changelog entry
+        if: steps.latest.outputs.is_new == 'true'
+        run: |
+          VER="${{ steps.latest.outputs.latest }}"
+          # Idempotent: re-running for the same version is a no-op (the monitor
+          # force-pushes its branch weekly). The publish workflow later rolls this
+          # [Unreleased] bullet into a versioned section at release time.
+          python3 scripts/changelog_add_bullet.py Changed "DuckDB version pin bumped to \`${VER}\`."
+
       - name: Build and test against new DuckDB version
         if: steps.latest.outputs.is_new == 'true'
         id: build
@@ -255,6 +264,12 @@ jobs:
 
           # Download new amalgamation
           just update-headers
+
+      - name: Record changelog entry (LTS)
+        if: steps.lts.outputs.is_new == 'true'
+        run: |
+          VER="${{ steps.lts.outputs.latest }}"
+          python3 scripts/changelog_add_bullet.py Changed "DuckDB LTS version pin bumped to \`${VER}\`."
 
       - name: Build and test against new LTS version
         if: steps.lts.outputs.is_new == 'true'

--- a/.github/workflows/PublishExtension.yml
+++ b/.github/workflows/PublishExtension.yml
@@ -1,0 +1,173 @@
+name: Publish Extension
+
+# Gated, post-merge republish to the DuckDB community-extensions registry.
+#
+# This is the piece the DuckDB Version Monitor deliberately does NOT do: it bumps
+# the pin and opens a PR, but publishing a new registry artifact has to happen
+# AFTER that PR merges (the published description.yml `ref` must point at a commit
+# that exists on `main`). This workflow performs that release:
+#
+#   gate -> version bump -> changelog roll -> tag -> description.yml sync -> CE PR
+#
+# It is intentionally MANUAL (workflow_dispatch) and runs in the `release`
+# environment so a required reviewer must approve each publish. The approval is
+# where a human confirms the registry is ready (see the registry-pin gate below).
+#
+# ── Required repo setup (one-time) ────────────────────────────────────────────
+#   * An Environment named `release` with required reviewers
+#     (Settings -> Environments). This is the human gate.
+#   * Secret CE_PUBLISH_PAT: a PAT with `repo` scope that can push to your fork
+#     `anentropic/community-extensions` AND open PRs against
+#     `duckdb/community-extensions`. Falls back to VERSION_MONITOR_PAT.
+#   * If `main` is branch-protected, the token above must be allowed to push the
+#     release commits + tag to `main` (or relax protection for this actor).
+# ──────────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 0.10.4). Leave blank to auto-bump the patch component of the current Cargo.toml version."
+        required: false
+        default: ""
+      dry_run:
+        description: "Build the release locally and show the diff, but do not push, tag, or open the CE PR."
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  CE_FORK: anentropic/community-extensions
+  CE_BRANCH: semantic-views
+  CE_UPSTREAM: duckdb/community-extensions
+
+jobs:
+  publish:
+    name: Publish to community-extensions
+    runs-on: ubuntu-latest
+    environment: release          # <- required-reviewer gate
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0          # need tags + full history for changelog/compare
+          token: ${{ secrets.CE_PUBLISH_PAT || secrets.VERSION_MONITOR_PAT || secrets.GITHUB_TOKEN }}
+
+      # 1. Resolve current + next version --------------------------------------
+      - name: Resolve versions
+        id: ver
+        run: |
+          CUR=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          if [ -z "$CUR" ]; then echo "could not read version from Cargo.toml" >&2; exit 1; fi
+          IN="${{ github.event.inputs.version }}"
+          if [ -n "$IN" ]; then
+            NEXT="$IN"
+          else
+            IFS=. read -r MA MI PA <<< "$CUR"
+            NEXT="${MA}.${MI}.$((PA + 1))"
+          fi
+          echo "current=$CUR"   >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT"     >> "$GITHUB_OUTPUT"
+          echo "prev_tag=v$CUR" >> "$GITHUB_OUTPUT"
+          echo "Publishing v$NEXT (previous v$CUR)"
+
+      # 2. GATE: our DuckDB pin must match the registry's build pin -------------
+      #    The registry builds every extension against a single maintainer-pinned
+      #    DuckDB version (the `DUCKDB_VERSION` default in its build.yml). Submitting
+      #    a descriptor whose source pins a newer DuckDB than the registry targets
+      #    just produces a failing registry build. Fail fast here instead.
+      - name: Gate — registry DuckDB pin equality
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OURS=$(cat .duckdb-version)
+          BUILD_YML=$(gh api repos/${{ env.CE_UPSTREAM }}/contents/.github/workflows/build.yml --jq '.content' | base64 -d)
+          REG=$(printf '%s\n' "$BUILD_YML" | grep -m1 'DUCKDB_VERSION:' | grep -oE 'v[0-9]+\.[0-9]+(\.[0-9]+)?' | tail -1)
+          echo "repo pin (.duckdb-version): $OURS"
+          echo "registry pin (build.yml):  $REG"
+          if [ -z "$REG" ]; then
+            echo "::error::could not parse registry DUCKDB_VERSION from build.yml" ; exit 1
+          fi
+          if [ "$OURS" != "$REG" ]; then
+            echo "::error::repo pins $OURS but the community-extensions registry builds against $REG. Wait for the registry to roll forward to $OURS (or align the repo pin) before publishing."
+            exit 1
+          fi
+          echo "Registry pin matches — safe to publish."
+
+      # 3. Changelog roll + version bump in this repo --------------------------
+      - name: Roll changelog and bump version
+        run: |
+          NEXT="${{ steps.ver.outputs.next }}"
+          PREV_TAG="${{ steps.ver.outputs.prev_tag }}"
+          DATE=$(date -u +%Y-%m-%d)
+          python3 scripts/changelog_release.py "$NEXT" "$DATE" "$PREV_TAG"
+          # Cargo.toml: first `version = "..."` line is the package version.
+          sed -i "0,/^version = \"/{s/^version = \"[^\"]*\"/version = \"$NEXT\"/}" Cargo.toml
+          # Keep Cargo.lock's own-package entry in sync (no cargo run needed).
+          sed -i "/^name = \"semantic_views\"$/{n;s/^version = \".*\"/version = \"$NEXT\"/}" Cargo.lock
+          sed -i "s/^  version: .*/  version: $NEXT/" description.yml
+
+      - name: Show diff (dry run inspection)
+        run: git --no-pager diff
+
+      # 4. Commit + tag the release, then sync description.yml ref --------------
+      #    Mirrors `just release`: the release commit is tagged, then a follow-up
+      #    commit sets description.yml `ref:` to the tagged commit's SHA.
+      - name: Commit, tag, and push
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          NEXT="${{ steps.ver.outputs.next }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add CHANGELOG.md Cargo.toml Cargo.lock description.yml
+          git commit -m "chore: release v$NEXT"
+          git tag "v$NEXT"
+          SHA=$(git rev-parse HEAD)
+
+          # Point description.yml at the tagged release commit, then commit that.
+          sed -i "s/^  ref: .*/  ref: $SHA/" description.yml
+          git add description.yml
+          git commit -m "chore: update description.yml for v$NEXT release"
+
+          git push origin main
+          git push origin "v$NEXT"
+          echo "RELEASE_SHA=$SHA" >> "$GITHUB_ENV"
+
+      # 5. Open the community-extensions PR from the fork ----------------------
+      - name: Open community-extensions PR
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.CE_PUBLISH_PAT || secrets.VERSION_MONITOR_PAT }}
+        run: |
+          NEXT="${{ steps.ver.outputs.next }}"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${CE_FORK}.git" ce-fork
+          cd ce-fork
+          git remote add upstream "https://github.com/${CE_UPSTREAM}.git"
+          git fetch upstream main
+          # Fresh branch off upstream/main so the PR is a clean one-file change.
+          git checkout -B "$CE_BRANCH" upstream/main
+          mkdir -p extensions/semantic_views
+          cp ../description.yml extensions/semantic_views/description.yml
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add extensions/semantic_views/description.yml
+          git commit -m "Update semantic_views to v$NEXT"
+          git push --force -u origin "$CE_BRANCH"
+          gh pr create \
+            --repo "$CE_UPSTREAM" \
+            --head "anentropic:$CE_BRANCH" \
+            --base main \
+            --title "Update semantic_views to v$NEXT" \
+            --body "Update semantic_views extension to v$NEXT (ref: ${RELEASE_SHA}). Built against the registry's current DuckDB pin."
+
+      - name: Summary
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          echo "### Published v${{ steps.ver.outputs.next }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- tag pushed: \`v${{ steps.ver.outputs.next }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- description.yml ref: \`${RELEASE_SHA}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- community-extensions PR opened from \`anentropic:${CE_BRANCH}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/changelog_add_bullet.py
+++ b/scripts/changelog_add_bullet.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Insert a bullet under the ``## [Unreleased]`` -> ``### <category>`` section.
+
+Used by the DuckDB Version Monitor workflow so an automated DuckDB-pin bump also
+records itself in the changelog, in the project's Keep-a-Changelog format, under
+the ``[Unreleased]`` section (the convention documented in CLAUDE.md).
+
+Behaviour:
+- Idempotent: if the bullet text already appears anywhere in the Unreleased
+  block, nothing is written (safe across the monitor's weekly force-push reruns).
+- Replaces the ``_No unreleased changes yet._`` placeholder when present.
+- Creates the ``### <category>`` subheading in canonical Keep-a-Changelog order
+  if it does not exist yet, otherwise appends to the existing one.
+
+Usage:
+    changelog_add_bullet.py <Category> <bullet text without leading "- ">
+
+Exit status is always 0 on success (including the idempotent no-op).
+"""
+
+import sys
+
+CHANGELOG = "CHANGELOG.md"
+# Canonical Keep a Changelog 1.1.0 ordering; only these are allowed as ### heads.
+CATEGORIES = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]
+PLACEHOLDER = "_No unreleased changes yet._"
+
+
+def normalize(block):
+    """Collapse repeated blank lines; pad with exactly one blank line each side."""
+    out = []
+    for line in block:
+        if line.strip() == "" and (not out or out[-1].strip() == ""):
+            continue
+        out.append(line)
+    while out and out[0].strip() == "":
+        out.pop(0)
+    while out and out[-1].strip() == "":
+        out.pop()
+    return [""] + out + [""]
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("usage: changelog_add_bullet.py <Category> <bullet text>")
+    category, bullet = sys.argv[1], sys.argv[2]
+    if category not in CATEGORIES:
+        sys.exit(f"category must be one of {CATEGORIES}, got {category!r}")
+
+    lines = open(CHANGELOG, encoding="utf-8").read().split("\n")
+
+    try:
+        start = next(i for i, l in enumerate(lines) if l.strip() == "## [Unreleased]")
+    except StopIteration:
+        sys.exit("could not find '## [Unreleased]' heading in CHANGELOG.md")
+    end = next(
+        (i for i in range(start + 1, len(lines)) if lines[i].startswith("## [")),
+        len(lines),
+    )
+    block = lines[start + 1 : end]
+
+    bullet_line = f"- {bullet}"
+    if any(bullet.strip() in l for l in block):
+        print("changelog: bullet already present; no change")
+        return
+
+    block = [l for l in block if l.strip() != PLACEHOLDER]
+
+    cat_head = f"### {category}"
+    head_idx = next((i for i, l in enumerate(block) if l.strip() == cat_head), None)
+    if head_idx is not None:
+        # Append after the last contiguous bullet of this subsection.
+        last = head_idx
+        for k in range(head_idx + 1, len(block)):
+            if block[k].startswith("- "):
+                last = k
+            elif block[k].startswith("### "):
+                break
+        block.insert(last + 1, bullet_line)
+    else:
+        # Create the subheading in canonical order relative to existing ones.
+        rank = {c: i for i, c in enumerate(CATEGORIES)}
+        mine = rank[category]
+        insert_at = len(block)
+        for i, l in enumerate(block):
+            s = l.strip()
+            if s.startswith("### "):
+                other = s[4:].strip()
+                if rank.get(other, 999) > mine:
+                    insert_at = i
+                    break
+        block[insert_at:insert_at] = ["", cat_head, "", bullet_line]
+
+    new_lines = lines[: start + 1] + normalize(block) + lines[end:]
+    open(CHANGELOG, "w", encoding="utf-8").write("\n".join(new_lines))
+    print(f"changelog: added under [Unreleased] ### {category}: {bullet}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/changelog_release.py
+++ b/scripts/changelog_release.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Roll the ``## [Unreleased]`` section into a tagged version section.
+
+Used by the publish workflow at release time. Moves everything currently under
+``## [Unreleased]`` into a new ``## [<version>] - <date>`` section, resets
+Unreleased to the placeholder, and fixes the link-reference block at the bottom:
+
+- ``[Unreleased]`` now compares ``v<version>...HEAD``
+- a new ``[<version>]`` line compares ``<prev_tag>...v<version>``
+
+The compare-URL base is read from the existing ``[Unreleased]:`` reference, so
+nothing about the repo URL is hardcoded here.
+
+Usage:
+    changelog_release.py <version> <date YYYY-MM-DD> <prev_tag e.g. v0.10.3>
+
+Refuses (exit 1) if the Unreleased section has no real content — you should not
+cut a release with an empty changelog.
+"""
+
+import re
+import sys
+
+CHANGELOG = "CHANGELOG.md"
+PLACEHOLDER = "_No unreleased changes yet._"
+
+
+def main():
+    if len(sys.argv) != 4:
+        sys.exit("usage: changelog_release.py <version> <date> <prev_tag>")
+    version, date, prev_tag = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    lines = open(CHANGELOG, encoding="utf-8").read().split("\n")
+
+    start = next(
+        (i for i, l in enumerate(lines) if l.strip() == "## [Unreleased]"), None
+    )
+    if start is None:
+        sys.exit("could not find '## [Unreleased]' heading")
+    end = next(
+        (i for i in range(start + 1, len(lines)) if lines[i].startswith("## [")),
+        len(lines),
+    )
+
+    body = [l for l in lines[start + 1 : end] if l.strip()]
+    if not body or all(l.strip() == PLACEHOLDER for l in body):
+        sys.exit("refusing to release: [Unreleased] has no content")
+
+    # Trim leading/trailing blanks from the moved body.
+    moved = lines[start + 1 : end]
+    while moved and moved[0].strip() == "":
+        moved.pop(0)
+    while moved and moved[-1].strip() == "":
+        moved.pop()
+
+    new_unreleased = [
+        "## [Unreleased]",
+        "",
+        PLACEHOLDER,
+        "",
+        f"## [{version}] - {date}",
+        "",
+        *moved,
+        "",
+    ]
+    lines = lines[:start] + new_unreleased + lines[end:]
+
+    # Update the link-reference block.
+    ur_idx = next(
+        (i for i, l in enumerate(lines) if l.startswith("[Unreleased]:")), None
+    )
+    if ur_idx is None:
+        sys.exit("could not find '[Unreleased]:' link reference")
+    m = re.match(r"(\[Unreleased\]:\s*)(\S+?)/compare/\S+\.\.\.HEAD\s*$", lines[ur_idx])
+    if not m:
+        sys.exit(f"unexpected [Unreleased] link format: {lines[ur_idx]!r}")
+    base = m.group(2)  # e.g. https://github.com/anentropic/duckdb-semantic-views
+    lines[ur_idx] = f"[Unreleased]: {base}/compare/v{version}...HEAD"
+    lines.insert(
+        ur_idx + 1,
+        f"[{version}]: {base}/compare/{prev_tag}...v{version}",
+    )
+
+    open(CHANGELOG, "w", encoding="utf-8").write("\n".join(lines))
+    print(f"changelog: released [{version}] - {date} (compare {prev_tag}...v{version})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to the question on PR #46: a DuckDB version-bump PR alone isn't sufficient to publish a new registry artifact. This wires up the missing pieces.

## What this adds

**1. Changelog entry in the bump PR** — `DuckDBVersionMonitor.yml` (both latest + LTS tracks) now records a `## [Unreleased]` → `### Changed` bullet for the pin bump, so a merged bump PR leaves `main` release-ready instead of half-done. Backed by `scripts/changelog_add_bullet.py` (idempotent — the monitor force-pushes its branch weekly; canonical Keep-a-Changelog ordering; replaces the `_No unreleased changes yet._` placeholder).

**2. Gated post-merge publish** — `PublishExtension.yml`: manual `workflow_dispatch`, runs in a `release` Environment (required-reviewer gate). Flow mirrors `just release`:

> gate → changelog roll → version bump → tag → `description.yml` sync → community-extensions PR

- **Registry-pin gate:** fetches `duckdb/community-extensions`'s `build.yml` and fails fast unless its `DUCKDB_VERSION` default matches our `.duckdb-version`. The registry builds every extension against one maintainer-pinned DuckDB version, which can lag the latest DuckDB release; this prevents submitting a descriptor whose source pins a newer DuckDB than the registry can build. Verified against the live file: registry `v1.5.4` vs `main` `v1.5.3` today → correctly blocks now, passes once #46 merges.
- `scripts/changelog_release.py` rolls `[Unreleased]` into `## [X.Y.Z] - <date>` and rewrites the compare-link refs (base parsed from the existing `[Unreleased]:` line).
- Treats a DuckDB-compat republish as a **patch release** — exactly what v0.10.1 was, done by hand. Feature milestones still bump minor/major manually.
- Has a `dry_run` input.

## Required one-time setup before the publish workflow can run

1. A `release` **Environment** with required reviewers (Settings → Environments) — the human gate.
2. Secret **`CE_PUBLISH_PAT`** — PAT that can push to the `anentropic/community-extensions` fork and open PRs against `duckdb/community-extensions` (falls back to `VERSION_MONITOR_PAT`).
3. If `main` is branch-protected, allow that token to push the release commits + tag.

## Notes

- Publish is **manual-only** by design. Auto-triggering on bump-PR merge (still behind the Environment approval) is a one-line `push:` trigger addition if preferred.
- The `sed` GNU-isms in `PublishExtension.yml` are correct for `ubuntu-latest` runners (not local macOS BSD `sed`); they live only in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)