### PR TITLE
Code-review remediation R0/R1: memory safety and expansion correctness (MS-1..3, FF-7, SG-1..17, TC-1/2/7)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -178,11 +178,17 @@ test-yaml-file-create: build
 test-readonly-fresh-drop: build
     uv run test/integration/test_drop_on_fresh_readonly_clear_error.py
 
+# Chunked-emission regression (MS-1, code-review 2026-07-02): bind-materialized
+# TFs (list/show/describe family) must emit >2048-row result sets across
+# multiple DataChunks instead of overflowing one chunk's capacity.
+test-chunk-boundary: build
+    uv run test/integration/test_chunk_boundary.py
+
 # All Python integration suites against the built extension. This is the
 # exact set the `python-integration` CI job runs (IntegrationChecks.yml) —
 # keep the two in sync by editing THIS recipe, not the workflow.
 # (test-ducklake-ci is excluded: it has its own dedicated CI job.)
-test-integration: test-vtab-crash test-caret test-adbc test-adbc-queries test-large-view test-multi-db test-readonly test-concurrent test-load-idempotent test-yaml-file-create test-readonly-fresh-drop
+test-integration: test-vtab-crash test-caret test-adbc test-adbc-queries test-large-view test-multi-db test-readonly test-concurrent test-load-idempotent test-yaml-file-create test-readonly-fresh-drop test-chunk-boundary
 
 # Run all tests: Rust unit tests + SQL logic tests + DuckLake integration + all Python integration suites
 # Note: test-iceberg requires `just setup-ducklake` first. test-ducklake-ci uses synthetic data.

--- a/Justfile
+++ b/Justfile
@@ -184,11 +184,18 @@ test-readonly-fresh-drop: build
 test-chunk-boundary: build
     uv run test/integration/test_chunk_boundary.py
 
+# Differential harness (TC-2, code-review 2026-07-02): semantic_view() results
+# vs independent hand-written SQL over a seeded randomized star schema, every
+# bounded dims×metrics combination. R1 fix PRs extend it with the scenarios
+# they repair.
+test-differential: build
+    uv run test/integration/test_differential.py
+
 # All Python integration suites against the built extension. This is the
 # exact set the `python-integration` CI job runs (IntegrationChecks.yml) —
 # keep the two in sync by editing THIS recipe, not the workflow.
 # (test-ducklake-ci is excluded: it has its own dedicated CI job.)
-test-integration: test-vtab-crash test-caret test-adbc test-adbc-queries test-large-view test-multi-db test-readonly test-concurrent test-load-idempotent test-yaml-file-create test-readonly-fresh-drop test-chunk-boundary
+test-integration: test-vtab-crash test-caret test-adbc test-adbc-queries test-large-view test-multi-db test-readonly test-concurrent test-load-idempotent test-yaml-file-create test-readonly-fresh-drop test-chunk-boundary test-differential
 
 # Run all tests: Rust unit tests + SQL logic tests + DuckLake integration + all Python integration suites
 # Note: test-iceberg requires `just setup-ducklake` first. test-ducklake-ci uses synthetic data.

--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -990,7 +990,13 @@ struct ListSemanticViewsBindData : public TableFunctionData {
 };
 
 struct ListSemanticViewsLocalState : public LocalTableFunctionState {
-    bool emitted = false;
+    // Next row to emit. Bind-materialized row sets can exceed one
+    // DataChunk's capacity (STANDARD_VECTOR_SIZE = 2048), so the exec
+    // callback must emit in chunks and resume from this cursor — a
+    // single-shot `emitted` flag overflowed the chunk for >2048 rows
+    // (writes past the vector's data buffer; no bounds check in
+    // release builds).
+    idx_t next_row = 0;
 };
 
 // Helper: read a little-endian u32 from buf[offset..offset+4] and advance.
@@ -1136,21 +1142,24 @@ static void sv_list_semantic_views_function(
             "sv_list_semantic_views_function: local_state missing despite init_local registration");
     }
     auto &state = state_p->Cast<ListSemanticViewsLocalState>();
-    if (state.emitted) {
+    idx_t total = bd.rows.size();
+    if (state.next_row >= total) {
         output.SetCardinality(0);
         return;
     }
-    idx_t n = bd.rows.size();
-    for (idx_t i = 0; i < n; ++i) {
-        output.SetValue(0, i, Value(bd.rows[i].created_on));
-        output.SetValue(1, i, Value(bd.rows[i].name));
-        output.SetValue(2, i, Value(bd.rows[i].kind));
-        output.SetValue(3, i, Value(bd.rows[i].database_name));
-        output.SetValue(4, i, Value(bd.rows[i].schema_name));
-        output.SetValue(5, i, Value(bd.rows[i].comment));
+    idx_t remaining = total - state.next_row;
+    idx_t count = remaining < STANDARD_VECTOR_SIZE ? remaining : STANDARD_VECTOR_SIZE;
+    for (idx_t i = 0; i < count; ++i) {
+        const auto &row = bd.rows[state.next_row + i];
+        output.SetValue(0, i, Value(row.created_on));
+        output.SetValue(1, i, Value(row.name));
+        output.SetValue(2, i, Value(row.kind));
+        output.SetValue(3, i, Value(row.database_name));
+        output.SetValue(4, i, Value(row.schema_name));
+        output.SetValue(5, i, Value(row.comment));
     }
-    output.SetCardinality(n);
-    state.emitted = true;
+    output.SetCardinality(count);
+    state.next_row += count;
 }
 
 extern "C" {
@@ -1188,7 +1197,11 @@ struct SvVarcharBindData : public TableFunctionData {
 };
 
 struct SvVarcharLocalState : public LocalTableFunctionState {
-    bool emitted = false;
+    // Next row to emit — see ListSemanticViewsLocalState::next_row for why
+    // this is a cursor and not a single-shot flag (chunked emission past
+    // STANDARD_VECTOR_SIZE rows). Shared by sv_emit_varchar_rows and
+    // sv_emit_varchar_bool_rows.
+    idx_t next_row = 0;
 };
 
 // Parse a length-prefixed VARCHAR wire-format payload into bd.rows. The
@@ -1242,19 +1255,21 @@ static void sv_emit_varchar_rows(
             "sv_emit_varchar_rows: local_state missing despite init_local registration");
     }
     auto &state = state_p->Cast<SvVarcharLocalState>();
-    if (state.emitted) {
+    idx_t total = bd.rows.size();
+    if (state.next_row >= total) {
         output.SetCardinality(0);
         return;
     }
-    idx_t n = bd.rows.size();
-    for (idx_t i = 0; i < n; ++i) {
-        const auto &row = bd.rows[i];
+    idx_t remaining = total - state.next_row;
+    idx_t count = remaining < STANDARD_VECTOR_SIZE ? remaining : STANDARD_VECTOR_SIZE;
+    for (idx_t i = 0; i < count; ++i) {
+        const auto &row = bd.rows[state.next_row + i];
         for (size_t c = 0; c < row.size(); ++c) {
             output.SetValue(c, i, Value(row[c]));
         }
     }
-    output.SetCardinality(n);
-    state.emitted = true;
+    output.SetCardinality(count);
+    state.next_row += count;
 }
 
 // VARCHAR-rows-with-trailing-BOOL shape (used by
@@ -1313,21 +1328,23 @@ static void sv_emit_varchar_bool_rows(
             "sv_emit_varchar_bool_rows: local_state missing despite init_local registration");
     }
     auto &state = state_p->Cast<SvVarcharLocalState>();
-    if (state.emitted) {
+    idx_t total = bd.rows.size();
+    if (state.next_row >= total) {
         output.SetCardinality(0);
         return;
     }
-    idx_t n = bd.rows.size();
-    for (idx_t i = 0; i < n; ++i) {
-        const auto &strs = bd.rows[i].first;
+    idx_t remaining = total - state.next_row;
+    idx_t count = remaining < STANDARD_VECTOR_SIZE ? remaining : STANDARD_VECTOR_SIZE;
+    for (idx_t i = 0; i < count; ++i) {
+        const auto &strs = bd.rows[state.next_row + i].first;
         for (size_t c = 0; c < strs.size(); ++c) {
             output.SetValue(c, i, Value(strs[c]));
         }
         // BOOLEAN trailing column at index strs.size().
-        output.SetValue(strs.size(), i, Value::BOOLEAN(bd.rows[i].second));
+        output.SetValue(strs.size(), i, Value::BOOLEAN(bd.rows[state.next_row + i].second));
     }
-    output.SetCardinality(n);
-    state.emitted = true;
+    output.SetCardinality(count);
+    state.next_row += count;
 }
 
 // Common idiom for the bind callback: open Connection, run Rust dispatcher

--- a/docs/how-to/materializations.rst
+++ b/docs/how-to/materializations.rst
@@ -154,7 +154,7 @@ Routing Exclusions
 
 Two kinds of metrics are **always excluded** from materialization routing, even when a materialization declaration covers them:
 
-- **Semi-additive metrics** (declared with ``NON ADDITIVE BY``): These require snapshot selection logic (ROW_NUMBER CTE) that cannot be pre-computed in a materialization table.
+- **Semi-additive metrics** (declared with ``NON ADDITIVE BY``): These require snapshot selection logic (RANK CTE) that cannot be pre-computed in a materialization table.
 - **Window metrics** (declared with ``OVER``): These require CTE-based window expansion that depends on the queried dimensions.
 
 When a query includes any semi-additive or window metric, the extension skips all materializations and falls back to standard expansion, regardless of whether a matching materialization exists.

--- a/docs/how-to/materializations.rst
+++ b/docs/how-to/materializations.rst
@@ -275,6 +275,34 @@ Each materialization entry must declare at least one dimension or one metric. A 
 See :ref:`ref-error-messages` for the full list of materialization validation errors.
 
 
+.. _howto-materializations-staleness:
+
+Staleness and validation caveats
+================================
+
+Materialization tables are user-owned pre-aggregations. The routing engine
+matches a request against a materialization by **name sets only** -- it does
+not validate that the table's contents agree with the view's current metric
+expressions, nor that the table is fresh:
+
+- If you redefine a metric's expression with ``CREATE OR REPLACE SEMANTIC
+  VIEW`` but keep the metric name, routed queries keep returning the old
+  pre-aggregated numbers until you rebuild the table.
+- If the base tables change after the pre-aggregation was built, routed
+  results are stale until you rebuild it.
+- A missing or misnamed column in the materialization table surfaces as a
+  binder error at query time (the routed SQL selects columns by dimension
+  and metric name).
+
+Rebuild materialization tables whenever the underlying data or the view
+definition changes. Use :ref:`ref-explain-semantic-view` to confirm whether
+a given request routes to a materialization or falls back to raw expansion.
+
+Dimensions-only routed queries apply ``SELECT DISTINCT``, matching the raw
+expansion path's semantics, so duplicate rows in a pre-aggregation table do
+not change dimension listings.
+
+
 .. _howto-materializations-related:
 
 Related

--- a/docs/how-to/semi-additive-metrics.rst
+++ b/docs/how-to/semi-additive-metrics.rst
@@ -105,7 +105,7 @@ Snapshot Behavior
 The semi-additive expansion depends on whether the non-additive dimensions are present in the query:
 
 **Non-additive dimension NOT in query (active):**
-   The extension generates a CTE with ``ROW_NUMBER() OVER (PARTITION BY <queried dims> ORDER BY <NA dims>)`` to select one snapshot row per group, then aggregates over the filtered rows. This is the snapshot selection behavior.
+   The extension generates a CTE with ``RANK() OVER (PARTITION BY <queried dims> ORDER BY <NA dims>)`` to select the snapshot rows per group, then aggregates over the filtered rows. ``RANK()`` means every row tied at the snapshot ordering value (e.g. several accounts sharing the same latest date within a group) shares rank 1 and is included in the aggregation. This is the snapshot selection behavior.
 
 .. code-block:: sql
 
@@ -128,6 +128,8 @@ The semi-additive expansion depends on whether the non-additive dimensions are p
 
 **Mixed regular and semi-additive metrics:**
    Regular metrics and semi-additive metrics can coexist in the same query. The CTE includes both, but only the semi-additive metrics get the ``CASE WHEN __sv_rn = 1`` conditional aggregation. Regular metrics aggregate over all rows.
+
+   Every metric in such a query (including the semi-additive metric itself) must be a single aggregate call ``SUM/COUNT/AVG/MIN/MAX(<expression>)`` -- the CTE decomposes each metric into a per-row column plus an outer re-aggregation. Shapes that cannot be decomposed (``COUNT(*)``, ``DISTINCT`` aggregates, arithmetic around the aggregate like ``SUM(x) * 0.1``, ``COALESCE``-wrapped aggregates, derived metrics) produce a clear error telling you to query them separately from the semi-additive metric.
 
 
 .. _howto-semi-additive-verify:
@@ -152,7 +154,7 @@ The ``sql`` column shows the generated query:
        SELECT
            "accounts"."customer_id",
            "accounts"."balance",
-           ROW_NUMBER() OVER (
+           RANK() OVER (
                PARTITION BY "accounts"."customer_id"
                ORDER BY "accounts"."report_date" DESC NULLS FIRST
            ) AS __sv_rn
@@ -164,7 +166,7 @@ The ``sql`` column shows the generated query:
    FROM __sv_snapshot
    GROUP BY "customer_id"
 
-The CTE assigns a row number per ``customer_id`` ordered by ``report_date DESC``, so row 1 is the latest snapshot. The outer query then aggregates only those latest rows via ``CASE WHEN __sv_rn = 1``.
+The CTE assigns a rank per ``customer_id`` ordered by ``report_date DESC``, so rank 1 is the latest snapshot -- including every row tied at that latest value. The outer query then aggregates only those latest rows via ``CASE WHEN __sv_rn = 1``.
 
 
 .. _howto-semi-additive-restrictions:
@@ -189,4 +191,4 @@ Troubleshooting
    Use :ref:`explain_semantic_view() <ref-explain-semantic-view>` to verify whether the CTE is generated. If all Non-additive dimensions are in the query, the metric behaves as a regular additive metric and no CTE is produced. Remove the Non-additive dimension from the query to activate snapshot selection.
 
 **Performance with multiple Non-Additive dimension sets**
-   When multiple semi-additive metrics have different ``NON ADDITIVE BY`` dimensions, each gets its own ``ROW_NUMBER`` column in the CTE (``__sv_rn_1``, ``__sv_rn_2``, etc.). This is functionally correct but adds window function overhead.
+   When multiple semi-additive metrics have different ``NON ADDITIVE BY`` dimensions, each gets its own ``RANK`` column in the CTE (``__sv_rn_1``, ``__sv_rn_2``, etc.). This is functionally correct but adds window function overhead.

--- a/docs/reference/create-semantic-view.rst
+++ b/docs/reference/create-semantic-view.rst
@@ -332,7 +332,7 @@ Declares named aggregation expressions, derived metrics, semi-additive metrics, 
            NON ADDITIVE BY (report_date DESC NULLS FIRST)
    )
 
-When a query does not include the non-additive dimension, the extension generates a CTE with ``ROW_NUMBER`` to select one snapshot row per group before aggregating. When the non-additive dimension is included in the query, the metric behaves as a standard additive metric.
+When a query does not include the non-additive dimension, the extension generates a CTE with ``RANK`` to select the snapshot rows per group before aggregating (rows tied at the snapshot ordering value all aggregate). When the non-additive dimension is included in the query, the metric behaves as a standard additive metric.
 
 See :ref:`howto-semi-additive` for details.
 

--- a/docs/reference/error-messages.rst
+++ b/docs/reference/error-messages.rst
@@ -118,20 +118,23 @@ Unclosed parenthesis
 
 .. _ref-err-name-uniqueness:
 
-Duplicate dimension name
-------------------------
+Duplicate or colliding names
+----------------------------
 
 .. code-block:: text
 
-   duplicate dimension name '<name>'
+   duplicate name '<name>': <kind> '<name>' collides with <kind> '<other>'
+   -- dimension, metric, and fact names share one namespace and are
+   case-insensitive
 
-**Cause:** Two or more dimensions in the same semantic view share the same name. The comparison is case-insensitive, so ``region`` and ``Region`` are considered duplicates.
+**Cause:** Two items in the same semantic view share a name. Dimensions, metrics, and facts are resolved from one namespace at query time, so the collision may be within a kind (two metrics named ``revenue``) or across kinds (a dimension and a metric both named ``amount``). The comparison is case-insensitive, so ``region`` and ``Region`` collide.
 
-**Fix:** Rename one of the dimensions so that all dimension names are unique (ignoring case).
+**Fix:** Rename one of the items so that every dimension, metric, and fact name is unique (ignoring case).
 
 .. code-block:: sql
 
-   -- This will fail: "duplicate dimension name 'Region'"
+   -- This will fail: "duplicate name 'Region': dimension 'Region' collides
+   -- with dimension 'region' ..."
    DIMENSIONS (
        o.region AS o.region,
        c.Region AS c.sales_region
@@ -143,33 +146,10 @@ Duplicate dimension name
        c.customer_region AS c.sales_region
    )
 
-
-Duplicate metric name
----------------------
-
-.. code-block:: text
-
-   duplicate metric name '<name>'
-
-**Cause:** Two or more metrics (base or derived) in the same semantic view share the same name. The comparison is case-insensitive.
-
-**Fix:** Rename one of the metrics so that all metric names are unique (ignoring case).
-
-
-Dimension-metric name collision
--------------------------------
-
-.. code-block:: text
-
-   name '<name>' is used as both a dimension and a metric
-
-**Cause:** A dimension and a metric share the same name. The comparison is case-insensitive, so a dimension named ``amount`` and a metric named ``Amount`` collide.
-
-**Fix:** Rename either the dimension or the metric so that names are unique across both categories.
-
 .. code-block:: sql
 
-   -- This will fail: "name 'amount' is used as both a dimension and a metric"
+   -- This will fail: "duplicate name 'Amount': metric 'Amount' collides
+   -- with dimension 'amount' ..."
    DIMENSIONS (
        o.amount AS o.amount_category
    )
@@ -187,7 +167,7 @@ Dimension-metric name collision
 
 .. note::
 
-   All three name uniqueness checks run at ``CREATE`` time, before the view definition is persisted. They are independent of the query-time duplicate checks described in :ref:`the next section <ref-err-query>`, which catch the same dimension or metric being requested twice in a single ``semantic_view()`` call.
+   The name uniqueness check runs at ``CREATE`` (and ``ALTER``) time, before the view definition is persisted. It is independent of the query-time duplicate checks described in :ref:`the next section <ref-err-query>`, which catch the same dimension or metric being requested twice in a single ``semantic_view()`` call. Semantic views created before this check existed keep working at query time: lookups resolve to the first declaration.
 
 
 Graph validation errors
@@ -561,9 +541,27 @@ Duplicate dimension or metric
 
    semantic view '<view>': duplicate metric '<name>'
 
-**Cause:** The same dimension or metric name appears more than once in the request.
+**Cause:** The same dimension or metric appears more than once in the request. Duplicates are detected on the *resolved* item, so requesting both the bare and the table-qualified spelling of the same item (``'region'`` and ``'o.region'``) is also rejected.
 
 **Fix:** Remove the duplicate from the ``dimensions`` or ``metrics`` list.
+
+
+COUNT(*) on a joined table requires a PRIMARY KEY
+-------------------------------------------------
+
+.. code-block:: text
+
+   semantic view '<view>': metric '<name>' uses COUNT(*) on joined table
+   '<alias>'. The generated LEFT JOIN produces one NULL-extended row per
+   base-table row with no match in '<alias>', which COUNT(*) would count --
+   so the expansion rewrites COUNT(*) to COUNT(<primary key>) for non-base
+   tables, but table '<alias>' has no PRIMARY KEY declared in the TABLES
+   clause. Add PRIMARY KEY (cols) to '<alias>' or use an explicit column:
+   COUNT(<alias>.<column>).
+
+**Cause:** A queried metric (directly, via a derived metric, or as a window metric's inner aggregate) is ``COUNT(*)`` on a table other than the base table. Generated joins are ``LEFT JOIN``\ s, so ``COUNT(*)`` would also count the NULL-extended row produced for each base row with no match — silently inflating the result. The expansion protects against this by rewriting ``COUNT(*)`` to ``COUNT(<first primary key column>)`` for non-base source tables, which requires the table to declare a ``PRIMARY KEY``.
+
+**Fix:** Declare ``PRIMARY KEY (<cols>)`` for the metric's source table in the ``TABLES`` clause, or define the metric as ``COUNT(<alias>.<column>)`` over a NOT NULL column.
 
 
 Fan trap detected

--- a/docs/reference/error-messages.rst
+++ b/docs/reference/error-messages.rst
@@ -596,6 +596,37 @@ Ambiguous dimension path
 **Fix:** See :ref:`howto-role-playing`. Add a metric with ``USING (<rel_name>)`` to disambiguate, or use a dimension from a table that is not a role-playing target.
 
 
+Metric cannot be co-queried with a semi-additive metric
+--------------------------------------------------------
+
+.. code-block:: text
+
+   semantic view '<view>': metric '<name>' (expression: <expr>) cannot be
+   co-queried with semi-additive metric '<semi>': <reason>. Snapshot expansion
+   for NON ADDITIVE BY requires every co-queried metric to be a single
+   aggregate call SUM/COUNT/AVG/MIN/MAX(<expression>) without '*', DISTINCT,
+   or surrounding expression text. Query '<name>' and '<semi>' separately.
+
+**Cause:** The query mixes an active semi-additive metric (its ``NON ADDITIVE BY`` dimension is not in the query) with a metric whose expression cannot be decomposed for the snapshot CTE: ``COUNT(*)``, a ``DISTINCT`` aggregate, arithmetic around the aggregate (``SUM(x) * 0.1``), a wrapped aggregate (``COALESCE(SUM(x), 0)``), or a derived metric.
+
+**Fix:** Query the two metrics separately, or redefine the co-queried metric as a single bare aggregate call (e.g. ``COUNT(<pk_column>)`` instead of ``COUNT(*)``).
+
+
+Semi-additive metric expression cannot be expanded
+---------------------------------------------------
+
+.. code-block:: text
+
+   semantic view '<view>': semi-additive metric '<name>' (expression: <expr>)
+   cannot be expanded: <reason>. NON ADDITIVE BY snapshot expansion requires
+   the metric to be a single aggregate call SUM/COUNT/AVG/MIN/MAX(<expression>)
+   without '*' or DISTINCT.
+
+**Cause:** The ``NON ADDITIVE BY`` metric's own expression is not a single decomposable aggregate call, so the snapshot CTE cannot split it into a per-row column plus an outer re-aggregation.
+
+**Fix:** Redefine the metric as a single aggregate call over a plain expression (e.g. ``SUM(a.balance)``).
+
+
 Private metric
 --------------
 

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -10,7 +10,7 @@
 
 use std::path::PathBuf;
 
-use duckdb::{Connection, Result};
+use duckdb::Connection;
 
 // Extension appended to the DuckDB file path to form the v0.1.0 companion file.
 // Used only in the one-time migration below. After the migration runs, the
@@ -28,7 +28,11 @@ const V010_COMPANION_EXT: &str = "semantic_views";
 /// companion-file migration (which INSERTs into the table) can run.
 /// Reader-path code in `CatalogReader` short-circuits separately when
 /// the table is genuinely absent. See 63-RESEARCH.md §3 Q2.
-pub fn init_catalog(con: &Connection, db_path: &str, is_read_only: bool) -> Result<()> {
+pub fn init_catalog(
+    con: &Connection,
+    db_path: &str,
+    is_read_only: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     if is_read_only {
         return Ok(());
     }
@@ -53,19 +57,43 @@ pub fn init_catalog(con: &Connection, db_path: &str, is_read_only: bool) -> Resu
             p
         };
         if migration_path.exists() {
-            if let Ok(contents) = std::fs::read_to_string(&migration_path) {
-                if let Ok(migrated) =
-                    serde_json::from_str::<std::collections::HashMap<String, String>>(&contents)
-                {
-                    for (name, def) in &migrated {
-                        con.execute(
-                            "INSERT OR REPLACE INTO semantic_layer._definitions (name, definition) VALUES (?, ?)",
-                            duckdb::params![name, def],
-                        )?;
-                    }
-                }
+            let contents = std::fs::read_to_string(&migration_path).map_err(|e| {
+                format!(
+                    "semantic_views: cannot read v0.1.0 companion file '{}': {e}. \
+                     The file was left in place — fix its permissions (or move it \
+                     away to skip migration) and re-LOAD.",
+                    migration_path.display()
+                )
+            })?;
+            let migrated: std::collections::HashMap<String, String> =
+                serde_json::from_str(&contents).map_err(|e| {
+                    format!(
+                        "semantic_views: v0.1.0 companion file '{}' is not valid JSON: {e}. \
+                         The file was left in place so its definitions are not lost — \
+                         repair it (or move it away to skip migration) and re-LOAD.",
+                        migration_path.display()
+                    )
+                })?;
+            for (name, def) in &migrated {
+                con.execute(
+                    "INSERT OR REPLACE INTO semantic_layer._definitions (name, definition) VALUES (?, ?)",
+                    duckdb::params![name, def],
+                )?;
             }
-            let _ = std::fs::remove_file(&migration_path);
+            // Delete ONLY after a fully successful import. Pre-fix the file was
+            // removed even when unreadable or corrupt, permanently destroying
+            // the user's pre-v0.2 definitions. A failed delete must also be an
+            // error: if the file survives, every subsequent LOAD re-imports
+            // this (now stale) snapshot over newer definitions via
+            // INSERT OR REPLACE.
+            std::fs::remove_file(&migration_path).map_err(|e| {
+                format!(
+                    "semantic_views: imported v0.1.0 companion file '{}' but could \
+                     not delete it: {e}. Delete it manually before the next LOAD to \
+                     avoid re-importing stale definitions.",
+                    migration_path.display()
+                )
+            })?;
         }
     }
 
@@ -453,6 +481,71 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[cfg(not(feature = "extension"))]
+    #[test]
+    fn migration_corrupt_companion_file_errors_and_survives() {
+        // MS-2 (code-review 2026-07-02): pre-fix, an unreadable or corrupt
+        // v0.1.0 companion file was silently DELETED without importing —
+        // permanent loss of pre-v0.2 definitions. Post-fix init_catalog must
+        // error, and the file must be left in place for the user to repair.
+        let tmp = std::env::temp_dir();
+        let db_path_buf = tmp.join("test_ms2_corrupt.duckdb");
+        let db_path = db_path_buf.to_str().expect("temp dir is UTF-8");
+        let companion = tmp.join("test_ms2_corrupt.duckdb.semantic_views");
+        let _ = std::fs::remove_file(db_path);
+        let _ = std::fs::remove_file(&companion);
+
+        std::fs::write(&companion, "{not valid json").unwrap();
+        let con = Connection::open(db_path).expect("open file-backed DB");
+        let err = init_catalog(&con, db_path, false)
+            .expect_err("corrupt companion file must fail the load");
+        assert!(
+            err.to_string().contains("not valid JSON"),
+            "error should name the problem, got: {err}"
+        );
+        assert!(
+            companion.exists(),
+            "corrupt companion file must be left in place, not deleted"
+        );
+
+        let _ = std::fs::remove_file(db_path);
+        let _ = std::fs::remove_file(&companion);
+    }
+
+    #[cfg(not(feature = "extension"))]
+    #[test]
+    fn migration_valid_companion_file_imports_then_deletes() {
+        let tmp = std::env::temp_dir();
+        let db_path_buf = tmp.join("test_ms2_valid.duckdb");
+        let db_path = db_path_buf.to_str().expect("temp dir is UTF-8");
+        let companion = tmp.join("test_ms2_valid.duckdb.semantic_views");
+        let _ = std::fs::remove_file(db_path);
+        let _ = std::fs::remove_file(&companion);
+
+        std::fs::write(
+            &companion,
+            r#"{"orders": "{\"base_table\":\"orders\",\"dimensions\":[],\"metrics\":[]}"}"#,
+        )
+        .unwrap();
+        let con = Connection::open(db_path).expect("open file-backed DB");
+        init_catalog(&con, db_path, false).expect("valid companion file imports cleanly");
+
+        let count: i64 = con
+            .query_row(
+                "SELECT count(*) FROM semantic_layer._definitions WHERE name = 'orders'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "companion definition should be imported");
+        assert!(
+            !companion.exists(),
+            "companion file should be deleted after a successful import"
+        );
+
+        let _ = std::fs::remove_file(db_path);
     }
 
     #[cfg(not(feature = "extension"))]

--- a/src/ddl/define.rs
+++ b/src/ddl/define.rs
@@ -122,7 +122,12 @@ pub fn enrich_definition_for_create(
         ));
     }
 
-    // 3. Graph validations.
+    // 3. Graph validations. Name uniqueness runs first (SG-13): dimensions,
+    //    metrics, and facts share one request namespace at query time, so
+    //    collisions -- within a kind or across kinds, case-insensitive --
+    //    are rejected at define time. Read paths keep first-match behavior
+    //    for legacy catalog rows that predate this check.
+    crate::graph::validate_name_uniqueness(&def)?;
     crate::graph::validate_graph(&def)?;
     crate::graph::validate_facts(&def)?;
     crate::graph::validate_derived_metrics(&def)?;

--- a/src/expand/facts.rs
+++ b/src/expand/facts.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::model::Fact;
-use crate::util::{is_word_boundary_char, replace_word_boundary, replace_word_boundary_any};
+use crate::util::{is_word_boundary_char, replace_word_boundary_any, replace_word_boundary_pairs};
 
 /// Maximum allowed nesting depth for derived metric resolution.
 /// Prevents stack overflow from deeply nested metric chains that pass
@@ -353,15 +353,30 @@ pub(super) fn inline_derived_metrics(
     for idx in derived_topo {
         let met = derived[idx].1;
         // Start with the raw expression, with facts inlined first
-        let mut expr = if facts.is_empty() {
+        let raw_expr = if facts.is_empty() {
             met.expr.clone()
         } else {
             inline_facts(&met.expr, facts, fact_topo_order)
         };
-        // Replace each known metric name with its resolved expression (parenthesized)
-        for (name, replacement) in &resolved {
-            expr = replace_word_boundary(&expr, name, &format!("({replacement})"));
-        }
+        // Replace every known metric name with its resolved expression
+        // (parenthesized) in ONE combined left-to-right pass. Sequential
+        // per-name replace_word_boundary calls iterated the HashMap in
+        // nondeterministic order and re-scanned earlier substitutions: a
+        // metric named like a column used in another metric's expression
+        // (`revenue` vs `SUM(o.revenue)` — `.` is a word boundary) was
+        // double-substituted into invalid nested-aggregate SQL on a
+        // hash-seed-dependent fraction of runs (SG-3, code-review
+        // 2026-07-02). Pair order is deterministic (longest needle first,
+        // then lexicographic), mirroring `inline_facts`.
+        let expr = {
+            let mut entries: Vec<(&str, String)> = resolved
+                .iter()
+                .map(|(name, replacement)| (name.as_str(), format!("({replacement})")))
+                .collect();
+            entries.sort_by(|(a, _), (b, _)| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+            let pairs: Vec<(&str, &str)> = entries.iter().map(|(n, r)| (*n, r.as_str())).collect();
+            replace_word_boundary_pairs(&raw_expr, &pairs)
+        };
         resolved.insert(met.name.to_ascii_lowercase(), expr);
     }
 
@@ -480,6 +495,48 @@ mod tests {
     #[test]
     fn max_derivation_depth_constant() {
         assert_eq!(MAX_DERIVATION_DEPTH, 64);
+    }
+
+    #[test]
+    fn inline_derived_metrics_name_matching_column_is_not_double_substituted() {
+        // SG-3 regression (code-review 2026-07-02): metric `revenue` also
+        // appears as the column reference `o.revenue` inside `tax`'s
+        // expression (`.` is a word boundary). The old sequential per-name
+        // substitution re-scanned inserted text in HashMap iteration order:
+        // when `tax` happened to be inlined first, the subsequent `revenue`
+        // pass also matched `revenue` inside the freshly inserted
+        // `SUM(o.revenue * 0.1)`, corrupting the expression into invalid
+        // nested-aggregate SQL on a hash-seed-dependent fraction of runs.
+        // The single combined pass must produce this exact expression, every
+        // run.
+        let metrics = vec![
+            make_metric("revenue", "SUM(o.revenue)", Some("o")),
+            make_metric("tax", "SUM(o.revenue * 0.1)", Some("o")),
+            make_metric("after_tax", "revenue - tax", None),
+        ];
+        let resolved = inline_derived_metrics(&metrics, &[], &[]).unwrap();
+        assert_eq!(
+            resolved.get("after_tax").unwrap(),
+            "(SUM(o.revenue)) - (SUM(o.revenue * 0.1))"
+        );
+    }
+
+    #[test]
+    fn inline_derived_metrics_chained_derived_not_rescanned() {
+        // A derived metric referencing another derived metric: the inner
+        // resolution is inserted verbatim and must not be re-scanned even
+        // though it contains the names of other metrics.
+        let metrics = vec![
+            make_metric("revenue", "SUM(o.revenue)", Some("o")),
+            make_metric("cost", "SUM(o.cost)", Some("o")),
+            make_metric("profit", "revenue - cost", None),
+            make_metric("margin", "profit / revenue", None),
+        ];
+        let resolved = inline_derived_metrics(&metrics, &[], &[]).unwrap();
+        assert_eq!(
+            resolved.get("margin").unwrap(),
+            "((SUM(o.revenue)) - (SUM(o.cost))) / (SUM(o.revenue))"
+        );
     }
 
     #[test]

--- a/src/expand/facts.rs
+++ b/src/expand/facts.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::model::Fact;
+use crate::model::{Fact, TableRef};
 use crate::util::{is_word_boundary_char, replace_word_boundary_any, replace_word_boundary_pairs};
+
+use super::resolution::quote_ident;
 
 /// Maximum allowed nesting depth for derived metric resolution.
 /// Prevents stack overflow from deeply nested metric chains that pass
@@ -214,6 +216,93 @@ pub(super) fn inline_facts(expr: &str, facts: &[Fact], topo_order: &[usize]) -> 
     result
 }
 
+/// Replace every `COUNT(*)` call in `expr` with `COUNT(<replacement_arg>)`.
+///
+/// Matches `count` case-insensitively at a word boundary, followed by
+/// optional whitespace, `(`, optional whitespace, `*`, optional whitespace,
+/// `)` — i.e. `COUNT(*)`, `count( * )`, etc. The original casing of the
+/// function name is preserved; only the argument is replaced. Occurrences
+/// inside single-quoted SQL string literals are left untouched.
+///
+/// Returns `None` when the expression contains no `COUNT(*)` call.
+pub(super) fn rewrite_count_star(expr: &str, replacement_arg: &str) -> Option<String> {
+    let bytes = expr.as_bytes();
+    let mut out = String::with_capacity(expr.len() + replacement_arg.len());
+    let mut copied = 0usize; // byte offset copied into `out` so far
+    let mut pos = 0usize;
+    let mut in_string = false;
+    let mut changed = false;
+    while pos < bytes.len() {
+        let byte = bytes[pos];
+        if byte == b'\'' {
+            in_string = !in_string;
+            pos += 1;
+            continue;
+        }
+        if in_string {
+            pos += 1;
+            continue;
+        }
+        if (byte == b'c' || byte == b'C')
+            && pos + 5 <= bytes.len()
+            && bytes[pos..pos + 5].eq_ignore_ascii_case(b"count")
+            && (pos == 0 || is_word_boundary_char(bytes[pos - 1]))
+        {
+            let mut open_paren = pos + 5;
+            while open_paren < bytes.len() && bytes[open_paren].is_ascii_whitespace() {
+                open_paren += 1;
+            }
+            if open_paren < bytes.len() && bytes[open_paren] == b'(' {
+                let mut star = open_paren + 1;
+                while star < bytes.len() && bytes[star].is_ascii_whitespace() {
+                    star += 1;
+                }
+                if star < bytes.len() && bytes[star] == b'*' {
+                    let mut close_paren = star + 1;
+                    while close_paren < bytes.len() && bytes[close_paren].is_ascii_whitespace() {
+                        close_paren += 1;
+                    }
+                    if close_paren < bytes.len() && bytes[close_paren] == b')' {
+                        // All scanned offsets sit on ASCII bytes, so slicing
+                        // is char-boundary safe. Copy through the `(`, swap
+                        // the `*` (and its padding) for the replacement.
+                        out.push_str(&expr[copied..=open_paren]);
+                        out.push_str(replacement_arg);
+                        out.push(')');
+                        copied = close_paren + 1;
+                        pos = close_paren + 1;
+                        changed = true;
+                        continue;
+                    }
+                }
+            }
+        }
+        pos += 1;
+    }
+    if !changed {
+        return None;
+    }
+    out.push_str(&expr[copied..]);
+    Some(out)
+}
+
+/// Resolved metric expressions plus SG-8 rewrite failures.
+///
+/// Produced by [`inline_derived_metrics`]. `count_star_no_pk` is keyed by
+/// lowercased metric name and holds the lowercased source-table alias of each
+/// base metric whose `COUNT(*)` could NOT be rewritten (non-base source table
+/// with no PRIMARY KEY declared). Erroring is the caller's job so that only
+/// queries which actually use such a metric fail — unrelated metrics on the
+/// same view keep working.
+#[derive(Debug)]
+pub(super) struct ResolvedMetricExprs {
+    /// Lowercased metric name -> fully-resolved expression.
+    pub exprs: HashMap<String, String>,
+    /// Lowercased metric name -> lowercased source-table alias for metrics
+    /// with an unrewritable `COUNT(*)` (SG-8).
+    pub count_star_no_pk: HashMap<String, String>,
+}
+
 /// Topologically sort derived metrics by their inter-dependencies.
 ///
 /// Uses Kahn's algorithm. Only derived-to-derived edges are considered;
@@ -303,27 +392,70 @@ fn toposort_derived(
 /// Resolve all metric expressions: inline facts into base metrics, then inline
 /// base/derived metric references into derived metrics in topological order.
 ///
-/// Returns a map from lowercased metric name to its fully-resolved expression.
+/// Returns a map from lowercased metric name to its fully-resolved expression,
+/// plus the SG-8 rewrite failures (see [`ResolvedMetricExprs`]).
 ///
 /// Processing order:
-/// 1. Base metrics (`source_table.is_some()`): inline facts, store resolved expression
+/// 1. Base metrics (`source_table.is_some()`): inline facts, apply the SG-8
+///    `COUNT(*)` rewrite (below), store resolved expression
 /// 2. Derived metrics (`source_table.is_none()`): topologically sort by inter-metric deps,
 ///    then for each derived metric, replace all known metric name references with
 ///    parenthesized resolved expressions
+///
+/// # SG-8: `COUNT(*)` rewrite for non-base source tables
+///
+/// All synthesized joins are LEFT JOINs, so a metric sourced on a table other
+/// than the base/root table sees one NULL-extended row per base row with no
+/// match — `COUNT(*)` silently over-counts by one per childless parent. For
+/// every base metric whose `source_table` is not the first declared table,
+/// `COUNT(*)` is rewritten to `COUNT("<alias>"."<pk>")` using the FIRST
+/// PRIMARY KEY column declared for that table (NULL-extended rows have a NULL
+/// PK and are excluded from the count). The alias is lowercased to match the
+/// alias emitted in the JOIN clause. Metrics on the base table keep plain
+/// `COUNT(*)` — the base table is never NULL-extended. Because the rewrite
+/// runs here, at the shared base-metric resolution step, it propagates to
+/// every emission path that consumes resolved expressions: the main
+/// aggregation path, derived-metric inlining, semi-additive co-query
+/// decomposition, and window-metric inner aggregates. If the source table has
+/// no PRIMARY KEY declared the rewrite is impossible; the metric is recorded
+/// in `count_star_no_pk` and the caller errors when (and only when) a query
+/// actually uses it.
 pub(super) fn inline_derived_metrics(
     metrics: &[crate::model::Metric],
     facts: &[Fact],
     fact_topo_order: &[usize],
-) -> Result<HashMap<String, String>, String> {
+    tables: &[TableRef],
+) -> Result<ResolvedMetricExprs, String> {
     let mut resolved: HashMap<String, String> = HashMap::new();
+    let mut count_star_no_pk: HashMap<String, String> = HashMap::new();
+    let base_alias = tables.first().map(|t| t.alias.to_ascii_lowercase());
 
     // Step 1: Resolve base metrics (have source_table) with fact inlining
     for met in metrics.iter().filter(|m| m.source_table.is_some()) {
-        let expr = if facts.is_empty() {
+        let mut expr = if facts.is_empty() {
             met.expr.clone()
         } else {
             inline_facts(&met.expr, facts, fact_topo_order)
         };
+        // SG-8: COUNT(*) on a non-base source table (see doc comment above).
+        if let Some(ref st) = met.source_table {
+            let st_lower = st.to_ascii_lowercase();
+            if base_alias.as_deref() != Some(st_lower.as_str()) {
+                let pk = tables
+                    .iter()
+                    .find(|t| t.alias.to_ascii_lowercase() == st_lower)
+                    .and_then(|t| t.pk_columns.first());
+                if let Some(pk) = pk {
+                    let qualified_pk = format!("{}.{}", quote_ident(&st_lower), quote_ident(pk));
+                    if let Some(rewritten) = rewrite_count_star(&expr, &qualified_pk) {
+                        expr = rewritten;
+                    }
+                } else if rewrite_count_star(&expr, "*").is_some() {
+                    // No PK declared (or unknown alias): rewrite impossible.
+                    count_star_no_pk.insert(met.name.to_ascii_lowercase(), st_lower);
+                }
+            }
+        }
         resolved.insert(met.name.to_ascii_lowercase(), expr);
     }
 
@@ -335,7 +467,10 @@ pub(super) fn inline_derived_metrics(
         .collect();
 
     if derived.is_empty() {
-        return Ok(resolved);
+        return Ok(ResolvedMetricExprs {
+            exprs: resolved,
+            count_star_no_pk,
+        });
     }
 
     // Step 3: Topologically sort derived metrics and inline in order
@@ -380,7 +515,79 @@ pub(super) fn inline_derived_metrics(
         resolved.insert(met.name.to_ascii_lowercase(), expr);
     }
 
-    Ok(resolved)
+    Ok(ResolvedMetricExprs {
+        exprs: resolved,
+        count_star_no_pk,
+    })
+}
+
+/// True when `expr_lower` references `name` at a word boundary.
+///
+/// Both arguments must already be lowercased. Shared byte-scan used by the
+/// transitive metric walks.
+fn references_name(expr_lower: &str, name: &str) -> bool {
+    let expr_bytes = expr_lower.as_bytes();
+    let name_bytes = name.as_bytes();
+    let name_len = name_bytes.len();
+    let mut pos = 0;
+    while pos + name_len <= expr_bytes.len() {
+        if &expr_bytes[pos..pos + name_len] == name_bytes {
+            let before_ok = pos == 0 || is_word_boundary_char(expr_bytes[pos - 1]);
+            let after_ok = pos + name_len == expr_bytes.len()
+                || is_word_boundary_char(expr_bytes[pos + name_len]);
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        pos += 1;
+    }
+    false
+}
+
+/// Collect the lowercased names of `met` and every metric it transitively
+/// depends on: derived metrics contribute the metric names referenced in
+/// their expressions; window metrics contribute their inner metric.
+///
+/// Used by the SG-8 check in `expand()` to decide whether a requested metric
+/// reaches a base metric whose `COUNT(*)` could not be rewritten.
+pub(super) fn collect_transitive_metric_names(
+    met: &crate::model::Metric,
+    all_metrics: &[crate::model::Metric],
+) -> HashSet<String> {
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut stack: Vec<String> = vec![met.name.to_ascii_lowercase()];
+
+    let name_map: HashMap<String, &crate::model::Metric> = all_metrics
+        .iter()
+        .map(|m| (m.name.to_ascii_lowercase(), m))
+        .collect();
+    let all_names: Vec<String> = all_metrics
+        .iter()
+        .map(|m| m.name.to_ascii_lowercase())
+        .collect();
+
+    while let Some(current_name) = stack.pop() {
+        if !visited.insert(current_name.clone()) {
+            continue;
+        }
+        let Some(current_met) = name_map.get(&current_name) else {
+            continue;
+        };
+        if let Some(ref ws) = current_met.window_spec {
+            stack.push(ws.inner_metric.to_ascii_lowercase());
+        }
+        if current_met.source_table.is_none() {
+            // Derived metric: find referenced metric names and push to stack
+            let expr_lower = current_met.expr.to_ascii_lowercase();
+            for name in &all_names {
+                if *name != current_name && references_name(&expr_lower, name) {
+                    stack.push(name.clone());
+                }
+            }
+        }
+    }
+
+    visited
 }
 
 /// Collect source tables needed by a derived metric by walking the metric
@@ -514,7 +721,9 @@ mod tests {
             make_metric("tax", "SUM(o.revenue * 0.1)", Some("o")),
             make_metric("after_tax", "revenue - tax", None),
         ];
-        let resolved = inline_derived_metrics(&metrics, &[], &[]).unwrap();
+        let resolved = inline_derived_metrics(&metrics, &[], &[], &[])
+            .unwrap()
+            .exprs;
         assert_eq!(
             resolved.get("after_tax").unwrap(),
             "(SUM(o.revenue)) - (SUM(o.revenue * 0.1))"
@@ -532,7 +741,9 @@ mod tests {
             make_metric("profit", "revenue - cost", None),
             make_metric("margin", "profit / revenue", None),
         ];
-        let resolved = inline_derived_metrics(&metrics, &[], &[]).unwrap();
+        let resolved = inline_derived_metrics(&metrics, &[], &[], &[])
+            .unwrap()
+            .exprs;
         assert_eq!(
             resolved.get("margin").unwrap(),
             "((SUM(o.revenue)) - (SUM(o.cost))) / (SUM(o.revenue))"
@@ -545,7 +756,7 @@ mod tests {
             make_metric("a", "b + 1", None),
             make_metric("b", "a + 1", None),
         ];
-        let result = inline_derived_metrics(&metrics, &[], &[]);
+        let result = inline_derived_metrics(&metrics, &[], &[], &[]);
         assert!(result.is_err(), "Cycle should produce error");
         let err = result.unwrap_err();
         assert!(err.contains("cycle"), "Error should mention cycle: {err}");
@@ -558,9 +769,9 @@ mod tests {
             make_metric("cost", "SUM(unit_cost)", Some("o")),
             make_metric("profit", "revenue - cost", None),
         ];
-        let result = inline_derived_metrics(&metrics, &[], &[]);
+        let result = inline_derived_metrics(&metrics, &[], &[], &[]);
         assert!(result.is_ok(), "Non-cyclic should succeed");
-        let resolved = result.unwrap();
+        let resolved = result.unwrap().exprs;
         assert_eq!(
             resolved.get("profit").unwrap(),
             "(SUM(amount)) - (SUM(unit_cost))"
@@ -580,12 +791,149 @@ mod tests {
                 None,
             ));
         }
-        let result = inline_derived_metrics(&metrics, &[], &[]);
+        let result = inline_derived_metrics(&metrics, &[], &[], &[]);
         assert!(result.is_err(), "Depth exceeding limit should error");
         let err = result.unwrap_err();
         assert!(
             err.contains("nesting depth") && err.contains("maximum"),
             "Error should mention depth limit: {err}"
+        );
+    }
+
+    // --- rewrite_count_star tests (SG-8) ---
+
+    fn make_table(alias: &str, pk: &[&str]) -> TableRef {
+        TableRef {
+            alias: alias.to_string(),
+            table: alias.to_string(),
+            pk_columns: pk.iter().map(|s| (*s).to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rewrite_count_star_basic() {
+        assert_eq!(
+            rewrite_count_star("COUNT(*)", "\"li\".\"id\"").as_deref(),
+            Some("COUNT(\"li\".\"id\")")
+        );
+    }
+
+    #[test]
+    fn rewrite_count_star_preserves_case_and_handles_spaces() {
+        assert_eq!(
+            rewrite_count_star("count( * )", "\"li\".\"id\"").as_deref(),
+            Some("count(\"li\".\"id\")")
+        );
+        assert_eq!(
+            rewrite_count_star("Count (*)", "x").as_deref(),
+            Some("Count (x)")
+        );
+    }
+
+    #[test]
+    fn rewrite_count_star_inside_larger_expression() {
+        assert_eq!(
+            rewrite_count_star("COUNT(*) * 2 + COUNT(*)", "\"li\".\"id\"").as_deref(),
+            Some("COUNT(\"li\".\"id\") * 2 + COUNT(\"li\".\"id\")")
+        );
+    }
+
+    #[test]
+    fn rewrite_count_star_none_when_absent() {
+        assert!(rewrite_count_star("COUNT(li.id)", "x").is_none());
+        assert!(rewrite_count_star("SUM(amount)", "x").is_none());
+        // `*` as multiplication, not a star argument
+        assert!(rewrite_count_star("COUNT(a * b)", "x").is_none());
+    }
+
+    #[test]
+    fn rewrite_count_star_skips_string_literals_and_word_boundaries() {
+        // Inside a single-quoted literal: untouched.
+        assert!(rewrite_count_star("'COUNT(*)'", "x").is_none());
+        // `miscount(*)` is not `count` at a word boundary.
+        assert!(rewrite_count_star("miscount(*)", "x").is_none());
+    }
+
+    // --- inline_derived_metrics COUNT(*) rewrite tests (SG-8) ---
+
+    #[test]
+    fn inline_derived_metrics_rewrites_count_star_on_non_base_table() {
+        let tables = vec![make_table("o", &["id"]), make_table("li", &["id"])];
+        let metrics = vec![make_metric("item_count", "COUNT(*)", Some("li"))];
+        let resolved = inline_derived_metrics(&metrics, &[], &[], &tables).unwrap();
+        assert_eq!(
+            resolved.exprs.get("item_count").unwrap(),
+            "COUNT(\"li\".\"id\")"
+        );
+        assert!(resolved.count_star_no_pk.is_empty());
+    }
+
+    #[test]
+    fn inline_derived_metrics_keeps_count_star_on_base_table() {
+        let tables = vec![make_table("o", &["id"]), make_table("li", &["id"])];
+        let metrics = vec![make_metric("order_count", "COUNT(*)", Some("o"))];
+        let resolved = inline_derived_metrics(&metrics, &[], &[], &tables).unwrap();
+        assert_eq!(resolved.exprs.get("order_count").unwrap(), "COUNT(*)");
+        assert!(resolved.count_star_no_pk.is_empty());
+    }
+
+    #[test]
+    fn inline_derived_metrics_records_no_pk_failure() {
+        // li declares no PRIMARY KEY: the rewrite is impossible and the
+        // metric is recorded so the caller can error when it is queried.
+        let tables = vec![make_table("o", &["id"]), make_table("li", &[])];
+        let metrics = vec![make_metric("item_count", "COUNT(*)", Some("li"))];
+        let resolved = inline_derived_metrics(&metrics, &[], &[], &tables).unwrap();
+        assert_eq!(resolved.exprs.get("item_count").unwrap(), "COUNT(*)");
+        assert_eq!(
+            resolved
+                .count_star_no_pk
+                .get("item_count")
+                .map(String::as_str),
+            Some("li")
+        );
+    }
+
+    #[test]
+    fn inline_derived_metrics_rewrite_propagates_into_derived() {
+        // The rewrite runs at base-metric resolution, BEFORE derived-metric
+        // inlining, so derived metrics inherit the rewritten text.
+        let tables = vec![make_table("o", &["id"]), make_table("li", &["li_id"])];
+        let metrics = vec![
+            make_metric("item_count", "COUNT(*)", Some("li")),
+            make_metric("double_items", "item_count * 2", None),
+        ];
+        let resolved = inline_derived_metrics(&metrics, &[], &[], &tables).unwrap();
+        assert_eq!(
+            resolved.exprs.get("double_items").unwrap(),
+            "(COUNT(\"li\".\"li_id\")) * 2"
+        );
+    }
+
+    // --- collect_transitive_metric_names tests (SG-8 check support) ---
+
+    #[test]
+    fn collect_transitive_metric_names_derived_and_window() {
+        let mut window_met = make_metric("rolling_items", "AVG(item_count)", None);
+        window_met.window_spec = Some(crate::model::WindowSpec {
+            window_function: "AVG".to_string(),
+            inner_metric: "item_count".to_string(),
+            ..Default::default()
+        });
+        let metrics = vec![
+            make_metric("item_count", "COUNT(*)", Some("li")),
+            make_metric("double_items", "item_count * 2", None),
+            window_met,
+        ];
+        let via_derived = collect_transitive_metric_names(&metrics[1], &metrics);
+        assert!(via_derived.contains("double_items"));
+        assert!(via_derived.contains("item_count"));
+        let via_window = collect_transitive_metric_names(&metrics[2], &metrics);
+        assert!(via_window.contains("rolling_items"));
+        assert!(
+            via_window.contains("item_count"),
+            "window metrics must chase their inner metric: {via_window:?}"
         );
     }
 

--- a/src/expand/fan_trap.rs
+++ b/src/expand/fan_trap.rs
@@ -1,52 +1,50 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::model::{Cardinality, SemanticViewDefinition};
+use crate::model::{Cardinality, Metric, SemanticViewDefinition};
 
 use super::facts::collect_derived_metric_source_tables;
+use super::semi_additive::is_active_semi_additive;
 use super::types::ExpandError;
 
-/// Check for fan traps: a metric aggregating across a one-to-many boundary.
+/// Cardinality map: `(from_lower, to_lower)` -> (worst-case cardinality,
+/// name of a relationship carrying that cardinality).
+type CardMap = HashMap<(String, String), (Cardinality, String)>;
+
+/// Check for fan traps: an aggregation whose input rows are multiplied by a
+/// one-to-many join boundary.
 ///
-/// Walks the join path between each (metric source, dimension source) pair
-/// and checks whether any edge is traversed in the fan-out direction.
-/// Returns `Err(ExpandError::FanTrap)` with details if a fan-out is detected.
+/// Two checks run over the same relationship/cardinality machinery:
+///
+/// 1. **metric × dimension**: walks the join path between each
+///    (metric source, dimension source) pair and errors when any edge is
+///    traversed in the fan-out direction (`ExpandError::FanTrap`).
+/// 2. **metric × metric** (SG-1, code review 2026-07-02): join resolution
+///    joins EVERY queried metric's source table, so two metrics at different
+///    grains double-count whenever the join path between their source tables
+///    crosses a fan-out edge — a classic fan trap (root metric + `ManyToOne`
+///    child metric) or chasm trap (metrics on two different child tables of
+///    one root). Errors with `ExpandError::MetricFanTrap`.
+///    Policy (remediation plan): erroring on multi-grain metric combinations
+///    is correct for now; per-grain CTE aggregation is future work.
 ///
 /// # Fan-out direction
 ///
 /// For an edge `(from_alias, to_alias)` with cardinality:
 /// - `ManyToOne`: from->to is safe (many go to one), to->from is fan-out
 /// - `OneToOne`: both directions are safe
-#[allow(clippy::result_large_err)]
+#[allow(clippy::result_large_err, clippy::too_many_lines)]
 pub(super) fn check_fan_traps(
     view_name: &str,
     def: &SemanticViewDefinition,
     resolved_dims: &[&crate::model::Dimension],
-    resolved_mets: &[&crate::model::Metric],
+    resolved_mets: &[&Metric],
 ) -> Result<(), ExpandError> {
     if def.joins.is_empty() {
         return Ok(());
     }
 
-    let Ok(graph) = crate::graph::RelationshipGraph::from_definition(def) else {
-        return Ok(()); // Graph was validated at define time
-    };
-
-    // Build cardinality map: (from_lower, to_lower) -> (Cardinality, relationship_name)
-    let card_map: HashMap<(String, String), (Cardinality, String)> = def
-        .joins
-        .iter()
-        .filter(|j| !j.fk_columns.is_empty())
-        .map(|j| {
-            let rel_name = j.name.as_deref().unwrap_or(&j.from_alias).to_string();
-            (
-                (
-                    j.from_alias.to_ascii_lowercase(),
-                    j.table.to_ascii_lowercase(),
-                ),
-                (j.cardinality, rel_name),
-            )
-        })
-        .collect();
+    let graph = build_relationship_graph(view_name, def)?;
+    let card_map = build_card_map(def);
 
     // Build parent map for tree path finding.
     // In a validated tree, each non-root node has exactly one parent via the reverse map.
@@ -57,32 +55,31 @@ pub(super) fn check_fan_traps(
         }
     }
 
+    let queried_dim_names: HashSet<String> = resolved_dims
+        .iter()
+        .map(|d| d.name.to_ascii_lowercase())
+        .collect();
+
     // For each metric + dimension pair, check for fan-out on the join path.
     for met in resolved_mets {
-        // Phase 47: Skip fan trap check for semi-additive metrics.
-        // The ROW_NUMBER CTE inherently handles fan-out by selecting one row
-        // per partition, making fan trap detection unnecessary.
-        if !met.non_additive_by.is_empty() {
+        // SG-6 (code review 2026-07-02): skip ONLY metrics that actually take
+        // the ROW_NUMBER-CTE snapshot path for THIS request (active
+        // semi-additive: at least one NA dim absent from the queried dims —
+        // the same predicate `expand()` routes on, shared via
+        // `is_active_semi_additive` so the two cannot drift). The CTE path is
+        // assumed to neutralize fan-out by selecting one row per partition;
+        // that assumption is itself unproven (ROW_NUMBER ties, co-queried
+        // regular metrics — SG-4/SG-5 rework will revisit it).
+        // Effectively-regular semi-additive metrics (all NA dims queried)
+        // take the standard aggregation path and get the standard check.
+        // Window metrics are NOT skipped: their inner aggregate is computed
+        // over the already-fanned join, so fan-out inflates it before the
+        // window function runs.
+        if is_active_semi_additive(met, &queried_dim_names) {
             continue;
         }
 
-        // Phase 48: Skip fan trap check for window function metrics.
-        // Window metrics operate on pre-aggregated CTE results, so fan-out
-        // is handled by the inner aggregation step.
-        if met.is_window() {
-            continue;
-        }
-
-        // Get source tables for this metric
-        let met_tables: Vec<String> = if let Some(ref st) = met.source_table {
-            vec![st.to_ascii_lowercase()]
-        } else {
-            // Derived metric: walk dependency graph to find transitive base metric source tables
-            collect_derived_metric_source_tables(met, &def.metrics)
-                .into_iter()
-                .map(|s| s.to_ascii_lowercase())
-                .collect()
-        };
+        let met_tables = metric_grain_tables(met, def);
 
         for dim in resolved_dims {
             let Some(ref dim_table_raw) = dim.source_table else {
@@ -101,8 +98,7 @@ pub(super) fn check_fan_traps(
                 let dim_ancestors = ancestors_to_root(&dim_table, &parent_map);
 
                 // Find the lowest common ancestor (LCA)
-                let dim_ancestor_set: std::collections::HashSet<&String> =
-                    dim_ancestors.iter().collect();
+                let dim_ancestor_set: HashSet<&String> = dim_ancestors.iter().collect();
                 let lca = met_ancestors
                     .iter()
                     .find(|a| dim_ancestor_set.contains(a))
@@ -112,24 +108,249 @@ pub(super) fn check_fan_traps(
                     continue; // No common ancestor (shouldn't happen in a tree)
                 };
 
-                // Build path: met_table -> ... -> LCA -> ... -> dim_table
-                // Check edges from met_table up to LCA
-                if let Some(err) =
-                    check_path_up(met_table, &lca, &parent_map, &card_map, view_name, met, dim)
-                {
-                    return Err(err);
+                // Build path: met_table -> ... -> LCA -> ... -> dim_table,
+                // then scan the up-leg and down-leg for a fanning edge.
+                let up_path = path_to_ancestor(met_table, &lca, &parent_map);
+                let down_path = path_from_ancestor_to_node(&lca, &dim_table, &dim_ancestors);
+                let fanning = fanning_edge_on_path(&up_path, &card_map)
+                    .or_else(|| fanning_edge_on_path(&down_path, &card_map));
+                if let Some(rel_name) = fanning {
+                    return Err(ExpandError::FanTrap {
+                        view_name: view_name.to_string(),
+                        metric_name: met.name.clone(),
+                        metric_table: met
+                            .source_table
+                            .clone()
+                            .unwrap_or_else(|| met_table.clone()),
+                        dimension_name: dim.name.clone(),
+                        dimension_table: dim_table_raw.clone(),
+                        relationship_name: rel_name,
+                    });
                 }
-                // Check edges from LCA down to dim_table
-                // We need the path from LCA down to dim_table. Build it from dim_ancestors.
-                let path_down = path_from_ancestor_to_node(&lca, &dim_table, &dim_ancestors);
-                if let Some(err) = check_path_down(&path_down, &card_map, view_name, met, dim) {
-                    return Err(err);
+            }
+        }
+    }
+
+    // SG-1 (code review 2026-07-02): metric × metric grain check.
+    // For each ordered pair (A, B) of queried metrics, treat B's source table
+    // the way a dimension table is treated above: if the join path from A's
+    // grain table to B's grain table crosses a fan-out edge in the direction
+    // that multiplies A's rows, A's aggregate would be silently inflated.
+    // Metrics with no source table (base-table metrics) sit at the root grain
+    // and participate — they are the ones inflated by joins to child tables.
+    let adjacency = build_adjacency(def);
+    let grains: Vec<Vec<String>> = resolved_mets
+        .iter()
+        .map(|m| {
+            let tables = metric_grain_tables(m, def);
+            if tables.is_empty() {
+                vec![graph.root.clone()]
+            } else {
+                tables
+            }
+        })
+        .collect();
+
+    for (i, met_a) in resolved_mets.iter().enumerate() {
+        // Same SG-6 skip as above: only the potentially-inflated side is
+        // skipped when it takes the CTE snapshot path. A CTE-handled metric
+        // still participates as the OTHER side (its source table is still
+        // joined, fanning co-queried metrics).
+        if is_active_semi_additive(met_a, &queried_dim_names) {
+            continue;
+        }
+        for (j, met_b) in resolved_mets.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            for table_a in &grains[i] {
+                for table_b in &grains[j] {
+                    if table_a == table_b {
+                        continue; // Same grain, no fan-out possible
+                    }
+                    // Tables not connected by PK/FK edges (e.g. legacy joins
+                    // with no FK metadata) cannot be analyzed — mirror the
+                    // met×dim behavior and skip rather than error.
+                    let Some(path) = find_path(table_a, table_b, &adjacency) else {
+                        continue;
+                    };
+                    if let Some(rel_name) = fanning_edge_on_path(&path, &card_map) {
+                        return Err(ExpandError::MetricFanTrap {
+                            view_name: view_name.to_string(),
+                            metric_name: met_a.name.clone(),
+                            metric_table: table_a.clone(),
+                            other_metric_name: met_b.name.clone(),
+                            other_metric_table: table_b.clone(),
+                            relationship_name: rel_name,
+                        });
+                    }
                 }
             }
         }
     }
 
     Ok(())
+}
+
+/// Build the relationship graph, surfacing construction failure as an error.
+///
+/// SG-7 (code review 2026-07-02): previously a failed graph build silently
+/// SKIPPED the fan-trap safety check (`return Ok(())`), so queries over
+/// legacy/invalid stored definitions produced mis-aggregated results with no
+/// warning. The correct bias for a safety check is loud failure.
+#[allow(clippy::result_large_err)]
+fn build_relationship_graph(
+    view_name: &str,
+    def: &SemanticViewDefinition,
+) -> Result<crate::graph::RelationshipGraph, ExpandError> {
+    crate::graph::RelationshipGraph::from_definition(def).map_err(|reason| {
+        ExpandError::UncheckableDefinition {
+            view_name: view_name.to_string(),
+            reason,
+        }
+    })
+}
+
+/// Build the cardinality map keyed by `(from_lower, to_lower)`.
+///
+/// SG-16 (code review 2026-07-02): multiple named relationships may connect
+/// the same table pair (role-playing). For fan detection the WORST case must
+/// win: if ANY edge between the pair is `ManyToOne` (fan-capable when
+/// traversed PK-side -> FK-side), the pair is treated as `ManyToOne`, and the
+/// recorded relationship name is that of a `ManyToOne` edge so error messages
+/// cite a relationship that actually fans. Previously the last-declared edge
+/// simply overwrote earlier ones, so a `OneToOne` declared after a
+/// `ManyToOne` masked the fan-out (declaration-order dependent).
+fn build_card_map(def: &SemanticViewDefinition) -> CardMap {
+    let mut card_map: CardMap = HashMap::new();
+    for join in def.joins.iter().filter(|j| !j.fk_columns.is_empty()) {
+        let key = (
+            join.from_alias.to_ascii_lowercase(),
+            join.table.to_ascii_lowercase(),
+        );
+        let rel_name = join.name.as_deref().unwrap_or(&join.from_alias).to_string();
+        match card_map.entry(key) {
+            std::collections::hash_map::Entry::Vacant(e) => {
+                e.insert((join.cardinality, rel_name));
+            }
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                if e.get().0 == Cardinality::OneToOne && join.cardinality == Cardinality::ManyToOne
+                {
+                    e.insert((join.cardinality, rel_name));
+                }
+            }
+        }
+    }
+    card_map
+}
+
+/// Source tables (lowercased, sorted, deduped) whose rows feed `met`'s
+/// aggregation — the metric's "grain".
+///
+/// - Base metric with `source_table`: that table.
+/// - Derived metric (`source_table == None`): transitive base-metric source
+///   tables via the dependency graph.
+/// - Window metric: additionally the INNER metric's source tables — the inner
+///   aggregate is what is computed over the joined row set (the window
+///   function itself runs over the pre-aggregated CTE), so the inner metric's
+///   grain is what fan-out inflates.
+fn metric_grain_tables(met: &Metric, def: &SemanticViewDefinition) -> Vec<String> {
+    let mut tables: Vec<String> = if let Some(ref st) = met.source_table {
+        vec![st.to_ascii_lowercase()]
+    } else {
+        // Derived metric: walk dependency graph to find transitive base metric source tables
+        collect_derived_metric_source_tables(met, &def.metrics)
+            .into_iter()
+            .map(|s| s.to_ascii_lowercase())
+            .collect()
+    };
+    if let Some(ref ws) = met.window_spec {
+        if !ws.inner_metric.eq_ignore_ascii_case(&met.name) {
+            if let Some(inner) = def
+                .metrics
+                .iter()
+                .find(|m| m.name.eq_ignore_ascii_case(&ws.inner_metric))
+            {
+                if let Some(ref st) = inner.source_table {
+                    tables.push(st.to_ascii_lowercase());
+                } else {
+                    tables.extend(
+                        collect_derived_metric_source_tables(inner, &def.metrics)
+                            .into_iter()
+                            .map(|s| s.to_ascii_lowercase()),
+                    );
+                }
+            }
+        }
+    }
+    tables.sort_unstable();
+    tables.dedup();
+    tables
+}
+
+/// Undirected adjacency over relationship edges (lowercased aliases), built
+/// in declaration order for deterministic traversal.
+fn build_adjacency(def: &SemanticViewDefinition) -> HashMap<String, Vec<String>> {
+    let mut adjacency: HashMap<String, Vec<String>> = HashMap::new();
+    for join in def.joins.iter().filter(|j| !j.fk_columns.is_empty()) {
+        let from = join.from_alias.to_ascii_lowercase();
+        let to = join.table.to_ascii_lowercase();
+        if from == to {
+            continue; // Self-references are rejected by graph construction
+        }
+        let entry = adjacency.entry(from.clone()).or_default();
+        if !entry.contains(&to) {
+            entry.push(to.clone());
+        }
+        let entry = adjacency.entry(to).or_default();
+        if !entry.contains(&from) {
+            entry.push(from);
+        }
+    }
+    adjacency
+}
+
+/// Find a path between two table aliases treating relationship edges as
+/// undirected (BFS). In a validated relationship tree the path is unique;
+/// role-playing multi-edges between one pair are collapsed to a single
+/// adjacency entry (their cardinality is collapsed to the worst case in the
+/// card map). Returns `None` when the tables are not connected (e.g. legacy
+/// joins carrying no FK metadata).
+fn find_path(
+    start: &str,
+    goal: &str,
+    adjacency: &HashMap<String, Vec<String>>,
+) -> Option<Vec<String>> {
+    if start == goal {
+        return Some(vec![start.to_string()]);
+    }
+    let mut prev: HashMap<String, String> = HashMap::new();
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+    visited.insert(start.to_string());
+    queue.push_back(start.to_string());
+    while let Some(node) = queue.pop_front() {
+        let Some(neighbors) = adjacency.get(&node) else {
+            continue;
+        };
+        for neighbor in neighbors {
+            if visited.insert(neighbor.clone()) {
+                prev.insert(neighbor.clone(), node.clone());
+                if neighbor == goal {
+                    let mut path = vec![goal.to_string()];
+                    let mut current = goal;
+                    while let Some(p) = prev.get(current) {
+                        path.push(p.clone());
+                        current = p;
+                    }
+                    path.reverse();
+                    return Some(path);
+                }
+                queue.push_back(neighbor.clone());
+            }
+        }
+    }
+    None
 }
 
 /// Walk from `node` to the root through the parent map, returning the chain
@@ -142,6 +363,52 @@ pub(crate) fn ancestors_to_root(node: &str, parent_map: &HashMap<String, String>
         current = parent.clone();
     }
     chain
+}
+
+/// Build the chain `[start, parent, ..., ancestor]` by walking the parent
+/// map. Stops early (returning a partial chain) if the parent chain breaks
+/// before reaching `ancestor`.
+fn path_to_ancestor(
+    start: &str,
+    ancestor: &str,
+    parent_map: &HashMap<String, String>,
+) -> Vec<String> {
+    let mut path = vec![start.to_string()];
+    let mut current = start.to_string();
+    while current != ancestor {
+        let Some(parent) = parent_map.get(&current) else {
+            break;
+        };
+        path.push(parent.clone());
+        current = parent.clone();
+    }
+    path
+}
+
+/// Scan consecutive pairs along `path` for an edge traversed in the fan-out
+/// direction, returning the fanning relationship's name.
+///
+/// The card map stores edges as `(from, to)` = (FK side, PK side). Traversing
+/// a pair `(a, b)` when the stored edge is `(a, b)` follows the FK forward
+/// (many rows -> one row: safe). Traversing when the stored edge is `(b, a)`
+/// goes from the PK side to the FK side, which multiplies rows when the edge
+/// is `ManyToOne`. `OneToOne` edges are safe in both directions.
+fn fanning_edge_on_path(path: &[String], card_map: &CardMap) -> Option<String> {
+    for window in path.windows(2) {
+        let a = &window[0];
+        let b = &window[1];
+        if card_map.contains_key(&(a.clone(), b.clone())) {
+            // Edge is a -> b (a has FK pointing to b): forward direction,
+            // no fan-out possible.
+        } else if let Some((card, rel_name)) = card_map.get(&(b.clone(), a.clone())) {
+            // Edge is b -> a (b has FK pointing to a). Walking a -> b means
+            // traversing this edge in REVERSE: ManyToOne reverse = fan-out.
+            if *card == Cardinality::ManyToOne {
+                return Some(rel_name.clone());
+            }
+        }
+    }
+    None
 }
 
 /// Validate that all tables referenced by a fact query are on the same
@@ -179,9 +446,8 @@ pub(super) fn validate_fact_table_path(
         return Ok(()); // Single table or empty — trivially valid
     }
 
-    let Ok(graph) = crate::graph::RelationshipGraph::from_definition(def) else {
-        return Ok(()); // Graph was validated at define time
-    };
+    // SG-7: an unbuildable graph is an error, not a skipped check.
+    let graph = build_relationship_graph(view_name, def)?;
 
     // Build parent map from reverse adjacency
     let mut parent_map: HashMap<String, String> = HashMap::new();
@@ -229,93 +495,6 @@ fn path_from_ancestor_to_node(
     } else {
         vec![ancestor.to_string(), target.to_string()]
     }
-}
-
-/// Check edges going UP from `start` to `ancestor` (toward root).
-/// Walking up means: at each step, current -> parent. The actual edge in the
-/// graph might be current->parent (forward edge) or parent->current (forward edge).
-///
-/// Returns `None` if no fan-out, `Some(ExpandError)` if fan-out detected.
-fn check_path_up(
-    start: &str,
-    ancestor: &str,
-    parent_map: &HashMap<String, String>,
-    card_map: &HashMap<(String, String), (Cardinality, String)>,
-    view_name: &str,
-    met: &crate::model::Metric,
-    dim: &crate::model::Dimension,
-) -> Option<ExpandError> {
-    let mut current = start.to_string();
-    while current != ancestor {
-        let Some(parent) = parent_map.get(&current) else {
-            break;
-        };
-        // Determine which direction this edge goes in the card_map.
-        // The graph stores edges as from_alias -> to_alias (FK -> PK).
-        // So either (current, parent) or (parent, current) is in the map.
-        if let Some((_card, _rel_name)) = card_map.get(&(current.clone(), parent.clone())) {
-            // Edge is current -> parent (current has FK pointing to parent)
-            // Walking current -> parent: this is the forward direction of the edge.
-            // ManyToOne forward = safe, OneToOne = safe -- no fan-out possible going forward
-        } else if let Some((card, rel_name)) = card_map.get(&(parent.clone(), current.clone())) {
-            // Edge is parent -> current (parent has FK pointing to current)
-            // Walking current -> parent means traversing this edge in REVERSE.
-            // ManyToOne reverse = fan-out, OneToOne = safe
-            if *card == Cardinality::ManyToOne {
-                let met_table = met.source_table.as_deref().unwrap_or(&current);
-                return Some(ExpandError::FanTrap {
-                    view_name: view_name.to_string(),
-                    metric_name: met.name.clone(),
-                    metric_table: met_table.to_string(),
-                    dimension_name: dim.name.clone(),
-                    dimension_table: dim.source_table.as_deref().unwrap_or("").to_string(),
-                    relationship_name: rel_name.clone(),
-                });
-            }
-        }
-        current = parent.clone();
-    }
-    None
-}
-
-/// Check edges going DOWN a path (from ancestor toward target).
-/// The path is [ancestor, ..., target]. For each consecutive pair (a, b),
-/// check the traversal direction vs cardinality.
-///
-/// Returns `None` if no fan-out, `Some(ExpandError)` if fan-out detected.
-fn check_path_down(
-    path: &[String],
-    card_map: &HashMap<(String, String), (Cardinality, String)>,
-    view_name: &str,
-    met: &crate::model::Metric,
-    dim: &crate::model::Dimension,
-) -> Option<ExpandError> {
-    for window in path.windows(2) {
-        let a = &window[0];
-        let b = &window[1];
-        // Walking a -> b (downward in the tree, away from root)
-        if let Some((_card, _rel_name)) = card_map.get(&(a.clone(), b.clone())) {
-            // Edge is a -> b (a has FK pointing to b)
-            // Walking a -> b: forward direction
-            // ManyToOne forward = safe, OneToOne = safe -- no fan-out possible going forward
-        } else if let Some((card, rel_name)) = card_map.get(&(b.clone(), a.clone())) {
-            // Edge is b -> a (b has FK pointing to a)
-            // Walking a -> b means traversing this edge in REVERSE.
-            // ManyToOne reverse = fan-out, OneToOne = safe
-            if *card == Cardinality::ManyToOne {
-                let met_table = met.source_table.as_deref().unwrap_or("").to_string();
-                return Some(ExpandError::FanTrap {
-                    view_name: view_name.to_string(),
-                    metric_name: met.name.clone(),
-                    metric_table: met_table,
-                    dimension_name: dim.name.clone(),
-                    dimension_table: dim.source_table.as_deref().unwrap_or("").to_string(),
-                    relationship_name: rel_name.clone(),
-                });
-            }
-        }
-    }
-    None
 }
 
 #[cfg(test)]
@@ -449,9 +628,16 @@ mod tests {
         );
     }
 
+    /// SG-6: a semi-additive metric whose NA dims are ALL in the queried
+    /// dimensions is effectively regular — it takes the standard aggregation
+    /// path (no `ROW_NUMBER` CTE), so it MUST get the standard fan-trap check.
+    /// Previously any non-empty `non_additive_by` skipped the check
+    /// unconditionally, letting this query silently inflate.
     #[test]
-    fn test_check_fan_traps_skips_semi_additive() {
-        // Same fan-out scenario, but the metric has non_additive_by set.
+    fn test_check_fan_traps_semi_additive_regular_path_checked() {
+        // Fan-out topology: metric on orders, dim on line_items reached by
+        // reversing a ManyToOne edge. The metric's only NA dim (item_name)
+        // IS queried, so the metric acts as a regular aggregate.
         let def = minimal_def("orders", "item_name", "name", "total", "sum(amount)")
             .with_table("orders", "orders", &["id"])
             .with_table("line_items", "line_items", &["id"])
@@ -475,14 +661,61 @@ mod tests {
         let resolved_mets: Vec<&_> = def.metrics.iter().collect();
         let result = check_fan_traps("test", &def, &resolved_dims, &resolved_mets);
         assert!(
-            result.is_ok(),
-            "Semi-additive metrics should skip fan trap check, got: {result:?}"
+            matches!(result, Err(ExpandError::FanTrap { .. })),
+            "Effectively-regular semi-additive metric must get the standard \
+             fan-trap check, got: {result:?}"
         );
     }
 
+    /// SG-6: a semi-additive metric with at least one NA dim NOT in the
+    /// queried dims takes the ROW_NUMBER-CTE snapshot path, which is assumed
+    /// to neutralize fan-out (one row per partition survives) — pinned here.
+    /// NOTE: that assumption is itself unproven (`ROW_NUMBER` ties, co-queried
+    /// regular metrics); the SG-4/SG-5 semi-additive rework will revisit it.
     #[test]
-    fn test_check_fan_traps_skips_window() {
-        // Same fan-out scenario, but the metric has window_spec set.
+    fn test_check_fan_traps_semi_additive_cte_path_skipped() {
+        let def = minimal_def("orders", "item_name", "name", "total", "sum(amount)")
+            .with_table("orders", "orders", &["id"])
+            .with_table("line_items", "line_items", &["id"])
+            .with_dimension("item_name", "name", Some("line_items"))
+            .with_dimension("report_date", "report_date", Some("orders"))
+            .with_metric("total_sourced", "sum(amount)", Some("orders"))
+            .with_non_additive_by(
+                "total_sourced",
+                &[("report_date", SortOrder::Desc, NullsOrder::First)],
+            )
+            .with_pkfk_join(
+                "items_to_orders",
+                "line_items",
+                "orders",
+                &["order_id"],
+                &["id"],
+            );
+        let mut def = def;
+        def.dimensions.retain(|d| d.source_table.is_some());
+        def.metrics.retain(|m| m.source_table.is_some());
+        // Query only item_name: report_date (the NA dim) is NOT queried, so
+        // the metric is ACTIVE semi-additive and takes the CTE path.
+        let resolved_dims: Vec<&_> = def
+            .dimensions
+            .iter()
+            .filter(|d| d.name == "item_name")
+            .collect();
+        let resolved_mets: Vec<&_> = def.metrics.iter().collect();
+        let result = check_fan_traps("test", &def, &resolved_dims, &resolved_mets);
+        assert!(
+            result.is_ok(),
+            "Active (CTE-path) semi-additive metrics skip the fan trap check, got: {result:?}"
+        );
+    }
+
+    /// SG-6: window metrics get the standard fan-trap check — the inner
+    /// aggregate is computed over the already-fanned join, so it is inflated
+    /// before the window function runs. Previously `is_window()` skipped the
+    /// check unconditionally.
+    #[test]
+    fn test_check_fan_traps_window_metric_fanning_dim_errors() {
+        // Metric (inner aggregate) on orders (root), dim on a fanning child.
         let def = minimal_def("orders", "item_name", "name", "total", "sum(amount)")
             .with_table("orders", "orders", &["id"])
             .with_table("line_items", "line_items", &["id"])
@@ -510,9 +743,240 @@ mod tests {
         let resolved_mets: Vec<&_> = def.metrics.iter().collect();
         let result = check_fan_traps("test", &def, &resolved_dims, &resolved_mets);
         assert!(
-            result.is_ok(),
-            "Window metrics should skip fan trap check, got: {result:?}"
+            matches!(result, Err(ExpandError::FanTrap { .. })),
+            "Window metrics must get the standard fan-trap check, got: {result:?}"
         );
+    }
+
+    /// Window metric in the SAFE direction (metric on the FK/child side, dim
+    /// on the referenced parent) stays allowed — guards against over-blocking
+    /// after the SG-6 skip removal.
+    #[test]
+    fn test_check_fan_traps_window_metric_safe_direction_ok() {
+        let def = minimal_def("orders", "cust_name", "name", "total", "sum(amount)")
+            .with_table("orders", "orders", &["id"])
+            .with_table("customers", "customers", &["id"])
+            .with_dimension("cust_name", "name", Some("customers"))
+            .with_metric("total_sourced", "sum(amount)", Some("orders"))
+            .with_window_spec(
+                "total_sourced",
+                WindowSpec {
+                    window_function: "AVG".to_string(),
+                    inner_metric: "total_sourced".to_string(),
+                    ..Default::default()
+                },
+            )
+            .with_pkfk_join(
+                "orders_customers",
+                "orders",
+                "customers",
+                &["customer_id"],
+                &["id"],
+            );
+        let mut def = def;
+        def.dimensions.retain(|d| d.source_table.is_some());
+        def.metrics.retain(|m| m.source_table.is_some());
+        let resolved_dims: Vec<&_> = def.dimensions.iter().collect();
+        let resolved_mets: Vec<&_> = def.metrics.iter().collect();
+        let result = check_fan_traps("test", &def, &resolved_dims, &resolved_mets);
+        assert!(
+            result.is_ok(),
+            "Window metric over a forward ManyToOne edge is safe, got: {result:?}"
+        );
+    }
+
+    /// SG-1: two metrics at different grains, no dimensions. `order_total`
+    /// aggregates the root table; `item_count` aggregates a `ManyToOne` child.
+    /// Joining both source tables multiplies the root's rows per child row,
+    /// silently inflating `order_total` — must error naming both metrics.
+    #[test]
+    fn test_check_fan_traps_metric_metric_multi_grain_errors() {
+        let def = minimal_def("o", "d", "d", "m", "count(*)")
+            .clear_dimensions()
+            .clear_metrics()
+            .with_table("li", "line_items", &["id"])
+            .with_metric("order_total", "SUM(o.amount)", Some("o"))
+            .with_metric("item_count", "COUNT(*)", Some("li"))
+            .with_pkfk_join("items_to_orders", "li", "o", &["order_id"], &["id"]);
+        let resolved_mets: Vec<&_> = def.metrics.iter().collect();
+        let result = check_fan_traps("test", &def, &[], &resolved_mets);
+        match result {
+            Err(ExpandError::MetricFanTrap {
+                metric_name,
+                metric_table,
+                other_metric_name,
+                other_metric_table,
+                relationship_name,
+                ..
+            }) => {
+                assert_eq!(metric_name, "order_total", "inflated metric");
+                assert_eq!(metric_table, "o");
+                assert_eq!(other_metric_name, "item_count");
+                assert_eq!(other_metric_table, "li");
+                assert_eq!(relationship_name, "items_to_orders");
+            }
+            other => panic!("Expected MetricFanTrap, got: {other:?}"),
+        }
+    }
+
+    /// SG-1 (chasm trap): metrics on two different child tables of one root.
+    /// FROM root LEFT JOIN `child_a` LEFT JOIN `child_b` builds a cross product
+    /// per root row — both aggregates inflate. Must error.
+    #[test]
+    fn test_check_fan_traps_metric_metric_chasm_trap_errors() {
+        let def = minimal_def("o", "d", "d", "m", "count(*)")
+            .clear_dimensions()
+            .clear_metrics()
+            .with_table("li", "line_items", &["id"])
+            .with_table("pay", "payments", &["id"])
+            .with_metric("item_total", "SUM(li.amount)", Some("li"))
+            .with_metric("payment_total", "SUM(pay.amount)", Some("pay"))
+            .with_pkfk_join("items_to_orders", "li", "o", &["order_id"], &["id"])
+            .with_pkfk_join("payments_to_orders", "pay", "o", &["order_id"], &["id"]);
+        let resolved_mets: Vec<&_> = def.metrics.iter().collect();
+        let result = check_fan_traps("test", &def, &[], &resolved_mets);
+        match result {
+            Err(ExpandError::MetricFanTrap {
+                metric_name,
+                other_metric_name,
+                ..
+            }) => {
+                assert_eq!(metric_name, "item_total");
+                assert_eq!(other_metric_name, "payment_total");
+            }
+            other => panic!("Expected MetricFanTrap for chasm trap, got: {other:?}"),
+        }
+    }
+
+    /// SG-1 guard: same-grain multi-metric queries stay allowed, including a
+    /// base-table metric with no `source_table` (which resolves to the root
+    /// grain) and root-ward dimension joins (`ManyToOne` toward a parent never
+    /// fans).
+    #[test]
+    fn test_check_fan_traps_metric_metric_same_grain_allowed() {
+        let def = minimal_def("orders", "cust_name", "name", "m", "count(*)")
+            .clear_dimensions()
+            .clear_metrics()
+            .with_table("customers", "customers", &["id"])
+            .with_dimension("cust_name", "name", Some("customers"))
+            .with_metric("total", "sum(amount)", Some("orders"))
+            .with_metric("cnt", "count(*)", None) // base metric -> root grain
+            .with_pkfk_join(
+                "orders_customers",
+                "orders",
+                "customers",
+                &["customer_id"],
+                &["id"],
+            );
+        let resolved_dims: Vec<&_> = def.dimensions.iter().collect();
+        let resolved_mets: Vec<&_> = def.metrics.iter().collect();
+        let result = check_fan_traps("test", &def, &resolved_dims, &resolved_mets);
+        assert!(
+            result.is_ok(),
+            "Same-grain metrics with a root-ward dim join must be allowed, got: {result:?}"
+        );
+    }
+
+    /// SG-1: an unqualified base-table metric (`source_table` = None) sits at
+    /// the ROOT grain and participates in the metric×metric check — it is
+    /// exactly the metric inflated by joining a `ManyToOne` child.
+    #[test]
+    fn test_check_fan_traps_metric_metric_base_metric_participates() {
+        let def = minimal_def("o", "d", "d", "m", "count(*)")
+            .clear_dimensions()
+            .clear_metrics()
+            .with_table("li", "line_items", &["id"])
+            .with_metric("order_total", "SUM(amount)", None) // base -> root grain "o"
+            .with_metric("item_count", "COUNT(*)", Some("li"))
+            .with_pkfk_join("items_to_orders", "li", "o", &["order_id"], &["id"]);
+        let resolved_mets: Vec<&_> = def.metrics.iter().collect();
+        let result = check_fan_traps("test", &def, &[], &resolved_mets);
+        match result {
+            Err(ExpandError::MetricFanTrap {
+                metric_name,
+                metric_table,
+                other_metric_name,
+                ..
+            }) => {
+                assert_eq!(metric_name, "order_total");
+                assert_eq!(metric_table, "o", "base metric resolves to the root grain");
+                assert_eq!(other_metric_name, "item_count");
+            }
+            other => panic!("Expected MetricFanTrap, got: {other:?}"),
+        }
+    }
+
+    /// SG-7: a definition whose relationship graph cannot be rebuilt (here: a
+    /// self-referencing join) must ERROR, not silently skip the safety check.
+    #[test]
+    fn test_check_fan_traps_unbuildable_graph_errors() {
+        let def = minimal_def("orders", "region", "region", "total", "sum(amount)").with_pkfk_join(
+            "self_ref",
+            "orders",
+            "orders",
+            &["parent_id"],
+            &["id"],
+        );
+        let resolved_dims: Vec<&_> = def.dimensions.iter().collect();
+        let resolved_mets: Vec<&_> = def.metrics.iter().collect();
+        let result = check_fan_traps("test", &def, &resolved_dims, &resolved_mets);
+        match result {
+            Err(ExpandError::UncheckableDefinition { view_name, reason }) => {
+                assert_eq!(view_name, "test");
+                assert!(
+                    reason.contains("cannot reference itself"),
+                    "reason should carry the graph error: {reason}"
+                );
+            }
+            other => panic!("Expected UncheckableDefinition, got: {other:?}"),
+        }
+        // Same for the fact-path validator (only reached with >= 2 tables).
+        let result = validate_fact_table_path("test", &def, &["a".to_string()], &["b".to_string()]);
+        assert!(
+            matches!(result, Err(ExpandError::UncheckableDefinition { .. })),
+            "validate_fact_table_path must also error on an unbuildable graph, got: {result:?}"
+        );
+    }
+
+    /// SG-16: two named relationships between the same table pair with
+    /// differing cardinalities (role-playing). The fan-out must be detected
+    /// regardless of declaration order, and the error must name the
+    /// relationship that actually fans (the `ManyToOne` one).
+    #[test]
+    fn test_check_fan_traps_role_playing_worst_case_cardinality() {
+        for m2o_first in [true, false] {
+            let mut def = minimal_def("orders", "item_name", "name", "total", "sum(amount)")
+                .with_table("orders", "orders", &["id"])
+                .with_table("line_items", "line_items", &["id"])
+                .with_dimension("item_name", "name", Some("line_items"))
+                .with_metric("total", "sum(amount)", Some("orders"))
+                .with_pkfk_join("rel_m2o", "line_items", "orders", &["order_id"], &["id"])
+                .with_pkfk_join("rel_o2o", "line_items", "orders", &["id"], &["id"]);
+            def.dimensions.retain(|d| d.source_table.is_some());
+            def.metrics.retain(|m| m.source_table.is_some());
+            let n = def.joins.len();
+            def.joins[n - 1].cardinality = Cardinality::OneToOne;
+            if !m2o_first {
+                def.joins.swap(n - 2, n - 1);
+            }
+            let resolved_dims: Vec<&_> = def.dimensions.iter().collect();
+            let resolved_mets: Vec<&_> = def.metrics.iter().collect();
+            let result = check_fan_traps("test", &def, &resolved_dims, &resolved_mets);
+            match result {
+                Err(ExpandError::FanTrap {
+                    relationship_name, ..
+                }) => {
+                    assert_eq!(
+                        relationship_name, "rel_m2o",
+                        "error must name the fanning relationship (m2o_first={m2o_first})"
+                    );
+                }
+                other => panic!(
+                    "Fan-out must be detected regardless of declaration order \
+                     (m2o_first={m2o_first}), got: {other:?}"
+                ),
+            }
+        }
     }
 
     #[test]

--- a/src/expand/join_resolver.rs
+++ b/src/expand/join_resolver.rs
@@ -1,10 +1,10 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::graph::RelationshipGraph;
 use crate::model::{Join, SemanticViewDefinition, TableRef};
 
 use super::facts::{collect_derived_metric_source_tables, collect_derived_metric_using};
-use super::resolution::quote_ident;
+use super::resolution::{qualify_and_quote_table_ref, quote_ident};
 
 /// Synthesize an ON clause from PK/FK column declarations (Phase 26).
 ///
@@ -58,67 +58,197 @@ pub(super) fn synthesize_on_clause_scoped(
     pairs.join(" AND ")
 }
 
+/// A join edge chosen by the resolver, in emission order.
+///
+/// Carries everything the emitters need to render the JOIN clause directly:
+/// no re-searching `def.joins` by alias (SG-2) and no re-parsing of scoped
+/// alias strings at `__` (SG-12).
+pub(super) struct ResolvedJoin<'a> {
+    /// SQL alias emitted after `AS` — the bare table alias (lowercased) or a
+    /// role-playing scoped alias in the documented `{bare}__{rel}` format.
+    pub emit_alias: String,
+    /// The bare (lowercased) table alias, used to look up the physical table
+    /// name in `def.tables`.
+    pub bare_alias: String,
+    /// The join edge connecting `emit_alias` to an already-emitted table.
+    pub join: &'a Join,
+    /// Whether `emit_alias` is a role-playing scoped alias. Scoped joins put
+    /// the scoped alias on the PK side of the synthesized ON clause.
+    pub scoped: bool,
+}
+
+/// Render `LEFT JOIN` clauses for resolver-selected edges onto `sql`.
+///
+/// `prefix` carries the newline + indentation + keyword for the emission site
+/// (e.g. `"\nLEFT JOIN "` in flat queries, `"\n    LEFT JOIN "` inside CTEs).
+pub(super) fn push_join_clauses(
+    sql: &mut String,
+    joins: &[ResolvedJoin<'_>],
+    def: &SemanticViewDefinition,
+    prefix: &str,
+) {
+    for rj in joins {
+        let table_ref = def
+            .tables
+            .iter()
+            .find(|t| t.alias.to_ascii_lowercase() == rj.bare_alias);
+        let physical_table = table_ref.map_or(rj.bare_alias.as_str(), |t| t.table.as_str());
+        sql.push_str(prefix);
+        sql.push_str(&qualify_and_quote_table_ref(physical_table, def));
+        sql.push_str(" AS ");
+        sql.push_str(&quote_ident(&rj.emit_alias));
+        sql.push_str(" ON ");
+        if rj.scoped {
+            sql.push_str(&synthesize_on_clause_scoped(
+                rj.join,
+                &def.tables,
+                &rj.emit_alias,
+            ));
+        } else {
+            sql.push_str(&synthesize_on_clause(rj.join, &def.tables));
+        }
+    }
+}
+
+/// Undirected BFS from the graph root over PK/FK join edges.
+///
+/// Returns, for each reachable non-root alias, its tree parent (the neighbor
+/// on the path toward the root) and the `Join` edge connecting the two. This
+/// is the edge the emitters must use for the alias's ON clause: any other join
+/// mentioning the alias would reference a table that is not yet (or never)
+/// joined (SG-2). Traversing edges in both directions also covers tables on
+/// the FK side of the root (SG-10).
+fn build_tree_parents<'a>(
+    def: &'a SemanticViewDefinition,
+    root: &str,
+) -> HashMap<String, (String, &'a Join)> {
+    let mut tree_parent: HashMap<String, (String, &'a Join)> = HashMap::new();
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(root.to_string());
+    let mut queue: VecDeque<String> = VecDeque::new();
+    queue.push_back(root.to_string());
+    while let Some(current) = queue.pop_front() {
+        // Visit edges in declaration order for determinism.
+        for join in &def.joins {
+            if join.fk_columns.is_empty() {
+                continue; // Legacy join -- not part of the PK/FK graph
+            }
+            let from = join.from_alias.to_ascii_lowercase();
+            let to = join.table.to_ascii_lowercase();
+            let neighbor = if from == current {
+                to
+            } else if to == current {
+                from
+            } else {
+                continue;
+            };
+            if visited.insert(neighbor.clone()) {
+                tree_parent.insert(neighbor.clone(), (current.clone(), join));
+                queue.push_back(neighbor.clone());
+            }
+        }
+    }
+    tree_parent
+}
+
+/// Append a bare-alias join to `result`, choosing the connecting edge.
+///
+/// Reachable aliases use their BFS tree edge. Aliases disconnected from the
+/// root (degenerate definitions that predate stricter validation) fall back to
+/// the first declared join mentioning the alias; aliases with no join at all
+/// are skipped, matching the previous emitters' behavior.
+fn push_bare_join<'a>(
+    result: &mut Vec<ResolvedJoin<'a>>,
+    def: &'a SemanticViewDefinition,
+    tree_parent: &HashMap<String, (String, &'a Join)>,
+    alias: String,
+) {
+    let join = if let Some((_, join)) = tree_parent.get(&alias) {
+        *join
+    } else {
+        let Some(join) = def.joins.iter().find(|j| {
+            j.table.to_ascii_lowercase() == alias || j.from_alias.to_ascii_lowercase() == alias
+        }) else {
+            return;
+        };
+        join
+    };
+    result.push(ResolvedJoin {
+        emit_alias: alias.clone(),
+        bare_alias: alias,
+        join,
+        scoped: false,
+    });
+}
+
 /// Resolve which joins are needed using graph-based PK/FK resolution (Phase 26+32).
 ///
-/// Builds a `RelationshipGraph` from the definition, collects needed table aliases
-/// from resolved dimensions and metrics, walks reverse edges to include transitive
-/// intermediaries, and returns aliases in topological order (root-outward).
+/// Builds a `RelationshipGraph` from the definition, collects needed table
+/// aliases from resolved dimensions, metrics, and fact source tables, includes
+/// every table on the path between the root and a needed alias (in both edge
+/// directions — SG-10), and returns structured join edges in emission order:
+/// each edge's ON clause references only the new alias and already-emitted
+/// tables (SG-2).
+///
+/// `fact_source_tables` carries fact source aliases for the facts path
+/// (`expand_facts`); other callers pass `&[]`. Fact-driven joins are appended
+/// after dimension-driven joins, preserving the historical clause order.
 ///
 /// Phase 32: When metrics have `using_relationships`, generates scoped aliases
-/// (`{to_alias}__{rel_name}`) instead of bare aliases. Scoped aliases are placed
-/// after the corresponding bare alias position in topological order.
+/// (`{to_alias}__{rel_name}`) instead of bare aliases. Scoped joins are placed
+/// after all bare joins, sorted by alias for deterministic output.
 #[allow(clippy::too_many_lines)]
-pub(super) fn resolve_joins_pkfk(
-    def: &SemanticViewDefinition,
+pub(super) fn resolve_joins_pkfk<'a>(
+    def: &'a SemanticViewDefinition,
     resolved_dims: &[&crate::model::Dimension],
     resolved_mets: &[&crate::model::Metric],
-) -> Vec<String> {
+    fact_source_tables: &[String],
+) -> Vec<ResolvedJoin<'a>> {
     let Ok(graph) = RelationshipGraph::from_definition(def) else {
         return Vec::new(); // Graph was validated at define time
     };
 
     let root = &graph.root;
 
-    // Phase 32: Collect scoped aliases from metrics with USING relationships.
-    let mut scoped_aliases: Vec<String> = Vec::new();
+    // Phase 32: Collect scoped joins from metrics with USING relationships.
+    // Each entry carries the scoped alias and the resolved Join edge, so the
+    // emitters never re-derive the relationship from the alias string (SG-12).
+    let mut scoped_joins: Vec<(String, &Join)> = Vec::new();
     // Also track which bare aliases are role-playing (have multiple relationships).
     let mut role_playing_bare_aliases: HashSet<String> = HashSet::new();
+
+    let add_scoped = |scoped_joins: &mut Vec<(String, &'a Join)>,
+                      role_playing: &mut HashSet<String>,
+                      using_rel: &str| {
+        let using_rel_lower = using_rel.to_ascii_lowercase();
+        if let Some(join) = def.joins.iter().find(|j| {
+            j.name
+                .as_ref()
+                .is_some_and(|n| n.to_ascii_lowercase() == using_rel_lower)
+        }) {
+            let to_alias = join.table.to_ascii_lowercase();
+            let scoped = format!("{to_alias}__{using_rel_lower}");
+            if !scoped_joins.iter().any(|(s, _)| *s == scoped) {
+                scoped_joins.push((scoped, join));
+            }
+            role_playing.insert(to_alias);
+        }
+    };
 
     for met in resolved_mets {
         if !met.using_relationships.is_empty() {
             for using_rel in &met.using_relationships {
-                // Find the join for this relationship name
-                let using_rel_lower = using_rel.to_ascii_lowercase();
-                if let Some(join) = def.joins.iter().find(|j| {
-                    j.name
-                        .as_ref()
-                        .is_some_and(|n| n.to_ascii_lowercase() == using_rel_lower)
-                }) {
-                    let to_alias = join.table.to_ascii_lowercase();
-                    let scoped = format!("{to_alias}__{using_rel_lower}");
-                    if !scoped_aliases.contains(&scoped) {
-                        scoped_aliases.push(scoped);
-                    }
-                    role_playing_bare_aliases.insert(to_alias);
-                }
+                add_scoped(&mut scoped_joins, &mut role_playing_bare_aliases, using_rel);
             }
         } else if met.source_table.is_none() {
             // Derived metric: walk transitive USING relationships
             let transitive_using = collect_derived_metric_using(met, &def.metrics);
             for using_rel in transitive_using {
-                let using_rel_lower = using_rel.to_ascii_lowercase();
-                if let Some(join) = def.joins.iter().find(|j| {
-                    j.name
-                        .as_ref()
-                        .is_some_and(|n| n.to_ascii_lowercase() == using_rel_lower)
-                }) {
-                    let to_alias = join.table.to_ascii_lowercase();
-                    let scoped = format!("{to_alias}__{using_rel_lower}");
-                    if !scoped_aliases.contains(&scoped) {
-                        scoped_aliases.push(scoped);
-                    }
-                    role_playing_bare_aliases.insert(to_alias);
-                }
+                add_scoped(
+                    &mut scoped_joins,
+                    &mut role_playing_bare_aliases,
+                    &using_rel,
+                );
             }
         }
     }
@@ -167,37 +297,119 @@ pub(super) fn resolve_joins_pkfk(
         }
     }
 
-    // If no bare aliases or scoped aliases needed, return empty
-    if needed.is_empty() && scoped_aliases.is_empty() {
+    // Fact source tables (facts path only), in declaration order.
+    let mut fact_needed: Vec<String> = Vec::new();
+    for st in fact_source_tables {
+        let alias = st.to_ascii_lowercase();
+        if alias != *root && !fact_needed.contains(&alias) {
+            fact_needed.push(alias);
+        }
+    }
+
+    // If no bare aliases, fact aliases, or scoped aliases needed, return empty
+    if needed.is_empty() && scoped_joins.is_empty() && fact_needed.is_empty() {
         return Vec::new();
     }
 
-    // Walk reverse edges to include transitive intermediaries for bare aliases.
-    let mut all_needed: HashSet<String> = needed.clone();
-    let mut to_visit: Vec<String> = needed.into_iter().collect();
-    while let Some(current) = to_visit.pop() {
-        if let Some(parents) = graph.reverse.get(&current) {
-            for parent in parents {
-                if parent != root && all_needed.insert(parent.clone()) {
-                    to_visit.push(parent.clone());
+    // Map each reachable alias to its connecting edge on the path to the root.
+    let tree_parent = build_tree_parents(def, root);
+
+    // Include every table on the path between the root and each needed alias.
+    let mut all_needed: HashSet<String> = HashSet::new();
+    for alias in &needed {
+        if tree_parent.contains_key(alias) {
+            // Reachable: walk the parent chain to the root, adding intermediaries.
+            let mut current = alias.clone();
+            while current != *root && all_needed.insert(current.clone()) {
+                let Some((parent, _)) = tree_parent.get(&current) else {
+                    break;
+                };
+                current = parent.clone();
+            }
+        } else {
+            // Disconnected from the root (degenerate definition): legacy
+            // reverse-edge walk, preserving pre-existing emission behavior.
+            all_needed.insert(alias.clone());
+            let mut to_visit = vec![alias.clone()];
+            while let Some(current) = to_visit.pop() {
+                if let Some(parents) = graph.reverse.get(&current) {
+                    for parent in parents {
+                        if parent != root && all_needed.insert(parent.clone()) {
+                            to_visit.push(parent.clone());
+                        }
+                    }
                 }
             }
         }
     }
 
-    // Build the result: bare aliases in topo order, then scoped aliases after.
+    // Base ordering: topological order over the PK/FK graph.
     let Ok(topo_order) = graph.toposort() else {
         return Vec::new(); // Should not happen -- validated at define time
     };
-
-    let mut result: Vec<String> = topo_order
+    let mut ordered: Vec<String> = topo_order
         .into_iter()
         .filter(|alias| all_needed.contains(alias))
         .collect();
 
-    // Sort scoped aliases for deterministic output, then append
-    scoped_aliases.sort();
-    result.extend(scoped_aliases);
+    // Stable re-sort: each reachable alias's tree parent must be emitted first
+    // (or be the root). Kahn order already satisfies this for root-outward
+    // trees; FK-side chains below the root need the fix (SG-10).
+    let mut emission: Vec<String> = Vec::with_capacity(ordered.len());
+    while !ordered.is_empty() {
+        let pos = ordered
+            .iter()
+            .position(|alias| match tree_parent.get(alias) {
+                Some((parent, _)) => parent == root || !ordered.contains(parent),
+                None => true, // Disconnected: no ordering constraint
+            });
+        // Reachable aliases always have their full parent chain included, so
+        // some alias is always emittable; fall back to the front defensively.
+        emission.push(ordered.remove(pos.unwrap_or(0)));
+    }
+
+    let mut result: Vec<ResolvedJoin<'a>> = Vec::new();
+    for alias in emission {
+        push_bare_join(&mut result, def, &tree_parent, alias);
+    }
+
+    // Fact-driven joins: appended after dimension-driven joins, each with its
+    // path intermediaries in root-outward order (SG-10 on the facts path).
+    for alias in fact_needed {
+        if result.iter().any(|rj| rj.emit_alias == alias) {
+            continue;
+        }
+        if tree_parent.contains_key(&alias) {
+            let mut path: Vec<String> = Vec::new();
+            let mut current = alias;
+            while current != *root {
+                path.push(current.clone());
+                let Some((parent, _)) = tree_parent.get(&current) else {
+                    break;
+                };
+                current = parent.clone();
+            }
+            for path_alias in path.into_iter().rev() {
+                if result.iter().any(|rj| rj.emit_alias == path_alias) {
+                    continue;
+                }
+                push_bare_join(&mut result, def, &tree_parent, path_alias);
+            }
+        } else {
+            push_bare_join(&mut result, def, &tree_parent, alias);
+        }
+    }
+
+    // Sort scoped joins by alias for deterministic output, then append.
+    scoped_joins.sort_by(|a, b| a.0.cmp(&b.0));
+    for (scoped_alias, join) in scoped_joins {
+        result.push(ResolvedJoin {
+            bare_alias: join.table.to_ascii_lowercase(),
+            emit_alias: scoped_alias,
+            join,
+            scoped: true,
+        });
+    }
 
     result
 }
@@ -358,7 +570,7 @@ mod tests {
         let def = orders_view();
         let resolved_dims: Vec<&_> = def.dimensions.iter().collect();
         let resolved_mets: Vec<&_> = def.metrics.iter().collect();
-        let result = resolve_joins_pkfk(&def, &resolved_dims, &resolved_mets);
+        let result = resolve_joins_pkfk(&def, &resolved_dims, &resolved_mets, &[]);
         assert!(result.is_empty(), "No joins should produce empty result");
     }
 
@@ -377,10 +589,11 @@ mod tests {
             );
         let resolved_dims: Vec<&_> = def.dimensions.iter().collect();
         let resolved_mets: Vec<&_> = def.metrics.iter().collect();
-        let result = resolve_joins_pkfk(&def, &resolved_dims, &resolved_mets);
+        let result = resolve_joins_pkfk(&def, &resolved_dims, &resolved_mets, &[]);
         assert!(
-            result.contains(&"customers".to_string()),
-            "Should include customers join, got: {result:?}"
+            result.iter().any(|rj| rj.emit_alias == "customers"),
+            "Should include customers join, got: {:?}",
+            result.iter().map(|rj| &rj.emit_alias).collect::<Vec<_>>()
         );
     }
 
@@ -412,10 +625,13 @@ mod tests {
             );
         let resolved_dims: Vec<&_> = def.dimensions.iter().collect();
         let resolved_mets: Vec<&_> = def.metrics.iter().collect();
-        let result = resolve_joins_pkfk(&def, &resolved_dims, &resolved_mets);
+        let result = resolve_joins_pkfk(&def, &resolved_dims, &resolved_mets, &[]);
         assert!(
-            result.iter().any(|a| a.contains("airports__dep_airport")),
-            "Should include scoped alias airports__dep_airport, got: {result:?}"
+            result
+                .iter()
+                .any(|rj| rj.emit_alias == "airports__dep_airport" && rj.scoped),
+            "Should include scoped alias airports__dep_airport, got: {:?}",
+            result.iter().map(|rj| &rj.emit_alias).collect::<Vec<_>>()
         );
     }
 }

--- a/src/expand/materialization.rs
+++ b/src/expand/materialization.rs
@@ -157,7 +157,15 @@ fn build_materialized_sql(
     }
 
     let mut sql = String::with_capacity(128);
-    sql.push_str("SELECT\n");
+    if mets.is_empty() {
+        // Dims-only requests emit SELECT DISTINCT on the normal expansion
+        // path; a routed query must match those semantics — a materialization
+        // table containing duplicate rows would otherwise silently change
+        // results (SG-11, code-review 2026-07-02).
+        sql.push_str("SELECT DISTINCT\n");
+    } else {
+        sql.push_str("SELECT\n");
+    }
     sql.push_str(&items.join(",\n"));
     sql.push_str("\nFROM ");
     sql.push_str(&qualify_and_quote_table_ref(table, def));
@@ -486,6 +494,42 @@ mod tests {
         assert!(
             try_route_materialization(&def, &dims, &mets).is_none(),
             "dims-only query should not match mat that has metrics"
+        );
+    }
+
+    // ================================================
+    // Dims-only routed queries apply SELECT DISTINCT (SG-11)
+    // ================================================
+
+    #[test]
+    fn dims_only_routed_query_selects_distinct() {
+        let def =
+            orders_view().with_materialization("region_list", "region_table", &["region"], &[]);
+        let dims = resolve_dims(&def, &["region"]);
+        let mets: Vec<&Metric> = vec![];
+        let sql = try_route_materialization(&def, &dims, &mets)
+            .expect("dims-only mat should match dims-only query");
+        assert!(
+            sql.starts_with("SELECT DISTINCT"),
+            "dims-only routed SQL must apply DISTINCT to match the raw \
+             expansion path's semantics (SG-11): {sql}"
+        );
+    }
+
+    #[test]
+    fn routed_query_with_metrics_does_not_select_distinct() {
+        let def = orders_view().with_materialization(
+            "region_agg",
+            "agg_table",
+            &["region"],
+            &["total_revenue"],
+        );
+        let dims = resolve_dims(&def, &["region"]);
+        let mets = resolve_mets(&def, &["total_revenue"]);
+        let sql = try_route_materialization(&def, &dims, &mets).expect("exact match should route");
+        assert!(
+            sql.starts_with("SELECT\n"),
+            "routed SQL with metrics must not apply DISTINCT: {sql}"
         );
     }
 

--- a/src/expand/resolution.rs
+++ b/src/expand/resolution.rs
@@ -98,11 +98,34 @@ pub fn qualify_and_quote_table_ref(table: &str, def: &SemanticViewDefinition) ->
     parts.join(".")
 }
 
+/// True when a qualified request's table part matches an item's declared
+/// `source_table` (case-insensitive). Items declared WITHOUT a table
+/// qualifier (`source_table == None`) are base-table items everywhere else in
+/// the expansion layer, so they match when the requested alias is the
+/// base/root (first declared) table's alias.
+fn source_table_matches(
+    source_table: Option<&str>,
+    alias: &str,
+    def: &SemanticViewDefinition,
+) -> bool {
+    match source_table {
+        Some(st) => st.eq_ignore_ascii_case(alias),
+        None => def
+            .tables
+            .first()
+            .is_some_and(|t| t.alias.eq_ignore_ascii_case(alias)),
+    }
+}
+
 /// Look up a dimension by name using case-insensitive matching.
 ///
 /// Supports table-qualified names: if `name` contains a '.' (e.g., "o.region"),
-/// splits into (alias, `bare_name`) and also matches `source_table == alias`.
-/// Falls back to `bare_name` lookup if no qualified match is found.
+/// splits into (alias, `bare_name`) and matches only dimensions whose
+/// `source_table` is that alias (unqualified declarations count as the base
+/// table). There is deliberately NO fallback to a bare-name match when the
+/// table part doesn't match (SG-14): `x.region` must not silently resolve to
+/// a `region` dimension on some other table — the caller surfaces the
+/// standard unknown-dimension error (with suggestions) instead.
 pub(super) fn find_dimension<'a>(
     def: &'a SemanticViewDefinition,
     name: &str,
@@ -110,19 +133,10 @@ pub(super) fn find_dimension<'a>(
     if let Some(dot_pos) = name.find('.') {
         let alias = &name[..dot_pos];
         let bare = &name[dot_pos + 1..];
-        // Try qualified lookup: bare_name match AND source_table == alias
-        if let Some(d) = def.dimensions.iter().find(|d| {
+        def.dimensions.iter().find(|d| {
             d.name.eq_ignore_ascii_case(bare)
-                && d.source_table
-                    .as_deref()
-                    .is_some_and(|st| st.eq_ignore_ascii_case(alias))
-        }) {
-            return Some(d);
-        }
-        // Fall back to bare_name only (backward compat)
-        def.dimensions
-            .iter()
-            .find(|d| d.name.eq_ignore_ascii_case(bare))
+                && source_table_matches(d.source_table.as_deref(), alias, def)
+        })
     } else {
         def.dimensions
             .iter()
@@ -133,8 +147,10 @@ pub(super) fn find_dimension<'a>(
 /// Look up a metric by name using case-insensitive matching.
 ///
 /// Supports table-qualified names: if `name` contains a '.' (e.g., "o.revenue"),
-/// splits into (alias, `bare_name`) and also matches `source_table == alias`.
-/// Falls back to `bare_name` lookup if no qualified match is found.
+/// splits into (alias, `bare_name`) and matches only metrics whose
+/// `source_table` is that alias (unqualified declarations count as the base
+/// table). As with [`find_dimension`], there is NO fallback to a bare-name
+/// match when the table part doesn't match (SG-14).
 pub(super) fn find_metric<'a>(
     def: &'a SemanticViewDefinition,
     name: &str,
@@ -142,17 +158,10 @@ pub(super) fn find_metric<'a>(
     if let Some(dot_pos) = name.find('.') {
         let alias = &name[..dot_pos];
         let bare = &name[dot_pos + 1..];
-        if let Some(m) = def.metrics.iter().find(|m| {
+        def.metrics.iter().find(|m| {
             m.name.eq_ignore_ascii_case(bare)
-                && m.source_table
-                    .as_deref()
-                    .is_some_and(|st| st.eq_ignore_ascii_case(alias))
-        }) {
-            return Some(m);
-        }
-        def.metrics
-            .iter()
-            .find(|m| m.name.eq_ignore_ascii_case(bare))
+                && source_table_matches(m.source_table.as_deref(), alias, def)
+        })
     } else {
         def.metrics
             .iter()
@@ -162,7 +171,9 @@ pub(super) fn find_metric<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::{qualify_and_quote_table_ref, quote_ident, quote_table_ref};
+    use super::{
+        find_dimension, find_metric, qualify_and_quote_table_ref, quote_ident, quote_table_ref,
+    };
     use crate::model::SemanticViewDefinition;
 
     /// Minimal SemanticViewDefinition fixture with optional db_name / schema_name.
@@ -183,6 +194,109 @@ mod tests {
             database_name: db.map(str::to_string),
             schema_name: schema.map(str::to_string),
             comment: None,
+        }
+    }
+
+    mod find_lookup_tests {
+        use super::*;
+        use crate::model::{Dimension, Metric, TableRef};
+
+        /// Base table `o` + joined table `c`. `region` lives on `c`;
+        /// `status` is declared without a source table (base-table item);
+        /// metric `revenue` lives on `c`, metric `order_count` is
+        /// unqualified (None).
+        fn lookup_def() -> SemanticViewDefinition {
+            let mut def = def_with_db_schema(None, None);
+            def.tables = vec![
+                TableRef {
+                    alias: "o".to_string(),
+                    table: "orders".to_string(),
+                    ..Default::default()
+                },
+                TableRef {
+                    alias: "c".to_string(),
+                    table: "customers".to_string(),
+                    ..Default::default()
+                },
+            ];
+            def.dimensions = vec![
+                Dimension {
+                    name: "region".to_string(),
+                    expr: "c.region".to_string(),
+                    source_table: Some("c".to_string()),
+                    ..Default::default()
+                },
+                Dimension {
+                    name: "status".to_string(),
+                    expr: "status".to_string(),
+                    source_table: None,
+                    ..Default::default()
+                },
+            ];
+            def.metrics = vec![
+                Metric {
+                    name: "revenue".to_string(),
+                    expr: "sum(c.amount)".to_string(),
+                    source_table: Some("c".to_string()),
+                    ..Default::default()
+                },
+                Metric {
+                    name: "order_count".to_string(),
+                    expr: "count(*)".to_string(),
+                    source_table: None,
+                    ..Default::default()
+                },
+            ];
+            def
+        }
+
+        #[test]
+        fn qualified_dimension_matching_table_resolves() {
+            let def = lookup_def();
+            let d = find_dimension(&def, "c.region").expect("c.region must resolve");
+            assert_eq!(d.name, "region");
+        }
+
+        #[test]
+        fn qualified_dimension_wrong_table_returns_none() {
+            // SG-14: no silent fallback to a dimension on another table.
+            let def = lookup_def();
+            assert!(find_dimension(&def, "o.region").is_none());
+            assert!(find_dimension(&def, "warehouse.region").is_none());
+        }
+
+        #[test]
+        fn base_alias_matches_unqualified_dimension() {
+            // `status` has source_table == None (base-table item), so the
+            // base alias qualifies it; a non-base alias does not.
+            let def = lookup_def();
+            assert!(find_dimension(&def, "o.status").is_some());
+            assert!(find_dimension(&def, "O.STATUS").is_some());
+            assert!(find_dimension(&def, "c.status").is_none());
+        }
+
+        #[test]
+        fn qualified_metric_wrong_table_returns_none() {
+            let def = lookup_def();
+            assert!(find_metric(&def, "c.revenue").is_some());
+            assert!(find_metric(&def, "o.revenue").is_none());
+            assert!(find_metric(&def, "x.revenue").is_none());
+        }
+
+        #[test]
+        fn base_alias_matches_unqualified_metric() {
+            let def = lookup_def();
+            assert!(find_metric(&def, "o.order_count").is_some());
+            assert!(find_metric(&def, "c.order_count").is_none());
+        }
+
+        #[test]
+        fn bare_lookup_unchanged() {
+            let def = lookup_def();
+            assert!(find_dimension(&def, "region").is_some());
+            assert!(find_dimension(&def, "STATUS").is_some());
+            assert!(find_metric(&def, "revenue").is_some());
+            assert!(find_dimension(&def, "nonexistent").is_none());
         }
     }
 

--- a/src/expand/semi_additive.rs
+++ b/src/expand/semi_additive.rs
@@ -2,8 +2,11 @@
 //!
 //! When any requested metric has a non-empty `non_additive_by` field AND at least
 //! one of its NA dims is NOT in the queried dimensions, the expansion wraps the
-//! base query in a CTE that uses `ROW_NUMBER()` to select snapshot rows before
-//! aggregation.
+//! base query in a CTE that uses `RANK()` to select snapshot rows before
+//! aggregation. `RANK()` — not `ROW_NUMBER()` — so that when the fact grain is
+//! finer than the queried dims (e.g. several accounts per customer, each with a
+//! row at the same latest date), ALL rows tied at the snapshot ordering value
+//! share rank 1 and aggregate together, deterministically (SG-4).
 //!
 //! **Effectively-regular classification (Snowflake semantics):**
 //! A semi-additive metric whose ALL NA dims are present in the queried dimensions
@@ -14,9 +17,18 @@
 //!
 //! The strategy for active semi-additive metrics:
 //! - Single CTE (`__sv_snapshot`) containing all raw columns needed
-//! - `ROW_NUMBER() OVER (PARTITION BY non-NA-dims ORDER BY NA-dims) AS __sv_rn`
+//! - `RANK() OVER (PARTITION BY non-NA-dims ORDER BY NA-dims) AS __sv_rn`
+//!   (the `__sv_rn` column name predates the RANK switch and is pinned by
+//!   sqllogictests -- keep it)
 //! - Outer SELECT: regular/effectively-regular metrics use plain aggregation,
 //!   active semi-additive metrics use `SUM(CASE WHEN __sv_rn = 1 THEN raw_val END)`
+//!
+//! Because the CTE decomposes every metric into an inner-expression capture plus
+//! an outer re-aggregation, every metric in the query must be a single bare
+//! aggregate call `FUNC(args)`. Anything else (arithmetic-wrapped, `COUNT(*)`,
+//! DISTINCT, `COALESCE`-wrapped, multi-aggregate derived metrics) cannot be
+//! decomposed and is rejected with a clear error instead of silently mangled
+//! (SG-5).
 //!
 //! When multiple semi-additive metrics have different NON ADDITIVE BY dimensions,
 //! each gets its own `__sv_rn_N` column in the CTE.
@@ -33,7 +45,7 @@ use super::types::ExpandError;
 /// Returns true when `met` is an ACTIVE semi-additive metric for a query over
 /// `queried_dim_names` (lowercased): it has a NON ADDITIVE BY clause and at
 /// least one of its NA dims is NOT in the queried dimension set, so it takes
-/// the `ROW_NUMBER`-CTE snapshot path. When ALL NA dims are queried, the
+/// the `RANK`-CTE snapshot path. When ALL NA dims are queried, the
 /// metric is "effectively regular" (Snowflake semantics) and takes the
 /// standard aggregation path.
 ///
@@ -53,11 +65,7 @@ pub(super) fn is_active_semi_additive(met: &Metric, queried_dim_names: &HashSet<
 ///
 /// Called from `expand()` when `has_active_semi_additive` is true.
 /// Receives already-resolved dims, metrics, expressions, and scoped aliases.
-#[allow(
-    clippy::too_many_lines,
-    clippy::result_large_err,
-    clippy::unnecessary_wraps
-)]
+#[allow(clippy::too_many_lines, clippy::result_large_err)]
 pub(super) fn expand_semi_additive(
     view_name: &str,
     def: &SemanticViewDefinition,
@@ -66,7 +74,6 @@ pub(super) fn expand_semi_additive(
     resolved_exprs: &HashMap<String, String>,
     dim_scoped_aliases: &[Option<String>],
 ) -> Result<String, ExpandError> {
-    let _ = view_name; // reserved for future error messages
     let mut sql = String::with_capacity(512);
 
     // Build set of queried dimension names for classification
@@ -81,6 +88,45 @@ pub(super) fn expand_semi_additive(
 
     // 1. Identify distinct NON ADDITIVE BY dimension sets for ACTIVE metrics only.
     let na_groups = collect_na_groups(resolved_mets, &queried_dim_names);
+
+    // 2. SG-5: validate every metric expression BEFORE emitting any SQL. The
+    //    snapshot CTE decomposes each metric into an inner-expression capture
+    //    (CTE column) plus an outer re-aggregation, which is only sound for a
+    //    single bare aggregate call. Anything else was previously mangled
+    //    silently (dropped arithmetic, star/DISTINCT arguments emitted as
+    //    broken CTE columns) -- reject it with a clear error instead.
+    let semi_metric_name = resolved_mets
+        .iter()
+        .find(|m| is_active_semi(m))
+        .map_or_else(String::new, |m| m.name.clone());
+    let mut decomposed: Vec<(String, String)> = Vec::with_capacity(resolved_mets.len());
+    for met in resolved_mets {
+        let resolved_expr = resolved_exprs
+            .get(&met.name.to_ascii_lowercase())
+            .cloned()
+            .unwrap_or_else(|| met.expr.clone());
+        match parse_snapshot_aggregate(&resolved_expr) {
+            Ok(parts) => decomposed.push(parts),
+            Err(reason) => {
+                return Err(if is_active_semi(met) {
+                    ExpandError::SemiAdditiveUnsupportedExpression {
+                        view_name: view_name.to_string(),
+                        metric_name: met.name.clone(),
+                        metric_expr: resolved_expr,
+                        reason,
+                    }
+                } else {
+                    ExpandError::SemiAdditiveCoQueryUnsupported {
+                        view_name: view_name.to_string(),
+                        metric_name: met.name.clone(),
+                        metric_expr: resolved_expr,
+                        semi_metric_name: semi_metric_name.clone(),
+                        reason,
+                    }
+                });
+            }
+        }
+    }
 
     // === CTE ===
     sql.push_str("WITH __sv_snapshot AS (\n    SELECT\n");
@@ -107,27 +153,22 @@ pub(super) fn expand_semi_additive(
         ));
     }
 
-    // Metric raw columns in CTE -- extract inner expression from aggregate
+    // Metric raw columns in CTE -- the validated inner expression of each
+    // metric's aggregate call (decomposed above).
     for (met_idx, met) in resolved_mets.iter().enumerate() {
-        let resolved_expr = resolved_exprs
-            .get(&met.name.to_ascii_lowercase())
-            .cloned()
-            .unwrap_or_else(|| met.expr.clone());
-
+        let inner = &decomposed[met_idx].1;
         if is_active_semi(met) {
-            // Active semi-additive: extract inner expression from aggregate
-            let inner =
-                extract_aggregate_inner(&resolved_expr).unwrap_or_else(|| resolved_expr.clone());
+            // Active semi-additive: snapshot-filtered in the outer SELECT
             cte_select_items.push(format!("        {inner} AS \"__sv_semi_{met_idx}\""));
         } else {
-            // Regular or effectively-regular: include raw column reference
-            let inner =
-                extract_aggregate_inner(&resolved_expr).unwrap_or_else(|| resolved_expr.clone());
+            // Regular or effectively-regular: aggregated over all rows
             cte_select_items.push(format!("        {inner} AS \"__sv_reg_{met_idx}\""));
         }
     }
 
-    // ROW_NUMBER columns (one per active NA group)
+    // Snapshot rank columns (one per active NA group). RANK() so that rows
+    // tied on all NA ordering keys share rank 1 and ALL aggregate (SG-4);
+    // ROW_NUMBER() would keep one arbitrary tied row per partition.
     for (group_idx, group) in na_groups.iter().enumerate() {
         let rn_alias = if na_groups.len() == 1 {
             "__sv_rn".to_string()
@@ -157,7 +198,8 @@ pub(super) fn expand_semi_additive(
 
         // ORDER BY: the NA dims with their specified sort order.
         // Use the dimension's raw expression when the NA dim is NOT in the
-        // queried dimensions (it won't have a CTE alias).
+        // queried dimensions (it won't have a CTE alias). That raw expression
+        // may reference a non-base table -- its join is guaranteed below (SG-9).
         let order_items: Vec<String> = group
             .na_dims
             .iter()
@@ -198,7 +240,7 @@ pub(super) fn expand_semi_additive(
         };
 
         cte_select_items.push(format!(
-            "        ROW_NUMBER() OVER ({window_spec}) AS \"{rn_alias}\""
+            "        RANK() OVER ({window_spec}) AS \"{rn_alias}\""
         ));
     }
 
@@ -212,8 +254,13 @@ pub(super) fn expand_semi_additive(
         sql.push_str(&quote_ident(&base_ref.alias));
     }
 
-    // CTE JOINs
-    let resolved_joins = resolve_joins_pkfk(def, resolved_dims, resolved_mets, &[]);
+    // CTE JOINs. SG-9: the snapshot ORDER BY references each active NA dim's
+    // raw expression even when that dim is not queried, so the NA dims'
+    // source tables must be joined too. They are passed through the
+    // resolver's extra-alias parameter, which appends each with its path
+    // intermediaries (aliases already joined for dims/metrics are skipped).
+    let na_dim_sources = collect_na_dim_source_tables(def, &na_groups);
+    let resolved_joins = resolve_joins_pkfk(def, resolved_dims, resolved_mets, &na_dim_sources);
     push_join_clauses(&mut sql, &resolved_joins, def, "\n    LEFT JOIN ");
 
     sql.push_str("\n)\n");
@@ -234,14 +281,11 @@ pub(super) fn expand_semi_additive(
 
     // Metric columns
     for (met_idx, met) in resolved_mets.iter().enumerate() {
-        let resolved_expr = resolved_exprs
-            .get(&met.name.to_ascii_lowercase())
-            .cloned()
-            .unwrap_or_else(|| met.expr.clone());
-        let agg_func = extract_aggregate_func(&resolved_expr).unwrap_or("SUM");
+        let agg_func = &decomposed[met_idx].0;
 
         if is_active_semi(met) {
-            // Active semi-additive: wrap in CASE WHEN __sv_rn = 1
+            // Active semi-additive: aggregate only rows at the snapshot rank.
+            // All rows tied at rank 1 contribute (RANK semantics, SG-4).
             let rn_col = get_rn_column_for_metric(met_idx, &na_groups);
             let final_expr =
                 format!("{agg_func}(CASE WHEN \"{rn_col}\" = 1 THEN \"__sv_semi_{met_idx}\" END)");
@@ -324,45 +368,154 @@ fn collect_na_groups(
         .collect()
 }
 
-/// Extract the inner expression from an aggregate function call.
-/// e.g., "SUM(a.balance)" -> Some("a.balance"), "COUNT(*)" -> Some("*"),
-/// "revenue - cost" -> None (not an aggregate).
-fn extract_aggregate_inner(expr: &str) -> Option<String> {
-    let trimmed = expr.trim();
-    let open = trimmed.find('(')?;
-    let close = trimmed.rfind(')')?;
-    if close <= open {
-        return None;
+/// Collect the (lowercased) source-table aliases of every active NA dim,
+/// resolved against the view's declared dimensions (SG-9).
+///
+/// A NA dim that lives on a non-queried, non-base table contributes its
+/// source alias here so the snapshot CTE joins that table (the resolver adds
+/// path intermediaries); otherwise its raw expression in the snapshot ORDER
+/// BY would reference an unjoined table and fail at bind time. Base-table
+/// dims (`source_table == None`) and unresolvable names contribute nothing.
+fn collect_na_dim_source_tables(
+    def: &SemanticViewDefinition,
+    na_groups: &[NaGroup],
+) -> Vec<String> {
+    let mut sources: Vec<String> = Vec::new();
+    for group in na_groups {
+        for nd in &group.na_dims {
+            let Some(dim) = def
+                .dimensions
+                .iter()
+                .find(|d| d.name.eq_ignore_ascii_case(&nd.dimension))
+            else {
+                continue;
+            };
+            if let Some(ref st) = dim.source_table {
+                let alias = st.to_ascii_lowercase();
+                if !sources.contains(&alias) {
+                    sources.push(alias);
+                }
+            }
+        }
     }
-    // Verify the part before '(' looks like a function name (alphanumeric/underscore)
+    sources
+}
+
+/// Aggregate functions the snapshot CTE knows how to decompose into an
+/// inner-expression capture (CTE column) plus an outer re-aggregation.
+const SNAPSHOT_AGG_FUNCS: [&str; 5] = ["SUM", "COUNT", "AVG", "MIN", "MAX"];
+
+/// Validate and decompose a metric expression for the snapshot CTE (SG-5).
+///
+/// Accepts exactly one top-level aggregate call `FUNC(args)` where `FUNC` is
+/// SUM/COUNT/AVG/MIN/MAX (any case), `args` is neither `*` nor
+/// DISTINCT-qualified, and no expression text precedes or follows the call.
+/// Returns `(FUNC as written, inner argument text)` on success, or a
+/// human-readable reason why the expression cannot be decomposed.
+///
+/// The matching-paren scan is parenthesis-depth and quote aware
+/// (single-quoted SQL strings, double-quoted identifiers), so arguments
+/// containing parens or quotes classify correctly.
+fn parse_snapshot_aggregate(expr: &str) -> Result<(String, String), String> {
+    let trimmed = expr.trim();
+    let Some(open) = trimmed.find('(') else {
+        return Err("the expression is not an aggregate function call".to_string());
+    };
     let func_name = trimmed[..open].trim();
     if func_name.is_empty()
         || !func_name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '_')
     {
-        return None;
+        return Err(
+            "the expression does not start with a single aggregate function call".to_string(),
+        );
     }
-    Some(trimmed[open + 1..close].trim().to_string())
+    if !SNAPSHOT_AGG_FUNCS.contains(&func_name.to_ascii_uppercase().as_str()) {
+        return Err(format!(
+            "aggregate function '{func_name}' cannot be decomposed for snapshot aggregation \
+             (supported: SUM, COUNT, AVG, MIN, MAX)"
+        ));
+    }
+    let Some(close) = find_matching_paren(trimmed, open) else {
+        return Err("unbalanced parentheses in the expression".to_string());
+    };
+    let trailing = trimmed[close + 1..].trim();
+    if !trailing.is_empty() {
+        return Err(format!(
+            "expression text follows the aggregate call: '{trailing}'"
+        ));
+    }
+    let inner = trimmed[open + 1..close].trim();
+    if inner.is_empty() {
+        return Err("the aggregate call has no argument".to_string());
+    }
+    if inner == "*" {
+        return Err("star aggregates like COUNT(*) are not supported".to_string());
+    }
+    if starts_with_distinct_keyword(inner) {
+        return Err("DISTINCT aggregates are not supported".to_string());
+    }
+    Ok((func_name.to_string(), inner.to_string()))
 }
 
-/// Extract the aggregate function name from an expression.
-/// e.g., "SUM(a.balance)" -> Some("SUM"), "COUNT(*)" -> Some("COUNT").
-fn extract_aggregate_func(expr: &str) -> Option<&str> {
-    let trimmed = expr.trim();
-    let open = trimmed.find('(')?;
-    let func_name = trimmed[..open].trim();
-    if func_name.is_empty()
-        || !func_name
+/// Byte index of the `)` matching the `(` at byte offset `open`, or `None`
+/// when unbalanced. Parens inside single-quoted SQL strings and double-quoted
+/// identifiers are ignored; the doubled-quote escapes (`''`, `""`) fall out
+/// naturally from toggling the in-quote state on every quote character.
+fn find_matching_paren(s: &str, open: usize) -> Option<usize> {
+    enum Mode {
+        Normal,
+        SingleQuote,
+        DoubleQuote,
+    }
+    let mut mode = Mode::Normal;
+    let mut depth = 0usize;
+    for (i, c) in s[open..].char_indices() {
+        match mode {
+            Mode::Normal => match c {
+                '(' => depth += 1,
+                ')' => {
+                    depth = depth.checked_sub(1)?;
+                    if depth == 0 {
+                        return Some(open + i);
+                    }
+                }
+                '\'' => mode = Mode::SingleQuote,
+                '"' => mode = Mode::DoubleQuote,
+                _ => {}
+            },
+            Mode::SingleQuote => {
+                if c == '\'' {
+                    mode = Mode::Normal;
+                }
+            }
+            Mode::DoubleQuote => {
+                if c == '"' {
+                    mode = Mode::Normal;
+                }
+            }
+        }
+    }
+    None
+}
+
+/// True when `inner` begins with the `DISTINCT` keyword at a word boundary
+/// (case-insensitive). UTF-8 safe: `get(..8)` returns `None` rather than
+/// panicking when byte 8 is not a char boundary.
+fn starts_with_distinct_keyword(inner: &str) -> bool {
+    let Some(prefix) = inner.get(..8) else {
+        return false;
+    };
+    prefix.eq_ignore_ascii_case("DISTINCT")
+        && inner[8..]
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
-    {
-        return None;
-    }
-    Some(func_name)
+            .next()
+            .is_none_or(|c| !c.is_ascii_alphanumeric() && c != '_')
 }
 
-/// Get the `ROW_NUMBER` column name for a given metric index.
+/// Get the snapshot rank column name (`__sv_rn` / `__sv_rn_N`) for a given
+/// metric index.
 fn get_rn_column_for_metric(met_idx: usize, na_groups: &[NaGroup]) -> String {
     if na_groups.len() == 1 {
         return "__sv_rn".to_string();
@@ -381,10 +534,10 @@ mod tests {
     use crate::expand::{expand, DimensionName, ExpandError, MetricName, QueryRequest};
     use crate::model::{NullsOrder, SortOrder};
 
-    use super::{extract_aggregate_func, extract_aggregate_inner};
+    use super::parse_snapshot_aggregate;
 
     /// Single table, one semi-additive metric with NA dim NOT in query.
-    /// Expects CTE with ROW_NUMBER and conditional aggregation.
+    /// Expects CTE with RANK and conditional aggregation.
     #[test]
     fn test_semi_additive_single_metric_single_dim() {
         let def = minimal_def(
@@ -408,9 +561,10 @@ mod tests {
 
         let sql = expand("test_view", &def, &req).unwrap();
         assert!(sql.contains("WITH __sv_snapshot AS"), "SQL: {sql}");
+        assert!(sql.contains("RANK() OVER"), "Should contain RANK: {sql}");
         assert!(
-            sql.contains("ROW_NUMBER() OVER"),
-            "Should contain ROW_NUMBER: {sql}"
+            !sql.contains("ROW_NUMBER"),
+            "ROW_NUMBER drops snapshot ties (SG-4): {sql}"
         );
         assert!(
             sql.contains("PARTITION BY \"customer_id\""),
@@ -461,10 +615,7 @@ mod tests {
             !sql.contains("WITH __sv_snapshot"),
             "Should NOT have CTE when all NA dims in query: {sql}"
         );
-        assert!(
-            !sql.contains("ROW_NUMBER"),
-            "Should NOT have ROW_NUMBER: {sql}"
-        );
+        assert!(!sql.contains("RANK"), "Should NOT have RANK: {sql}");
         // Standard expansion path
         assert!(
             sql.contains("GROUP BY"),
@@ -568,35 +719,372 @@ mod tests {
             !sql.contains("WITH __sv_snapshot"),
             "Regular-only should NOT have CTE: {sql}"
         );
+        assert!(!sql.contains("RANK"), "Regular-only should NOT rank: {sql}");
+    }
+
+    /// SG-5: shapes the snapshot CTE can decompose.
+    #[test]
+    fn test_parse_snapshot_aggregate_accepts_single_aggregate_calls() {
+        assert_eq!(
+            parse_snapshot_aggregate("SUM(a.balance)"),
+            Ok(("SUM".to_string(), "a.balance".to_string()))
+        );
+        // Function case is preserved so previously-valid emissions stay
+        // byte-identical.
+        assert_eq!(
+            parse_snapshot_aggregate("sum(amount)"),
+            Ok(("sum".to_string(), "amount".to_string()))
+        );
+        assert_eq!(
+            parse_snapshot_aggregate("AVG( amount )"),
+            Ok(("AVG".to_string(), "amount".to_string()))
+        );
+        assert_eq!(
+            parse_snapshot_aggregate("COUNT(id)"),
+            Ok(("COUNT".to_string(), "id".to_string()))
+        );
+        assert_eq!(
+            parse_snapshot_aggregate("MIN(price)"),
+            Ok(("MIN".to_string(), "price".to_string()))
+        );
+        assert_eq!(
+            parse_snapshot_aggregate("MAX(price)"),
+            Ok(("MAX".to_string(), "price".to_string()))
+        );
+        // Parens inside a single-quoted string literal do not fool the scan.
+        assert_eq!(
+            parse_snapshot_aggregate("SUM(CASE WHEN note = ')' THEN amount ELSE 0 END)"),
+            Ok((
+                "SUM".to_string(),
+                "CASE WHEN note = ')' THEN amount ELSE 0 END".to_string()
+            ))
+        );
+        // Parens inside a double-quoted identifier do not fool the scan.
+        assert_eq!(
+            parse_snapshot_aggregate("SUM(\"weird)col\")"),
+            Ok(("SUM".to_string(), "\"weird)col\"".to_string()))
+        );
+        // A column merely named like DISTINCT is not the DISTINCT keyword.
+        assert_eq!(
+            parse_snapshot_aggregate("SUM(distinctive_col)"),
+            Ok(("SUM".to_string(), "distinctive_col".to_string()))
+        );
+    }
+
+    /// SG-5: every previously-silently-mangled shape must now be rejected
+    /// with a reason.
+    #[test]
+    fn test_parse_snapshot_aggregate_rejects_undecomposable_shapes() {
+        // Arithmetic-wrapped: the `* 0.1` was silently DROPPED before.
+        let err = parse_snapshot_aggregate("SUM(amount) * 0.1").unwrap_err();
+        assert!(err.contains("follows the aggregate call"), "got: {err}");
+        // COUNT(*): the `*` was emitted as a broken star-alias CTE column.
+        let err = parse_snapshot_aggregate("COUNT(*)").unwrap_err();
+        assert!(err.contains("star aggregates"), "got: {err}");
+        // DISTINCT (either case).
+        let err = parse_snapshot_aggregate("COUNT(DISTINCT x)").unwrap_err();
+        assert!(err.contains("DISTINCT"), "got: {err}");
+        let err = parse_snapshot_aggregate("count(distinct x)").unwrap_err();
+        assert!(err.contains("DISTINCT"), "got: {err}");
+        // COALESCE-wrapped: only the outermost call is considered.
+        let err = parse_snapshot_aggregate("COALESCE(SUM(x), 0)").unwrap_err();
+        assert!(err.contains("cannot be decomposed"), "got: {err}");
+        // Multi-aggregate (inlined derived metric shape).
+        let err = parse_snapshot_aggregate("SUM(revenue) - SUM(cost)").unwrap_err();
+        assert!(err.contains("follows the aggregate call"), "got: {err}");
+        // Leading expression text.
+        let err = parse_snapshot_aggregate("1 + SUM(x)").unwrap_err();
         assert!(
-            !sql.contains("ROW_NUMBER"),
-            "Regular-only should NOT have ROW_NUMBER: {sql}"
+            err.contains("does not start with a single aggregate"),
+            "got: {err}"
+        );
+        // Not an aggregate at all (previously fell back to a hardcoded SUM).
+        let err = parse_snapshot_aggregate("revenue - cost").unwrap_err();
+        assert!(err.contains("not an aggregate function call"), "got: {err}");
+        let err = parse_snapshot_aggregate("42").unwrap_err();
+        assert!(err.contains("not an aggregate function call"), "got: {err}");
+        // Unsupported aggregate function.
+        let err = parse_snapshot_aggregate("STRING_AGG(x, ',')").unwrap_err();
+        assert!(err.contains("cannot be decomposed"), "got: {err}");
+        // Malformed input never panics.
+        let err = parse_snapshot_aggregate("SUM(").unwrap_err();
+        assert!(err.contains("unbalanced parentheses"), "got: {err}");
+        let err = parse_snapshot_aggregate("SUM()").unwrap_err();
+        assert!(err.contains("no argument"), "got: {err}");
+    }
+
+    /// SG-5: a regular metric with an arithmetic-wrapped aggregate co-queried
+    /// with an active semi-additive metric errors instead of silently
+    /// dropping the arithmetic.
+    #[test]
+    fn test_co_query_arithmetic_wrapped_metric_errors() {
+        let def = minimal_def(
+            "accounts",
+            "customer_id",
+            "customer_id",
+            "balance",
+            "SUM(balance)",
+        )
+        .with_dimension("report_date", "report_date", None)
+        .with_metric("discounted", "SUM(amount) * 0.1", None)
+        .with_non_additive_by(
+            "balance",
+            &[("report_date", SortOrder::Desc, NullsOrder::First)],
+        );
+
+        let req = QueryRequest {
+            facts: vec![],
+            dimensions: vec![DimensionName::new("customer_id")],
+            metrics: vec![MetricName::new("discounted"), MetricName::new("balance")],
+        };
+
+        let result = expand("test_view", &def, &req);
+        match result {
+            Err(ExpandError::SemiAdditiveCoQueryUnsupported {
+                metric_name,
+                semi_metric_name,
+                ..
+            }) => {
+                assert_eq!(metric_name, "discounted");
+                assert_eq!(semi_metric_name, "balance");
+            }
+            other => panic!("expected SemiAdditiveCoQueryUnsupported, got: {other:?}"),
+        }
+    }
+
+    /// SG-5: `COUNT(*)` co-queried with an active semi-additive metric errors
+    /// instead of emitting a star-alias CTE column that COUNTs an arbitrary
+    /// (NULL-sensitive) join column.
+    #[test]
+    fn test_co_query_count_star_errors() {
+        let def = minimal_def(
+            "accounts",
+            "customer_id",
+            "customer_id",
+            "balance",
+            "SUM(balance)",
+        )
+        .with_dimension("report_date", "report_date", None)
+        .with_metric("row_count", "COUNT(*)", None)
+        .with_non_additive_by(
+            "balance",
+            &[("report_date", SortOrder::Desc, NullsOrder::First)],
+        );
+
+        let req = QueryRequest {
+            facts: vec![],
+            dimensions: vec![DimensionName::new("customer_id")],
+            metrics: vec![MetricName::new("row_count"), MetricName::new("balance")],
+        };
+
+        let result = expand("test_view", &def, &req);
+        assert!(
+            matches!(
+                result,
+                Err(ExpandError::SemiAdditiveCoQueryUnsupported { .. })
+            ),
+            "COUNT(*) co-query must error, got: {result:?}"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("cannot be co-queried with semi-additive metric 'balance'"),
+            "message should name both metrics: {msg}"
+        );
+        assert!(
+            msg.contains("separately"),
+            "message should suggest querying separately: {msg}"
         );
     }
 
-    /// Unit test for extract_aggregate_inner helper.
+    /// SG-5: DISTINCT aggregate co-query errors.
     #[test]
-    fn test_extract_aggregate_inner() {
-        assert_eq!(
-            extract_aggregate_inner("SUM(a.balance)"),
-            Some("a.balance".to_string())
+    fn test_co_query_count_distinct_errors() {
+        let def = minimal_def(
+            "accounts",
+            "customer_id",
+            "customer_id",
+            "balance",
+            "SUM(balance)",
+        )
+        .with_dimension("report_date", "report_date", None)
+        .with_metric("uniq_customers", "COUNT(DISTINCT customer_id)", None)
+        .with_non_additive_by(
+            "balance",
+            &[("report_date", SortOrder::Desc, NullsOrder::First)],
         );
-        assert_eq!(extract_aggregate_inner("COUNT(*)"), Some("*".to_string()));
-        assert_eq!(
-            extract_aggregate_inner("AVG(amount)"),
-            Some("amount".to_string())
+
+        let req = QueryRequest {
+            facts: vec![],
+            dimensions: vec![DimensionName::new("customer_id")],
+            metrics: vec![
+                MetricName::new("uniq_customers"),
+                MetricName::new("balance"),
+            ],
+        };
+
+        let result = expand("test_view", &def, &req);
+        assert!(
+            matches!(
+                result,
+                Err(ExpandError::SemiAdditiveCoQueryUnsupported { .. })
+            ),
+            "COUNT(DISTINCT ...) co-query must error, got: {result:?}"
         );
-        assert_eq!(extract_aggregate_inner("revenue - cost"), None);
-        assert_eq!(extract_aggregate_inner("42"), None);
     }
 
-    /// Unit test for extract_aggregate_func helper.
+    /// SG-5: COALESCE-wrapped aggregate co-query errors.
     #[test]
-    fn test_extract_aggregate_func() {
-        assert_eq!(extract_aggregate_func("SUM(a.balance)"), Some("SUM"));
-        assert_eq!(extract_aggregate_func("COUNT(*)"), Some("COUNT"));
-        assert_eq!(extract_aggregate_func("AVG(amount)"), Some("AVG"));
-        assert_eq!(extract_aggregate_func("revenue - cost"), None);
+    fn test_co_query_coalesce_wrapped_errors() {
+        let def = minimal_def(
+            "accounts",
+            "customer_id",
+            "customer_id",
+            "balance",
+            "SUM(balance)",
+        )
+        .with_dimension("report_date", "report_date", None)
+        .with_metric("safe_total", "COALESCE(SUM(amount), 0)", None)
+        .with_non_additive_by(
+            "balance",
+            &[("report_date", SortOrder::Desc, NullsOrder::First)],
+        );
+
+        let req = QueryRequest {
+            facts: vec![],
+            dimensions: vec![DimensionName::new("customer_id")],
+            metrics: vec![MetricName::new("safe_total"), MetricName::new("balance")],
+        };
+
+        let result = expand("test_view", &def, &req);
+        assert!(
+            matches!(
+                result,
+                Err(ExpandError::SemiAdditiveCoQueryUnsupported { .. })
+            ),
+            "COALESCE-wrapped co-query must error, got: {result:?}"
+        );
+    }
+
+    /// SG-5: a derived metric (inlines to a multi-aggregate expression)
+    /// co-queried with an active semi-additive metric errors instead of
+    /// falling back to a hardcoded SUM over a mangled column.
+    #[test]
+    fn test_co_query_derived_metric_errors() {
+        let def = minimal_def(
+            "accounts",
+            "customer_id",
+            "customer_id",
+            "balance",
+            "SUM(balance)",
+        )
+        .with_dimension("report_date", "report_date", None)
+        .with_metric("revenue", "SUM(amount)", None)
+        .with_metric("cost_total", "SUM(cost)", None)
+        .with_metric("profit", "revenue - cost_total", None)
+        .with_non_additive_by(
+            "balance",
+            &[("report_date", SortOrder::Desc, NullsOrder::First)],
+        );
+
+        let req = QueryRequest {
+            facts: vec![],
+            dimensions: vec![DimensionName::new("customer_id")],
+            metrics: vec![MetricName::new("profit"), MetricName::new("balance")],
+        };
+
+        let result = expand("test_view", &def, &req);
+        match result {
+            Err(ExpandError::SemiAdditiveCoQueryUnsupported {
+                metric_name,
+                metric_expr,
+                ..
+            }) => {
+                assert_eq!(metric_name, "profit");
+                // The error carries the INLINED expression the CTE would
+                // have had to decompose.
+                assert!(
+                    metric_expr.contains("SUM(amount)") && metric_expr.contains("SUM(cost)"),
+                    "expected inlined derived expression, got: {metric_expr}"
+                );
+            }
+            other => panic!("expected SemiAdditiveCoQueryUnsupported, got: {other:?}"),
+        }
+    }
+
+    /// SG-5: the active semi-additive metric's OWN expression is validated
+    /// too — an arithmetic-wrapped NON ADDITIVE BY metric errors instead of
+    /// silently dropping the arithmetic.
+    #[test]
+    fn test_semi_additive_metric_own_expression_validated() {
+        let def = minimal_def(
+            "accounts",
+            "customer_id",
+            "customer_id",
+            "balance",
+            "SUM(balance) * 2",
+        )
+        .with_dimension("report_date", "report_date", None)
+        .with_non_additive_by(
+            "balance",
+            &[("report_date", SortOrder::Desc, NullsOrder::First)],
+        );
+
+        let req = QueryRequest {
+            facts: vec![],
+            dimensions: vec![DimensionName::new("customer_id")],
+            metrics: vec![MetricName::new("balance")],
+        };
+
+        let result = expand("test_view", &def, &req);
+        match result {
+            Err(ExpandError::SemiAdditiveUnsupportedExpression { metric_name, .. }) => {
+                assert_eq!(metric_name, "balance");
+            }
+            other => panic!("expected SemiAdditiveUnsupportedExpression, got: {other:?}"),
+        }
+    }
+
+    /// SG-9: a NON ADDITIVE BY dim living on a non-queried, non-base table
+    /// must get its source table joined into the snapshot CTE — otherwise the
+    /// snapshot ORDER BY references an unjoined alias and fails at bind time.
+    /// Topology: base `a AS accounts` with `a(date_id) REFERENCES d`, NA dim
+    /// `report_date = d.report_date`, query by a BASE dim only.
+    #[test]
+    fn test_na_dim_on_non_queried_table_joins_its_source() {
+        let mut def = minimal_def(
+            "accounts",
+            "customer_id",
+            "a.customer_id",
+            "balance",
+            "SUM(a.balance)",
+        );
+        def.tables[0].alias = "a".to_string();
+        def.tables[0].pk_columns = vec!["id".to_string()];
+        def.metrics[0].source_table = Some("a".to_string());
+        let def = def
+            .with_table("d", "dates", &["id"])
+            .with_dimension("report_date", "d.report_date", Some("d"))
+            .with_non_additive_by(
+                "balance",
+                &[("report_date", SortOrder::Desc, NullsOrder::First)],
+            )
+            .with_pkfk_join("acct_date", "a", "d", &["date_id"], &["id"]);
+
+        let req = QueryRequest {
+            facts: vec![],
+            dimensions: vec![DimensionName::new("customer_id")],
+            metrics: vec![MetricName::new("balance")],
+        };
+
+        let sql = expand("test_view", &def, &req).unwrap();
+        assert!(
+            sql.contains("LEFT JOIN \"dates\" AS \"d\" ON \"a\".\"date_id\" = \"d\".\"id\""),
+            "Snapshot CTE must join the NA dim's source table: {sql}"
+        );
+        assert!(
+            sql.contains("ORDER BY d.report_date DESC NULLS FIRST"),
+            "Snapshot ORDER BY must reference the joined alias: {sql}"
+        );
     }
 
     /// Metrics-only (no dims) semi-additive -> global aggregate with CTE.
@@ -640,7 +1128,7 @@ mod tests {
 
     /// SG-6 (code review 2026-07-02): a semi-additive metric whose NA dims
     /// are ALL in the queried dimensions is "effectively regular" — it takes
-    /// the standard aggregation path (never the `ROW_NUMBER` CTE), so it MUST
+    /// the standard aggregation path (never the snapshot CTE), so it MUST
     /// get the standard fan-trap check. The previous unconditional
     /// `non_additive_by`-non-empty skip let this query silently inflate.
     /// (The CTE-path skip is pinned by
@@ -769,5 +1257,154 @@ mod tests {
             sql.contains("ASC NULLS LAST"),
             "Should have ASC NULLS LAST in ORDER BY: {sql}"
         );
+    }
+
+    /// Data-level tests: execute the generated snapshot SQL against an
+    /// in-memory `DuckDB`. The `extension` feature swaps the bundled API for
+    /// loadable-extension stubs, so these are gated like catalog.rs's tests.
+    #[cfg(not(feature = "extension"))]
+    mod execution {
+        use super::*;
+
+        fn run_by_first_col(sql: &str) -> Vec<(String, f64)> {
+            let con = duckdb::Connection::open_in_memory().expect("in-memory DuckDB");
+            con.execute_batch(
+                "CREATE TABLE accounts (customer_id VARCHAR, report_date DATE, balance DOUBLE);
+                 INSERT INTO accounts VALUES
+                     ('alice', DATE '2024-01-01', 999.0),
+                     ('alice', DATE '2024-01-02', 100.0),
+                     ('alice', DATE '2024-01-02', 150.0),
+                     ('bob',   NULL,              40.0),
+                     ('bob',   DATE '2024-01-01', 300.0);",
+            )
+            .expect("setup");
+            let wrapped = format!("SELECT * FROM ({sql}) ORDER BY 1");
+            let mut stmt = con.prepare(&wrapped).expect("prepare generated SQL");
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
+                })
+                .expect("query");
+            rows.collect::<Result<Vec<_>, _>>().expect("rows")
+        }
+
+        fn snapshot_def(nulls: NullsOrder) -> crate::model::SemanticViewDefinition {
+            minimal_def(
+                "accounts",
+                "customer_id",
+                "customer_id",
+                "balance",
+                "SUM(balance)",
+            )
+            .with_dimension("report_date", "report_date", None)
+            .with_non_additive_by("balance", &[("report_date", SortOrder::Desc, nulls)])
+        }
+
+        fn snapshot_req() -> QueryRequest {
+            QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("customer_id")],
+                metrics: vec![MetricName::new("balance")],
+            }
+        }
+
+        /// SG-4 data-level: alice has TWO rows tied at the latest date
+        /// (2024-01-02: 100.0 and 150.0). RANK gives both rows rank 1, so
+        /// the snapshot sum is 250.0 — deterministically. `ROW_NUMBER` kept
+        /// one arbitrary tied row (100.0 or 150.0, run-to-run
+        /// nondeterministic). bob (NULLS LAST variant): the latest non-NULL
+        /// date wins -> 300.0.
+        #[test]
+        fn test_ties_at_snapshot_all_aggregate() {
+            let sql = expand(
+                "test_view",
+                &snapshot_def(NullsOrder::Last),
+                &snapshot_req(),
+            )
+            .expect("expand");
+            let rows = run_by_first_col(&sql);
+            assert_eq!(rows.len(), 2, "two customers: {rows:?}");
+            assert_eq!(rows[0].0, "alice");
+            assert!(
+                (rows[0].1 - 250.0).abs() < 1e-9,
+                "both tied rows must aggregate (100 + 150), got: {rows:?}"
+            );
+            assert_eq!(rows[1].0, "bob");
+            assert!(
+                (rows[1].1 - 300.0).abs() < 1e-9,
+                "NULLS LAST: latest non-NULL date wins for bob, got: {rows:?}"
+            );
+        }
+
+        /// TC-7 data-level: with DESC NULLS FIRST (the parser default for
+        /// DESC), bob's NULL-dated row outranks the dated row -> 40.0.
+        #[test]
+        fn test_nulls_first_null_row_wins() {
+            let sql = expand(
+                "test_view",
+                &snapshot_def(NullsOrder::First),
+                &snapshot_req(),
+            )
+            .expect("expand");
+            let rows = run_by_first_col(&sql);
+            assert_eq!(rows[1].0, "bob");
+            assert!(
+                (rows[1].1 - 40.0).abs() < 1e-9,
+                "NULLS FIRST: the NULL-dated row must win for bob, got: {rows:?}"
+            );
+        }
+
+        /// SG-9 data-level: NA dim on a non-queried, non-base table. The
+        /// snapshot CTE joins `dates`, the ORDER BY binds to `d.report_date`,
+        /// and each customer's balance snapshots at their latest date.
+        /// customer 10: `date_id` 2 (2024-01-02) is latest -> 150.0
+        /// customer 20: only `date_id` 1 -> 300.0
+        #[test]
+        fn test_na_dim_join_executes() {
+            let mut def = minimal_def(
+                "accounts",
+                "customer_id",
+                "a.customer_id",
+                "balance",
+                "SUM(a.balance)",
+            );
+            def.tables[0].alias = "a".to_string();
+            def.tables[0].pk_columns = vec!["id".to_string()];
+            def.metrics[0].source_table = Some("a".to_string());
+            let def = def
+                .with_table("d", "dates", &["id"])
+                .with_dimension("report_date", "d.report_date", Some("d"))
+                .with_non_additive_by(
+                    "balance",
+                    &[("report_date", SortOrder::Desc, NullsOrder::First)],
+                )
+                .with_pkfk_join("acct_date", "a", "d", &["date_id"], &["id"]);
+
+            let sql = expand("test_view", &def, &snapshot_req()).expect("expand");
+
+            let con = duckdb::Connection::open_in_memory().expect("in-memory DuckDB");
+            con.execute_batch(
+                "CREATE TABLE dates (id INTEGER, report_date DATE);
+                 INSERT INTO dates VALUES (1, DATE '2024-01-01'), (2, DATE '2024-01-02');
+                 CREATE TABLE accounts (id INTEGER, customer_id INTEGER, date_id INTEGER, balance DOUBLE);
+                 INSERT INTO accounts VALUES
+                     (1, 10, 1, 100.0),
+                     (2, 10, 2, 150.0),
+                     (3, 20, 1, 300.0);",
+            )
+            .expect("setup");
+            let wrapped = format!("SELECT * FROM ({sql}) ORDER BY 1");
+            let mut stmt = con.prepare(&wrapped).expect("prepare generated SQL");
+            let rows = stmt
+                .query_map([], |row| Ok((row.get::<_, i32>(0)?, row.get::<_, f64>(1)?)))
+                .expect("query")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("rows");
+            assert_eq!(rows.len(), 2, "rows: {rows:?}");
+            assert_eq!(rows[0].0, 10);
+            assert!((rows[0].1 - 150.0).abs() < 1e-9, "rows: {rows:?}");
+            assert_eq!(rows[1].0, 20);
+            assert!((rows[1].1 - 300.0).abs() < 1e-9, "rows: {rows:?}");
+        }
     }
 }

--- a/src/expand/semi_additive.rs
+++ b/src/expand/semi_additive.rs
@@ -26,7 +26,7 @@ use std::collections::{HashMap, HashSet};
 use crate::model::{Metric, NonAdditiveDim, NullsOrder, SemanticViewDefinition, SortOrder};
 use crate::util::replace_word_boundary;
 
-use super::join_resolver::{resolve_joins_pkfk, synthesize_on_clause, synthesize_on_clause_scoped};
+use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{qualify_and_quote_table_ref, quote_ident};
 use super::types::ExpandError;
 
@@ -199,49 +199,8 @@ pub(super) fn expand_semi_additive(
     }
 
     // CTE JOINs
-    let ordered_aliases = resolve_joins_pkfk(def, resolved_dims, resolved_mets);
-    for alias in &ordered_aliases {
-        if let Some(sep_pos) = alias.find("__") {
-            let rel_name = &alias[sep_pos + 2..];
-            let Some(join) = def.joins.iter().find(|j| {
-                j.name
-                    .as_ref()
-                    .is_some_and(|n| n.eq_ignore_ascii_case(rel_name))
-            }) else {
-                continue;
-            };
-            let bare_alias = &alias[..sep_pos];
-            let table_ref = def
-                .tables
-                .iter()
-                .find(|t| t.alias.to_ascii_lowercase() == bare_alias);
-            let physical_table = table_ref.map_or(bare_alias, |t| t.table.as_str());
-            sql.push_str("\n    LEFT JOIN ");
-            sql.push_str(&qualify_and_quote_table_ref(physical_table, def));
-            sql.push_str(" AS ");
-            sql.push_str(&quote_ident(alias));
-            sql.push_str(" ON ");
-            sql.push_str(&synthesize_on_clause_scoped(join, &def.tables, alias));
-        } else {
-            let Some(join) = def.joins.iter().find(|j| {
-                j.table.to_ascii_lowercase() == *alias
-                    || j.from_alias.to_ascii_lowercase() == *alias
-            }) else {
-                continue;
-            };
-            let table_ref = def
-                .tables
-                .iter()
-                .find(|t| t.alias.to_ascii_lowercase() == *alias);
-            let physical_table = table_ref.map_or(alias.as_str(), |t| t.table.as_str());
-            sql.push_str("\n    LEFT JOIN ");
-            sql.push_str(&qualify_and_quote_table_ref(physical_table, def));
-            sql.push_str(" AS ");
-            sql.push_str(&quote_ident(alias));
-            sql.push_str(" ON ");
-            sql.push_str(&synthesize_on_clause(join, &def.tables));
-        }
-    }
+    let resolved_joins = resolve_joins_pkfk(def, resolved_dims, resolved_mets, &[]);
+    push_join_clauses(&mut sql, &resolved_joins, def, "\n    LEFT JOIN ");
 
     sql.push_str("\n)\n");
 

--- a/src/expand/semi_additive.rs
+++ b/src/expand/semi_additive.rs
@@ -30,6 +30,25 @@ use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{qualify_and_quote_table_ref, quote_ident};
 use super::types::ExpandError;
 
+/// Returns true when `met` is an ACTIVE semi-additive metric for a query over
+/// `queried_dim_names` (lowercased): it has a NON ADDITIVE BY clause and at
+/// least one of its NA dims is NOT in the queried dimension set, so it takes
+/// the `ROW_NUMBER`-CTE snapshot path. When ALL NA dims are queried, the
+/// metric is "effectively regular" (Snowflake semantics) and takes the
+/// standard aggregation path.
+///
+/// This is THE routing predicate — shared by `expand()` (CTE dispatch),
+/// `expand_semi_additive` (per-metric classification), and the fan-trap check
+/// (which must skip exactly the metrics that take the CTE path, SG-6) so the
+/// three cannot drift.
+pub(super) fn is_active_semi_additive(met: &Metric, queried_dim_names: &HashSet<String>) -> bool {
+    !met.non_additive_by.is_empty()
+        && met
+            .non_additive_by
+            .iter()
+            .any(|na| !queried_dim_names.contains(&na.dimension.to_ascii_lowercase()))
+}
+
 /// Generate CTE-based expansion SQL for queries containing semi-additive metrics.
 ///
 /// Called from `expand()` when `has_active_semi_additive` is true.
@@ -56,14 +75,9 @@ pub(super) fn expand_semi_additive(
         .map(|d| d.name.to_ascii_lowercase())
         .collect();
 
-    // Classify each metric as active semi-additive
-    let is_active_semi = |met: &Metric| -> bool {
-        !met.non_additive_by.is_empty()
-            && met
-                .non_additive_by
-                .iter()
-                .any(|na| !queried_dim_names.contains(&na.dimension.to_ascii_lowercase()))
-    };
+    // Classify each metric as active semi-additive (shared routing predicate)
+    let is_active_semi =
+        |met: &Metric| -> bool { is_active_semi_additive(met, &queried_dim_names) };
 
     // 1. Identify distinct NON ADDITIVE BY dimension sets for ACTIVE metrics only.
     let na_groups = collect_na_groups(resolved_mets, &queried_dim_names);
@@ -286,15 +300,8 @@ fn collect_na_groups(
 ) -> Vec<NaGroup> {
     let mut groups: Vec<(Vec<String>, Vec<NonAdditiveDim>, Vec<usize>)> = Vec::new();
     for (idx, met) in resolved_mets.iter().enumerate() {
-        if met.non_additive_by.is_empty() {
-            continue;
-        }
-        // Skip effectively-regular metrics (all NA dims in query)
-        let all_na_in_query = met
-            .non_additive_by
-            .iter()
-            .all(|na| queried_dim_names.contains(&na.dimension.to_ascii_lowercase()));
-        if all_na_in_query {
+        // Skip regular and effectively-regular metrics (shared routing predicate)
+        if !is_active_semi_additive(met, queried_dim_names) {
             continue;
         }
         let key: Vec<String> = met
@@ -371,7 +378,7 @@ fn get_rn_column_for_metric(met_idx: usize, na_groups: &[NaGroup]) -> String {
 #[cfg(test)]
 mod tests {
     use crate::expand::test_helpers::{minimal_def, orders_view, TestFixtureExt};
-    use crate::expand::{expand, DimensionName, MetricName, QueryRequest};
+    use crate::expand::{expand, DimensionName, ExpandError, MetricName, QueryRequest};
     use crate::model::{NullsOrder, SortOrder};
 
     use super::{extract_aggregate_func, extract_aggregate_inner};
@@ -631,13 +638,19 @@ mod tests {
         );
     }
 
-    /// Fan trap check skips semi-additive metrics.
+    /// SG-6 (code review 2026-07-02): a semi-additive metric whose NA dims
+    /// are ALL in the queried dimensions is "effectively regular" — it takes
+    /// the standard aggregation path (never the `ROW_NUMBER` CTE), so it MUST
+    /// get the standard fan-trap check. The previous unconditional
+    /// `non_additive_by`-non-empty skip let this query silently inflate.
+    /// (The CTE-path skip is pinned by
+    /// `fan_trap::tests::test_check_fan_traps_semi_additive_cte_path_skipped`.)
     #[test]
-    fn test_fan_trap_skips_semi_additive() {
-        // Create a multi-table view where a regular metric on table c
-        // queried with dim on table a would cause fan trap (a -> c is many-to-one,
-        // dim on a means traversing c->a which is one-to-many fan-out direction).
-        // But with semi-additive, it should be skipped.
+    fn test_fan_trap_checks_effectively_regular_semi_additive() {
+        // Multi-table view where the metric on table c queried with a dim on
+        // table a causes a fan trap (a -> c is many-to-one; the dim on a
+        // means traversing c -> a, the fan-out direction). The metric's only
+        // NA dim (acct_name) IS queried, so it acts as a regular aggregate.
         let def = orders_view()
             .with_table("customers", "customers", &[])
             .clear_dimensions()
@@ -658,12 +671,12 @@ mod tests {
             metrics: vec![MetricName::new("total_balance")],
         };
 
-        // This should NOT return a FanTrap error because semi-additive metrics are skipped
+        // Effectively-regular semi-additive metrics get the standard check.
         let result = expand("test_view", &def, &req);
         assert!(
-            result.is_ok(),
-            "Semi-additive metric should skip fan trap: {:?}",
-            result.err()
+            matches!(result, Err(ExpandError::FanTrap { .. })),
+            "Effectively-regular semi-additive metric over a fanning join \
+             must be a fan trap error, got: {result:?}"
         );
     }
 

--- a/src/expand/sql_gen.rs
+++ b/src/expand/sql_gen.rs
@@ -1,7 +1,9 @@
 use crate::model::{AccessModifier, SemanticViewDefinition};
 use crate::util::{replace_word_boundary, suggest_closest};
 
-use super::facts::{inline_derived_metrics, inline_facts, toposort_facts};
+use super::facts::{
+    collect_transitive_metric_names, inline_derived_metrics, inline_facts, toposort_facts,
+};
 use super::fan_trap::{check_fan_traps, validate_fact_table_path};
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{find_dimension, find_metric, qualify_and_quote_table_ref, quote_ident};
@@ -13,6 +15,11 @@ use super::types::{ExpandError, QueryRequest};
 ///
 /// Generic helper that deduplicates the resolution pattern used for
 /// dimensions, metrics, and facts.
+///
+/// Duplicate detection keys on the RESOLVED item's identity, not the raw
+/// request string (SG-14): `region` and `o.region` resolve to the same
+/// dimension and are rejected as duplicates instead of emitting the same
+/// column twice.
 #[allow(clippy::too_many_arguments, clippy::result_large_err)]
 fn resolve_names<'a, T, N: AsRef<str>>(
     names: &[N],
@@ -26,12 +33,9 @@ fn resolve_names<'a, T, N: AsRef<str>>(
     make_private_err: impl Fn(String, String) -> ExpandError,
 ) -> Result<Vec<&'a T>, ExpandError> {
     let mut resolved = Vec::with_capacity(names.len());
-    let mut seen = std::collections::HashSet::new();
+    let mut seen: std::collections::HashSet<*const T> = std::collections::HashSet::new();
     for name in names {
         let name_str = name.as_ref();
-        if !seen.insert(name_str.to_ascii_lowercase()) {
-            return Err(make_dup_err(view_name.to_string(), name_str.to_string()));
-        }
         let item = find_fn(name_str).ok_or_else(|| {
             let avail = available_fn();
             let suggestion = suggest_fn(name_str);
@@ -42,6 +46,9 @@ fn resolve_names<'a, T, N: AsRef<str>>(
                 suggestion,
             )
         })?;
+        if !seen.insert(std::ptr::from_ref(item)) {
+            return Err(make_dup_err(view_name.to_string(), name_str.to_string()));
+        }
         if is_private(item) {
             return Err(make_private_err(
                 view_name.to_string(),
@@ -138,6 +145,17 @@ fn expand_facts(
         .filter_map(|d| d.source_table.clone())
         .collect();
     validate_fact_table_path(view_name, def, &fact_tables, &dim_tables)?;
+
+    // 3b. Role-playing ambiguity detection (SG-17), mirroring the metrics
+    // path in expand(). Fact queries carry no metrics, so there is never a
+    // USING context to disambiguate: a dimension on a table reached by
+    // multiple named relationships always raises AmbiguousPath here — the
+    // same error the metrics path raises when no co-queried metric supplies
+    // USING. Previously the facts path skipped this check and silently bound
+    // the dimension to an arbitrary relationship edge.
+    for dim in &resolved_dims {
+        let _ = find_using_context(view_name, def, dim, &[])?;
+    }
 
     // 4. Resolve fact expressions via DAG inlining (fact-to-fact dependencies).
     let topo_order = toposort_facts(&def.facts).map_err(|e| ExpandError::CycleDetected {
@@ -317,13 +335,36 @@ pub fn expand(
         view_name: view_name.to_string(),
         cycle_description: e,
     })?;
-    let resolved_exprs =
-        inline_derived_metrics(&def.metrics, &def.facts, &topo_order).map_err(|e| {
-            ExpandError::CycleDetected {
-                view_name: view_name.to_string(),
-                cycle_description: e,
-            }
+    let resolved = inline_derived_metrics(&def.metrics, &def.facts, &topo_order, &def.tables)
+        .map_err(|e| ExpandError::CycleDetected {
+            view_name: view_name.to_string(),
+            cycle_description: e,
         })?;
+
+    // SG-8: fail loudly when a REQUESTED metric (directly, via a derived
+    // metric, or as a window metric's inner aggregate) depends on a COUNT(*)
+    // that could not be rewritten to COUNT(<pk>) — a non-base source table
+    // with no PRIMARY KEY declared. Emitting it as-is would count
+    // NULL-extended LEFT JOIN rows (one per childless base row).
+    if !resolved.count_star_no_pk.is_empty() {
+        for met in &resolved_mets {
+            for name in collect_transitive_metric_names(met, &def.metrics) {
+                if let Some(table_alias) = resolved.count_star_no_pk.get(&name) {
+                    let metric_name = def
+                        .metrics
+                        .iter()
+                        .find(|m| m.name.eq_ignore_ascii_case(&name))
+                        .map_or(name.clone(), |m| m.name.clone());
+                    return Err(ExpandError::CountStarRequiresPrimaryKey {
+                        view_name: view_name.to_string(),
+                        metric_name,
+                        table_alias: table_alias.clone(),
+                    });
+                }
+            }
+        }
+    }
+    let resolved_exprs = resolved.exprs;
 
     // Phase 31: Check for fan traps before generating SQL.
     check_fan_traps(view_name, def, &resolved_dims, &resolved_mets)?;
@@ -2094,7 +2135,9 @@ GROUP BY
                     window_spec: None,
                 },
             ];
-            let resolved = inline_derived_metrics(&metrics, &[], &[]).unwrap();
+            let resolved = inline_derived_metrics(&metrics, &[], &[], &[])
+                .unwrap()
+                .exprs;
             assert_eq!(
                 resolved.get("profit").unwrap(),
                 "(SUM(amount)) - (SUM(unit_cost))"
@@ -2153,7 +2196,9 @@ GROUP BY
                     window_spec: None,
                 },
             ];
-            let resolved = inline_derived_metrics(&metrics, &[], &[]).unwrap();
+            let resolved = inline_derived_metrics(&metrics, &[], &[], &[])
+                .unwrap()
+                .exprs;
             assert_eq!(
                 resolved.get("profit").unwrap(),
                 "(SUM(amount)) - (SUM(unit_cost))"
@@ -2202,7 +2247,9 @@ GROUP BY
                 access: AccessModifier::Public,
             }];
             let topo_order = toposort_facts(&facts).unwrap();
-            let resolved = inline_derived_metrics(&metrics, &facts, &topo_order).unwrap();
+            let resolved = inline_derived_metrics(&metrics, &facts, &topo_order, &[])
+                .unwrap()
+                .exprs;
             assert_eq!(
                 resolved.get("revenue").unwrap(),
                 "SUM((extended_price * (1 - discount)))"
@@ -2265,7 +2312,9 @@ GROUP BY
                     window_spec: None,
                 },
             ];
-            let resolved = inline_derived_metrics(&metrics, &[], &[]).unwrap();
+            let resolved = inline_derived_metrics(&metrics, &[], &[], &[])
+                .unwrap()
+                .exprs;
             assert_eq!(
                 resolved.get("margin").unwrap(),
                 "((SUM(x)) - (SUM(y))) / (SUM(x))"
@@ -2312,7 +2361,9 @@ GROUP BY
                     window_spec: None,
                 },
             ];
-            let resolved = inline_derived_metrics(&metrics, &[], &[]).unwrap();
+            let resolved = inline_derived_metrics(&metrics, &[], &[], &[])
+                .unwrap()
+                .exprs;
             assert_eq!(
                 resolved.get("derived").unwrap(),
                 "(SUM(amount)) + (SUM(total))"
@@ -4186,6 +4237,437 @@ GROUP BY
             assert!(
                 sql.contains("\"f\".\"departure_code\" = \"a__dep_airport\".\"airport_code\""),
                 "ON clause must use the scoped alias on the PK side: {sql}"
+            );
+        }
+    }
+
+    // ===================================================================
+    // Code review 2026-07-02 remediation: SG-8 (COUNT(*) on non-base
+    // tables), SG-14 (qualified-name resolution), SG-17 (facts-path
+    // role-playing ambiguity).
+    // ===================================================================
+
+    mod count_star_rewrite_tests {
+        use super::*;
+        use crate::expand::test_helpers::{orders_view, TestFixtureExt};
+        use crate::model::WindowSpec;
+
+        /// `orders` (base) + `line_items` child with a declared PK.
+        fn child_count_def() -> crate::model::SemanticViewDefinition {
+            orders_view()
+                .clear_dimensions()
+                .clear_metrics()
+                .with_dimension("region", "region", None)
+                .with_table("li", "line_items", &["id"])
+                .with_metric("item_count", "COUNT(*)", Some("li"))
+                .with_pkfk_join("li_orders", "li", "orders", &["order_id"], &["id"])
+        }
+
+        #[test]
+        fn test_child_count_star_rewritten_exact_sql() {
+            // SG-8: COUNT(*) on the LEFT-JOINed child must count the child's
+            // PK, not NULL-extended rows (one per childless order).
+            let def = child_count_def();
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![],
+                metrics: vec![MetricName::new("item_count")],
+            };
+            let sql = expand("orders", &def, &req).unwrap();
+            let expected = "\
+SELECT
+    COUNT(\"li\".\"id\") AS \"item_count\"
+FROM \"orders\" AS \"orders\"
+LEFT JOIN \"line_items\" AS \"li\" ON \"li\".\"order_id\" = \"orders\".\"id\"";
+            assert_eq!(sql, expected);
+        }
+
+        #[test]
+        fn test_child_count_star_rewritten_with_base_dimension() {
+            let def = child_count_def();
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("region")],
+                metrics: vec![MetricName::new("item_count")],
+            };
+            let sql = expand("orders", &def, &req).unwrap();
+            assert!(
+                sql.contains("COUNT(\"li\".\"id\") AS \"item_count\""),
+                "child COUNT(*) must be rewritten to COUNT(pk): {sql}"
+            );
+            assert!(sql.contains("GROUP BY"), "grouped query expected: {sql}");
+        }
+
+        #[test]
+        fn test_base_table_count_star_unchanged() {
+            // Metrics on the base table keep plain COUNT(*): the base table
+            // is never NULL-extended by the synthesized LEFT JOINs.
+            let def = child_count_def().with_metric("order_count", "COUNT(*)", Some("orders"));
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![],
+                metrics: vec![MetricName::new("order_count")],
+            };
+            let sql = expand("orders", &def, &req).unwrap();
+            let expected = "\
+SELECT
+    COUNT(*) AS \"order_count\"
+FROM \"orders\" AS \"orders\"";
+            assert_eq!(sql, expected);
+        }
+
+        #[test]
+        fn test_unqualified_count_star_metric_unchanged() {
+            // Legacy single-table shape: metric declared without a source
+            // table (None) is a base-table/derived metric — no rewrite.
+            let def = orders_view();
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![],
+                metrics: vec![MetricName::new("order_count")],
+            };
+            let sql = expand("orders", &def, &req).unwrap();
+            assert!(
+                sql.contains("count(*) AS \"order_count\""),
+                "COUNT(*) without a non-base source table must be preserved: {sql}"
+            );
+        }
+
+        #[test]
+        fn test_child_count_star_without_pk_errors() {
+            let def = orders_view()
+                .clear_dimensions()
+                .clear_metrics()
+                .with_table("li", "line_items", &[]) // no PK declared
+                .with_metric("item_count", "COUNT(*)", Some("li"))
+                .with_pkfk_join("li_orders", "li", "orders", &["order_id"], &["id"]);
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![],
+                metrics: vec![MetricName::new("item_count")],
+            };
+            let err = expand("orders", &def, &req).unwrap_err();
+            match &err {
+                ExpandError::CountStarRequiresPrimaryKey {
+                    view_name,
+                    metric_name,
+                    table_alias,
+                } => {
+                    assert_eq!(view_name, "orders");
+                    assert_eq!(metric_name, "item_count");
+                    assert_eq!(table_alias, "li");
+                }
+                other => panic!("Expected CountStarRequiresPrimaryKey, got: {other}"),
+            }
+            let msg = err.to_string();
+            assert!(
+                msg.contains("no PRIMARY KEY declared") && msg.contains("COUNT(*)"),
+                "error must explain the rewrite requirement: {msg}"
+            );
+        }
+
+        #[test]
+        fn test_unrelated_metric_still_works_when_sibling_count_star_lacks_pk() {
+            // The no-PK failure is scoped to queries that actually use the
+            // metric: other metrics on the same view keep working.
+            let def = orders_view()
+                .clear_dimensions()
+                .clear_metrics()
+                .with_table("li", "line_items", &[]) // no PK declared
+                .with_metric("item_count", "COUNT(*)", Some("li"))
+                .with_metric("revenue", "SUM(li.amount)", Some("li"))
+                .with_pkfk_join("li_orders", "li", "orders", &["order_id"], &["id"]);
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![],
+                metrics: vec![MetricName::new("revenue")],
+            };
+            let sql = expand("orders", &def, &req).unwrap();
+            assert!(sql.contains("SUM(li.amount)"), "SQL: {sql}");
+        }
+
+        #[test]
+        fn test_derived_metric_reaching_no_pk_count_star_errors() {
+            let def = orders_view()
+                .clear_dimensions()
+                .clear_metrics()
+                .with_table("li", "line_items", &[]) // no PK declared
+                .with_metric("item_count", "COUNT(*)", Some("li"))
+                .with_metric("double_items", "item_count * 2", None)
+                .with_pkfk_join("li_orders", "li", "orders", &["order_id"], &["id"]);
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![],
+                metrics: vec![MetricName::new("double_items")],
+            };
+            let err = expand("orders", &def, &req).unwrap_err();
+            match &err {
+                ExpandError::CountStarRequiresPrimaryKey { metric_name, .. } => {
+                    assert_eq!(
+                        metric_name, "item_count",
+                        "error must name the failing base metric"
+                    );
+                }
+                other => panic!("Expected CountStarRequiresPrimaryKey, got: {other}"),
+            }
+        }
+
+        #[test]
+        fn test_derived_metric_inherits_rewritten_count_star() {
+            let def = child_count_def().with_metric("double_items", "item_count * 2", None);
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![],
+                metrics: vec![MetricName::new("double_items")],
+            };
+            let sql = expand("orders", &def, &req).unwrap();
+            assert!(
+                sql.contains("(COUNT(\"li\".\"id\")) * 2 AS \"double_items\""),
+                "derived metric must inline the REWRITTEN child count: {sql}"
+            );
+        }
+
+        #[test]
+        fn test_window_inner_aggregate_gets_rewrite() {
+            // Window path: the inner aggregate is emitted from the shared
+            // resolved expressions, so the rewrite must appear in the CTE.
+            let def = orders_view()
+                .clear_dimensions()
+                .clear_metrics()
+                .with_table("li", "line_items", &["id"])
+                .with_dimension("product", "li.product", Some("li"))
+                .with_metric("item_count", "COUNT(*)", Some("li"))
+                .with_metric("rolling_items", "AVG(item_count)", None)
+                .with_window_spec(
+                    "rolling_items",
+                    WindowSpec {
+                        window_function: "AVG".to_string(),
+                        inner_metric: "item_count".to_string(),
+                        ..Default::default()
+                    },
+                )
+                .with_pkfk_join("li_orders", "li", "orders", &["order_id"], &["id"]);
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("product")],
+                metrics: vec![MetricName::new("rolling_items")],
+            };
+            let sql = expand("orders", &def, &req).unwrap();
+            assert!(
+                sql.contains("COUNT(\"li\".\"id\") AS \"item_count\""),
+                "window CTE inner aggregate must use the rewritten count: {sql}"
+            );
+        }
+
+        #[test]
+        fn test_semi_additive_co_query_uses_rewritten_count() {
+            // Semi-additive path: a same-grain COUNT(*) co-metric on the
+            // child table decomposes into a CTE capture of the child PK and
+            // an outer COUNT over it (NULL-extended rows excluded). The
+            // base-table COUNT(*) rejection in parse_snapshot_aggregate is
+            // untouched (covered by semi_additive tests).
+            let def = orders_view()
+                .clear_dimensions()
+                .clear_metrics()
+                .with_dimension("customer_id", "customer_id", None)
+                .with_table("li", "line_items", &["id"])
+                .with_dimension("report_date", "li.report_date", Some("li"))
+                .with_metric("balance", "SUM(li.balance)", Some("li"))
+                .with_metric("txn_count", "COUNT(*)", Some("li"))
+                .with_pkfk_join("li_orders", "li", "orders", &["order_id"], &["id"])
+                .with_non_additive_by(
+                    "balance",
+                    &[(
+                        "report_date",
+                        crate::model::SortOrder::Desc,
+                        crate::model::NullsOrder::First,
+                    )],
+                );
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("customer_id")],
+                metrics: vec![MetricName::new("balance"), MetricName::new("txn_count")],
+            };
+            let sql = expand("orders", &def, &req).unwrap();
+            assert!(
+                sql.contains("\"li\".\"id\" AS \"__sv_reg_1\""),
+                "CTE must capture the rewritten count argument: {sql}"
+            );
+            assert!(
+                sql.contains("COUNT(\"__sv_reg_1\") AS \"txn_count\""),
+                "outer select must re-aggregate the captured PK column: {sql}"
+            );
+        }
+    }
+
+    mod qualified_name_resolution_tests {
+        use super::*;
+        use crate::expand::test_helpers::{orders_view, TestFixtureExt};
+
+        #[test]
+        fn test_qualified_dimension_wrong_table_errors() {
+            // SG-14: no fallback to "any dimension with that bare name".
+            let def = orders_view();
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("x.region")],
+                metrics: vec![MetricName::new("total_revenue")],
+            };
+            let err = expand("orders", &def, &req).unwrap_err();
+            match err {
+                ExpandError::UnknownDimension { name, .. } => {
+                    assert_eq!(name, "x.region");
+                }
+                other => panic!("Expected UnknownDimension, got: {other}"),
+            }
+        }
+
+        #[test]
+        fn test_qualified_metric_wrong_table_errors() {
+            let def = orders_view().clear_metrics().with_metric(
+                "total_revenue",
+                "sum(amount)",
+                Some("orders"),
+            );
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![],
+                metrics: vec![MetricName::new("x.total_revenue")],
+            };
+            let err = expand("orders", &def, &req).unwrap_err();
+            match err {
+                ExpandError::UnknownMetric { name, .. } => {
+                    assert_eq!(name, "x.total_revenue");
+                }
+                other => panic!("Expected UnknownMetric, got: {other}"),
+            }
+        }
+
+        #[test]
+        fn test_base_alias_qualification_matches_unqualified_declaration() {
+            // A dimension declared without a source table is a base-table
+            // item; qualifying the request with the base alias must resolve.
+            let def = orders_view();
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("orders.region")],
+                metrics: vec![MetricName::new("total_revenue")],
+            };
+            let sql = expand("orders", &def, &req).unwrap();
+            assert!(sql.contains("region AS \"region\""), "SQL: {sql}");
+        }
+
+        #[test]
+        fn test_bare_and_qualified_same_dimension_rejected_as_duplicate() {
+            // SG-14: the duplicate check keys on the RESOLVED item, so
+            // `region` and `orders.region` cannot emit the column twice.
+            let def = orders_view();
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![
+                    DimensionName::new("region"),
+                    DimensionName::new("orders.region"),
+                ],
+                metrics: vec![],
+            };
+            let err = expand("orders", &def, &req).unwrap_err();
+            match err {
+                ExpandError::DuplicateDimension { name, .. } => {
+                    assert_eq!(name, "orders.region");
+                }
+                other => panic!("Expected DuplicateDimension, got: {other}"),
+            }
+        }
+
+        #[test]
+        fn test_bare_and_qualified_same_metric_rejected_as_duplicate() {
+            let def = orders_view().clear_metrics().with_metric(
+                "total_revenue",
+                "sum(amount)",
+                Some("orders"),
+            );
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![],
+                metrics: vec![
+                    MetricName::new("total_revenue"),
+                    MetricName::new("orders.total_revenue"),
+                ],
+            };
+            let err = expand("orders", &def, &req).unwrap_err();
+            match err {
+                ExpandError::DuplicateMetric { name, .. } => {
+                    assert_eq!(name, "orders.total_revenue");
+                }
+                other => panic!("Expected DuplicateMetric, got: {other}"),
+            }
+        }
+    }
+
+    mod facts_path_role_playing_tests {
+        use super::*;
+        use crate::expand::test_helpers::{orders_view, TestFixtureExt};
+
+        fn role_playing_facts_def(two_rels: bool) -> crate::model::SemanticViewDefinition {
+            let def = orders_view()
+                .clear_dimensions()
+                .clear_metrics()
+                .with_table("a", "airports", &["code"])
+                .with_dimension("city", "a.city", Some("a"))
+                .with_fact("order_note", "orders.note", "orders")
+                .with_pkfk_join("dep_airport", "orders", "a", &["dep_code"], &["code"]);
+            if two_rels {
+                def.with_pkfk_join("arr_airport", "orders", "a", &["arr_code"], &["code"])
+            } else {
+                def
+            }
+        }
+
+        #[test]
+        fn test_facts_path_role_playing_dimension_raises_ambiguous_path() {
+            // SG-17: the facts path must run the same role-playing ambiguity
+            // detection as the metrics path. With two named relationships to
+            // `a` and no USING context (facts cannot supply one), the
+            // dimension is ambiguous — previously it silently bound to an
+            // arbitrary edge.
+            let def = role_playing_facts_def(true);
+            let req = QueryRequest {
+                facts: vec!["order_note".to_string()],
+                dimensions: vec![DimensionName::new("city")],
+                metrics: vec![],
+            };
+            let err = expand("orders", &def, &req).unwrap_err();
+            match err {
+                ExpandError::AmbiguousPath {
+                    dimension_name,
+                    dimension_table,
+                    available_relationships,
+                    ..
+                } => {
+                    assert_eq!(dimension_name, "city");
+                    assert_eq!(dimension_table, "a");
+                    assert!(
+                        available_relationships.contains(&"dep_airport".to_string())
+                            && available_relationships.contains(&"arr_airport".to_string()),
+                        "both relationships must be listed: {available_relationships:?}"
+                    );
+                }
+                other => panic!("Expected AmbiguousPath, got: {other}"),
+            }
+        }
+
+        #[test]
+        fn test_facts_path_single_relationship_dimension_ok() {
+            let def = role_playing_facts_def(false);
+            let req = QueryRequest {
+                facts: vec!["order_note".to_string()],
+                dimensions: vec![DimensionName::new("city")],
+                metrics: vec![],
+            };
+            let sql = expand("orders", &def, &req).unwrap();
+            assert!(
+                sql.contains("LEFT JOIN \"airports\" AS \"a\""),
+                "single relationship stays unambiguous: {sql}"
             );
         }
     }

--- a/src/expand/sql_gen.rs
+++ b/src/expand/sql_gen.rs
@@ -339,17 +339,15 @@ pub fn expand(
     // Phase 47: Check if any resolved metric ACTUALLY needs semi-additive expansion.
     // A semi-additive metric only needs CTE treatment when at least one of its
     // NA dims is NOT in the queried dimension set. When ALL NA dims are in the
-    // query, the metric acts as regular (Snowflake semantics).
+    // query, the metric acts as regular (Snowflake semantics). The predicate
+    // is shared with expand_semi_additive and the fan-trap check (SG-6).
     let queried_dim_names: std::collections::HashSet<String> = resolved_dims
         .iter()
         .map(|d| d.name.to_ascii_lowercase())
         .collect();
-    let has_active_semi_additive = resolved_mets.iter().any(|m| {
-        !m.non_additive_by.is_empty()
-            && m.non_additive_by
-                .iter()
-                .any(|na| !queried_dim_names.contains(&na.dimension.to_ascii_lowercase()))
-    });
+    let has_active_semi_additive = resolved_mets
+        .iter()
+        .any(|m| super::semi_additive::is_active_semi_additive(m, &queried_dim_names));
 
     if has_active_semi_additive {
         return super::semi_additive::expand_semi_additive(

--- a/src/expand/sql_gen.rs
+++ b/src/expand/sql_gen.rs
@@ -3,7 +3,7 @@ use crate::util::{replace_word_boundary, suggest_closest};
 
 use super::facts::{inline_derived_metrics, inline_facts, toposort_facts};
 use super::fan_trap::{check_fan_traps, validate_fact_table_path};
-use super::join_resolver::{resolve_joins_pkfk, synthesize_on_clause, synthesize_on_clause_scoped};
+use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{find_dimension, find_metric, qualify_and_quote_table_ref, quote_ident};
 use super::role_playing::find_using_context;
 use super::types::{ExpandError, QueryRequest};
@@ -182,69 +182,16 @@ fn expand_facts(
         sql.push_str(&quote_ident(&base_ref.alias));
     }
 
-    // 7. JOIN clauses — resolve required joins for fact + dim tables.
-    // Build temporary Metric slice as empty (no metrics in fact queries)
-    let empty_mets: Vec<&crate::model::Metric> = vec![];
-    let ordered_aliases = resolve_joins_pkfk(def, &resolved_dims, &empty_mets);
-
-    // Also ensure fact source tables are included in join resolution.
-    let mut fact_aliases: Vec<String> = Vec::new();
-    for fact in &resolved_facts {
-        if let Some(ref st) = fact.source_table {
-            let lower = st.to_ascii_lowercase();
-            if !ordered_aliases
-                .iter()
-                .any(|a| a.to_ascii_lowercase() == lower)
-                && !fact_aliases.contains(&lower)
-                && def
-                    .tables
-                    .first()
-                    .is_none_or(|t| t.alias.to_ascii_lowercase() != lower)
-            {
-                fact_aliases.push(lower);
-            }
-        }
-    }
-
-    // Emit joins from resolve_joins_pkfk
-    for alias in &ordered_aliases {
-        let Some(join) = def.joins.iter().find(|j| {
-            j.table.to_ascii_lowercase() == *alias || j.from_alias.to_ascii_lowercase() == *alias
-        }) else {
-            continue;
-        };
-        let table_ref = def
-            .tables
-            .iter()
-            .find(|t| t.alias.to_ascii_lowercase() == *alias);
-        let physical_table = table_ref.map_or(alias.as_str(), |t| t.table.as_str());
-        sql.push_str("\nLEFT JOIN ");
-        sql.push_str(&qualify_and_quote_table_ref(physical_table, def));
-        sql.push_str(" AS ");
-        sql.push_str(&quote_ident(alias));
-        sql.push_str(" ON ");
-        sql.push_str(&synthesize_on_clause(join, &def.tables));
-    }
-
-    // Emit additional joins for fact source tables not covered by dim resolution
-    for alias in &fact_aliases {
-        let Some(join) = def.joins.iter().find(|j| {
-            j.table.to_ascii_lowercase() == *alias || j.from_alias.to_ascii_lowercase() == *alias
-        }) else {
-            continue;
-        };
-        let table_ref = def
-            .tables
-            .iter()
-            .find(|t| t.alias.to_ascii_lowercase() == *alias);
-        let physical_table = table_ref.map_or(alias.as_str(), |t| t.table.as_str());
-        sql.push_str("\nLEFT JOIN ");
-        sql.push_str(&qualify_and_quote_table_ref(physical_table, def));
-        sql.push_str(" AS ");
-        sql.push_str(&quote_ident(alias));
-        sql.push_str(" ON ");
-        sql.push_str(&synthesize_on_clause(join, &def.tables));
-    }
+    // 7. JOIN clauses — resolve required joins for dim + fact source tables.
+    // Fact queries have no metrics; fact source tables are resolved through
+    // the same path walk as dimensions (SG-10) and their joins are appended
+    // after the dimension-driven joins.
+    let fact_sources: Vec<String> = resolved_facts
+        .iter()
+        .filter_map(|f| f.source_table.clone())
+        .collect();
+    let resolved_joins = resolve_joins_pkfk(def, &resolved_dims, &[], &fact_sources);
+    push_join_clauses(&mut sql, &resolved_joins, def, "\nLEFT JOIN ");
 
     // NO GROUP BY — fact queries are unaggregated
 
@@ -503,55 +450,10 @@ pub fn expand(
     }
 
     // Join resolution via PK/FK graph (legacy resolve_joins removed in Phase 27).
-    // Phase 32: ordered_aliases may contain scoped aliases like "a__dep_airport".
-    let ordered_aliases = resolve_joins_pkfk(def, &resolved_dims, &resolved_mets);
-    for alias in &ordered_aliases {
-        // Phase 32: Check if this is a scoped alias (contains "__").
-        if let Some(sep_pos) = alias.find("__") {
-            let rel_name = &alias[sep_pos + 2..];
-            // Find the Join by relationship name.
-            let Some(join) = def.joins.iter().find(|j| {
-                j.name
-                    .as_ref()
-                    .is_some_and(|n| n.eq_ignore_ascii_case(rel_name))
-            }) else {
-                continue;
-            };
-            // Find physical table name from the bare alias (before __).
-            let bare_alias = &alias[..sep_pos];
-            let table_ref = def
-                .tables
-                .iter()
-                .find(|t| t.alias.to_ascii_lowercase() == bare_alias);
-            let physical_table = table_ref.map_or(bare_alias, |t| t.table.as_str());
-            sql.push_str("\nLEFT JOIN ");
-            sql.push_str(&qualify_and_quote_table_ref(physical_table, def));
-            sql.push_str(" AS ");
-            sql.push_str(&quote_ident(alias));
-            sql.push_str(" ON ");
-            sql.push_str(&synthesize_on_clause_scoped(join, &def.tables, alias));
-        } else {
-            // Standard bare alias join (non-role-playing).
-            let Some(join) = def.joins.iter().find(|j| {
-                j.table.to_ascii_lowercase() == *alias
-                    || j.from_alias.to_ascii_lowercase() == *alias
-            }) else {
-                continue;
-            };
-            // Find the TableRef for this alias to get the physical table name.
-            let table_ref = def
-                .tables
-                .iter()
-                .find(|t| t.alias.to_ascii_lowercase() == *alias);
-            let physical_table = table_ref.map_or(alias.as_str(), |t| t.table.as_str());
-            sql.push_str("\nLEFT JOIN ");
-            sql.push_str(&qualify_and_quote_table_ref(physical_table, def));
-            sql.push_str(" AS ");
-            sql.push_str(&quote_ident(alias));
-            sql.push_str(" ON ");
-            sql.push_str(&synthesize_on_clause(join, &def.tables));
-        }
-    }
+    // The resolver returns structured edges in emission order; role-playing
+    // scoped joins (e.g. "a__dep_airport") follow the bare joins.
+    let resolved_joins = resolve_joins_pkfk(def, &resolved_dims, &resolved_mets, &[]);
+    push_join_clauses(&mut sql, &resolved_joins, def, "\nLEFT JOIN ");
 
     // 7. GROUP BY (only when both dimensions and metrics are present).
     //    Use ordinal positions (GROUP BY 1, 2, ...) instead of expressions to avoid
@@ -4063,6 +3965,229 @@ GROUP BY
             assert!(
                 sql.contains("DECIMAL(10,2)"),
                 "Must include output type: {sql}"
+            );
+        }
+    }
+
+    /// Regression tests for the join-emission overhaul (code review 2026-07-02,
+    /// findings SG-2, SG-10, SG-12): the resolver returns structured edges, so
+    /// the join emitted for an alias is always the edge connecting it to an
+    /// already-emitted table, independent of relationship declaration order,
+    /// and scoped role-playing aliases are never re-parsed from strings.
+    mod join_emission_regression_tests {
+        use super::*;
+        use crate::expand::test_helpers::TestFixtureExt;
+        use crate::model::SemanticViewDefinition;
+
+        /// li (base) -> o -> c chain with configurable relationship
+        /// declaration order.
+        fn li_o_c_def(o_to_c_first: bool) -> SemanticViewDefinition {
+            let def = SemanticViewDefinition::default()
+                .with_table("li", "line_items", &["id"])
+                .with_table("o", "orders", &["id"])
+                .with_table("c", "customers", &["id"])
+                .with_dimension("customer_name", "c.name", Some("c"))
+                .with_metric("total_qty", "sum(li.qty)", Some("li"));
+            if o_to_c_first {
+                def.with_pkfk_join("o_to_c", "o", "c", &["customer_id"], &["id"])
+                    .with_pkfk_join("li_to_o", "li", "o", &["order_id"], &["id"])
+            } else {
+                def.with_pkfk_join("li_to_o", "li", "o", &["order_id"], &["id"])
+                    .with_pkfk_join("o_to_c", "o", "c", &["customer_id"], &["id"])
+            }
+        }
+
+        /// SG-2: the join emitted for alias `o` must be the edge that connects
+        /// `o` to the already-emitted base (li -> o), not whichever declared
+        /// relationship mentions `o` first (o -> c would forward-reference the
+        /// not-yet-joined `c`). Both declaration orders must produce identical
+        /// SQL with no forward references and no dropped joins.
+        #[test]
+        fn sg2_join_selection_is_declaration_order_independent() {
+            let expected = "\
+SELECT
+    c.name AS \"customer_name\",
+    sum(li.qty) AS \"total_qty\"
+FROM \"line_items\" AS \"li\"
+LEFT JOIN \"orders\" AS \"o\" ON \"li\".\"order_id\" = \"o\".\"id\"
+LEFT JOIN \"customers\" AS \"c\" ON \"o\".\"customer_id\" = \"c\".\"id\"
+GROUP BY
+    1";
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("customer_name")],
+                metrics: vec![MetricName::new("total_qty")],
+            };
+            let sql_a = expand("test", &li_o_c_def(true), &req).unwrap();
+            let sql_b = expand("test", &li_o_c_def(false), &req).unwrap();
+            assert_eq!(sql_a, expected, "o->c declared first must be correct");
+            assert_eq!(sql_b, expected, "li->o declared first must be correct");
+        }
+
+        /// SG-2: a child table (`li`) with FKs to two parents (`p` declared
+        /// first, then `o` = base). Query needing only the li -> o edge must
+        /// emit it — not the first-declared li -> p edge, whose ON clause
+        /// would reference the never-joined `p`.
+        #[test]
+        fn sg2_two_parent_child_picks_connecting_edge() {
+            let def = SemanticViewDefinition::default()
+                .with_table("o", "orders", &["id"])
+                .with_table("li", "line_items", &["id"])
+                .with_table("p", "products", &["id"])
+                .with_dimension("region", "o.region", Some("o"))
+                .with_metric("qty", "sum(li.qty)", Some("li"))
+                .with_pkfk_join("li_to_p", "li", "p", &["product_id"], &["id"])
+                .with_pkfk_join("li_to_o", "li", "o", &["order_id"], &["id"]);
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("region")],
+                metrics: vec![MetricName::new("qty")],
+            };
+            let sql = expand("test", &def, &req).unwrap();
+            let expected = "\
+SELECT
+    o.region AS \"region\",
+    sum(li.qty) AS \"qty\"
+FROM \"orders\" AS \"o\"
+LEFT JOIN \"line_items\" AS \"li\" ON \"li\".\"order_id\" = \"o\".\"id\"
+GROUP BY
+    1";
+            assert_eq!(sql, expected, "must join li via li->o, not li->p");
+            assert!(
+                !sql.contains("\"p\"."),
+                "ON clause must not reference the never-joined p: {sql}"
+            );
+        }
+
+        /// ld -> li -> o (base) chain: metric two hops below the root.
+        fn ld_li_o_def() -> SemanticViewDefinition {
+            SemanticViewDefinition::default()
+                .with_table("o", "orders", &["id"])
+                .with_table("li", "line_items", &["id"])
+                .with_table("ld", "line_item_details", &["id"])
+                .with_dimension("region", "o.region", Some("o"))
+                .with_metric("detail_qty", "sum(ld.qty)", Some("ld"))
+                .with_fact("detail_amount", "ld.amount", "ld")
+                .with_pkfk_join("ld_to_li", "ld", "li", &["line_item_id"], &["id"])
+                .with_pkfk_join("li_to_o", "li", "o", &["order_id"], &["id"])
+        }
+
+        /// SG-10: a needed table two hops below the root must pull in its
+        /// intermediate (`li`) and join in dependency order (li before ld),
+        /// with each ON clause referencing only already-joined tables.
+        #[test]
+        fn sg10_fk_side_chain_includes_intermediate_join() {
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("region")],
+                metrics: vec![MetricName::new("detail_qty")],
+            };
+            let sql = expand("test", &ld_li_o_def(), &req).unwrap();
+            let expected = "\
+SELECT
+    o.region AS \"region\",
+    sum(ld.qty) AS \"detail_qty\"
+FROM \"orders\" AS \"o\"
+LEFT JOIN \"line_items\" AS \"li\" ON \"li\".\"order_id\" = \"o\".\"id\"
+LEFT JOIN \"line_item_details\" AS \"ld\" ON \"ld\".\"line_item_id\" = \"li\".\"id\"
+GROUP BY
+    1";
+            assert_eq!(sql, expected);
+
+            // Reversed declaration order must produce the same SQL.
+            let mut def_rev = ld_li_o_def();
+            def_rev.joins.reverse();
+            let sql_rev = expand("test", &def_rev, &req).unwrap();
+            assert_eq!(sql_rev, expected, "declaration order must not matter");
+        }
+
+        /// SG-10 (facts path): `expand_facts` previously joined only the
+        /// fact's direct source table with no path walk; the intermediate
+        /// `li` join was missing entirely.
+        #[test]
+        fn sg10_fact_source_chain_includes_intermediate_join() {
+            let req = QueryRequest {
+                facts: vec!["detail_amount".to_string()],
+                dimensions: vec![],
+                metrics: vec![],
+            };
+            let sql = expand("test", &ld_li_o_def(), &req).unwrap();
+            let expected = "\
+SELECT
+    ld.amount AS \"detail_amount\"
+FROM \"orders\" AS \"o\"
+LEFT JOIN \"line_items\" AS \"li\" ON \"li\".\"order_id\" = \"o\".\"id\"
+LEFT JOIN \"line_item_details\" AS \"ld\" ON \"ld\".\"line_item_id\" = \"li\".\"id\"";
+            assert_eq!(sql, expected);
+        }
+
+        /// SG-12: a user table alias containing `__` is a bare alias, not a
+        /// role-playing scoped alias. It must be joined normally — previously
+        /// the emitter re-parsed the alias at the first `__`, looked up a
+        /// relationship named after the suffix, and silently dropped the join.
+        #[test]
+        fn sg12_bare_alias_containing_double_underscore_joins_normally() {
+            let def = SemanticViewDefinition::default()
+                .with_table("o", "orders", &["id"])
+                .with_table("my__dim", "dim_table", &["id"])
+                .with_dimension("dim_name", "my__dim.name", Some("my__dim"))
+                .with_metric("cnt", "count(*)", Some("o"))
+                .with_pkfk_join("o_to_dim", "o", "my__dim", &["dim_id"], &["id"]);
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("dim_name")],
+                metrics: vec![MetricName::new("cnt")],
+            };
+            let sql = expand("test", &def, &req).unwrap();
+            let expected = "\
+SELECT
+    my__dim.name AS \"dim_name\",
+    count(*) AS \"cnt\"
+FROM \"orders\" AS \"o\"
+LEFT JOIN \"dim_table\" AS \"my__dim\" ON \"o\".\"dim_id\" = \"my__dim\".\"id\"
+GROUP BY
+    1";
+            assert_eq!(sql, expected);
+        }
+
+        /// SG-12: role-playing scoped aliases keep the documented
+        /// `{alias}__{relationship}` SQL alias format, and the scoped alias is
+        /// used on the PK side of the ON clause.
+        #[test]
+        fn sg12_role_playing_scoped_alias_format_preserved() {
+            let def = SemanticViewDefinition::default()
+                .with_table("f", "flights", &["flight_id"])
+                .with_table("a", "airports", &["airport_code"])
+                .with_dimension("city", "a.city", Some("a"))
+                .with_metric("departure_count", "COUNT(*)", Some("f"))
+                .with_using_relationship("departure_count", &["dep_airport"])
+                .with_pkfk_join(
+                    "dep_airport",
+                    "f",
+                    "a",
+                    &["departure_code"],
+                    &["airport_code"],
+                )
+                .with_pkfk_join(
+                    "arr_airport",
+                    "f",
+                    "a",
+                    &["arrival_code"],
+                    &["airport_code"],
+                );
+            let req = QueryRequest {
+                facts: vec![],
+                dimensions: vec![DimensionName::new("city")],
+                metrics: vec![MetricName::new("departure_count")],
+            };
+            let sql = expand("test", &def, &req).unwrap();
+            assert!(
+                sql.contains("LEFT JOIN \"airports\" AS \"a__dep_airport\""),
+                "Scoped alias format {{alias}}__{{rel}} must be preserved: {sql}"
+            );
+            assert!(
+                sql.contains("\"f\".\"departure_code\" = \"a__dep_airport\".\"airport_code\""),
+                "ON clause must use the scoped alias on the PK side: {sql}"
             );
         }
     }

--- a/src/expand/types.rs
+++ b/src/expand/types.rs
@@ -237,6 +237,21 @@ pub enum ExpandError {
         dimension_table: String,
         relationship_name: String,
     },
+    /// Two queried metrics sit at different grains (source tables) and the
+    /// join path between those tables crosses a fan-out edge: joining both
+    /// source tables multiplies `metric_table`'s rows, silently inflating
+    /// `metric_name` (fan trap / chasm trap between metric grains).
+    MetricFanTrap {
+        view_name: String,
+        metric_name: String,
+        metric_table: String,
+        other_metric_name: String,
+        other_metric_table: String,
+        relationship_name: String,
+    },
+    /// The stored definition's relationship graph could not be rebuilt at
+    /// query time, so safety checks (fan-trap detection) cannot run.
+    UncheckableDefinition { view_name: String, reason: String },
     /// A dimension from a role-playing table is ambiguous because multiple
     /// relationships reach that table and no co-queried metric provides USING
     /// context to disambiguate.
@@ -363,6 +378,33 @@ impl fmt::Display for ExpandError {
                      This would inflate aggregation results. \
                      Remove the dimension, use a metric from the same table, or restructure the \
                      relationship."
+                )
+            }
+            Self::MetricFanTrap {
+                view_name,
+                metric_name,
+                metric_table,
+                other_metric_name,
+                other_metric_table,
+                relationship_name,
+            } => {
+                write!(
+                    f,
+                    "semantic view '{view_name}': fan trap detected -- metric '{metric_name}' \
+                     (table '{metric_table}') and metric '{other_metric_name}' (table \
+                     '{other_metric_table}') aggregate at different grains: joining their source \
+                     tables via relationship '{relationship_name}' (many-to-one cardinality) \
+                     duplicates rows of '{metric_table}' and would inflate '{metric_name}'. \
+                     Query the metrics separately, or restructure the relationship."
+                )
+            }
+            Self::UncheckableDefinition { view_name, reason } => {
+                write!(
+                    f,
+                    "semantic view '{view_name}': cannot verify the query is safe from fan traps \
+                     -- the stored definition's relationship graph could not be built: {reason}. \
+                     The definition likely predates current validation rules; re-create it with \
+                     CREATE OR REPLACE SEMANTIC VIEW."
                 )
             }
             Self::AmbiguousPath {

--- a/src/expand/types.rs
+++ b/src/expand/types.rs
@@ -328,6 +328,17 @@ pub enum ExpandError {
         metric_expr: String,
         reason: String,
     },
+    /// A `COUNT(*)` metric on a non-base source table cannot be made safe
+    /// (SG-8). Synthesized joins are LEFT JOINs, so the source table is
+    /// NULL-extended by one row per unmatched base row and `COUNT(*)` would
+    /// silently over-count. The expansion rewrites such metrics to
+    /// `COUNT(<first PK column>)`, which requires the source table to declare
+    /// a PRIMARY KEY.
+    CountStarRequiresPrimaryKey {
+        view_name: String,
+        metric_name: String,
+        table_alias: String,
+    },
 }
 
 impl fmt::Display for ExpandError {
@@ -576,6 +587,22 @@ impl fmt::Display for ExpandError {
                      (expression: {metric_expr}) cannot be expanded: {reason}. NON ADDITIVE BY \
                      snapshot expansion requires the metric to be a single aggregate call \
                      SUM/COUNT/AVG/MIN/MAX(<expression>) without '*' or DISTINCT."
+                )
+            }
+            Self::CountStarRequiresPrimaryKey {
+                view_name,
+                metric_name,
+                table_alias,
+            } => {
+                write!(
+                    f,
+                    "semantic view '{view_name}': metric '{metric_name}' uses COUNT(*) on joined \
+                     table '{table_alias}'. The generated LEFT JOIN produces one NULL-extended \
+                     row per base-table row with no match in '{table_alias}', which COUNT(*) \
+                     would count -- so the expansion rewrites COUNT(*) to COUNT(<primary key>) \
+                     for non-base tables, but table '{table_alias}' has no PRIMARY KEY declared \
+                     in the TABLES clause. Add PRIMARY KEY (cols) to '{table_alias}' or use an \
+                     explicit column: COUNT({table_alias}.<column>)."
                 )
             }
         }

--- a/src/expand/types.rs
+++ b/src/expand/types.rs
@@ -308,6 +308,26 @@ pub enum ExpandError {
         depth: usize,
         max_depth: usize,
     },
+    /// A metric co-queried with an active semi-additive metric cannot be
+    /// decomposed for the snapshot CTE (SG-5). The CTE captures each metric's
+    /// inner expression per row and re-aggregates it outside the snapshot
+    /// filter, which is only sound for a single bare aggregate call
+    /// `FUNC(args)` with FUNC in SUM/COUNT/AVG/MIN/MAX, no `*`, no DISTINCT.
+    SemiAdditiveCoQueryUnsupported {
+        view_name: String,
+        metric_name: String,
+        metric_expr: String,
+        semi_metric_name: String,
+        reason: String,
+    },
+    /// An active semi-additive metric's own expression cannot be decomposed
+    /// for the snapshot CTE (same shape requirements as co-queried metrics).
+    SemiAdditiveUnsupportedExpression {
+        view_name: String,
+        metric_name: String,
+        metric_expr: String,
+        reason: String,
+    },
 }
 
 impl fmt::Display for ExpandError {
@@ -525,6 +545,37 @@ impl fmt::Display for ExpandError {
                     f,
                     "semantic view '{view_name}': derived metric nesting depth {depth} exceeds \
                      maximum allowed depth of {max_depth}"
+                )
+            }
+            Self::SemiAdditiveCoQueryUnsupported {
+                view_name,
+                metric_name,
+                metric_expr,
+                semi_metric_name,
+                reason,
+            } => {
+                write!(
+                    f,
+                    "semantic view '{view_name}': metric '{metric_name}' (expression: \
+                     {metric_expr}) cannot be co-queried with semi-additive metric \
+                     '{semi_metric_name}': {reason}. Snapshot expansion for NON ADDITIVE BY \
+                     requires every co-queried metric to be a single aggregate call \
+                     SUM/COUNT/AVG/MIN/MAX(<expression>) without '*', DISTINCT, or surrounding \
+                     expression text. Query '{metric_name}' and '{semi_metric_name}' separately."
+                )
+            }
+            Self::SemiAdditiveUnsupportedExpression {
+                view_name,
+                metric_name,
+                metric_expr,
+                reason,
+            } => {
+                write!(
+                    f,
+                    "semantic view '{view_name}': semi-additive metric '{metric_name}' \
+                     (expression: {metric_expr}) cannot be expanded: {reason}. NON ADDITIVE BY \
+                     snapshot expansion requires the metric to be a single aggregate call \
+                     SUM/COUNT/AVG/MIN/MAX(<expression>) without '*' or DISTINCT."
                 )
             }
         }

--- a/src/expand/wildcard.rs
+++ b/src/expand/wildcard.rs
@@ -18,6 +18,12 @@ pub enum WildcardItemType {
 /// (matches Snowflake behavior). PRIVATE metrics and facts are excluded from
 /// expansion. Dimensions have no access modifier and are always included.
 /// Duplicates (from wildcard + explicit overlap) are removed.
+///
+/// Items declared without a table qualifier (`source_table == None`) are
+/// base-table items everywhere else in the expansion layer, so they are
+/// included when the wildcard alias is the base/root (first declared) table's
+/// alias (SG-15). Both spellings — `source_table == Some(base_alias)` and
+/// `source_table == None` — expand identically under `base_alias.*`.
 pub fn expand_wildcards(
     items: &[String],
     def: &SemanticViewDefinition,
@@ -55,14 +61,19 @@ pub fn expand_wildcards(
                         .join(", ")
                 ));
             }
+            // SG-15: items declared without a source table are base-table
+            // items; `base_alias.*` must include them.
+            let is_base_alias = def
+                .tables
+                .first()
+                .is_some_and(|t| t.alias.eq_ignore_ascii_case(alias));
+            let on_table = |source_table: Option<&str>| -> bool {
+                source_table.map_or(is_base_alias, |st| st.eq_ignore_ascii_case(alias))
+            };
             match item_type {
                 WildcardItemType::Dimension => {
                     for dim in &def.dimensions {
-                        if dim
-                            .source_table
-                            .as_deref()
-                            .is_some_and(|st| st.eq_ignore_ascii_case(alias))
-                        {
+                        if on_table(dim.source_table.as_deref()) {
                             let key = dim.name.to_ascii_lowercase();
                             if seen.insert(key) {
                                 result.push(dim.name.clone());
@@ -72,10 +83,7 @@ pub fn expand_wildcards(
                 }
                 WildcardItemType::Metric => {
                     for met in &def.metrics {
-                        if met
-                            .source_table
-                            .as_deref()
-                            .is_some_and(|st| st.eq_ignore_ascii_case(alias))
+                        if on_table(met.source_table.as_deref())
                             && met.access != AccessModifier::Private
                         {
                             let key = met.name.to_ascii_lowercase();
@@ -87,10 +95,7 @@ pub fn expand_wildcards(
                 }
                 WildcardItemType::Fact => {
                     for fact in &def.facts {
-                        if fact
-                            .source_table
-                            .as_deref()
-                            .is_some_and(|st| st.eq_ignore_ascii_case(alias))
+                        if on_table(fact.source_table.as_deref())
                             && fact.access != AccessModifier::Private
                         {
                             let key = fact.name.to_ascii_lowercase();
@@ -267,5 +272,85 @@ mod tests {
         let items = vec!["region".to_string(), "status".to_string()];
         let result = expand_wildcards(&items, &def, &WildcardItemType::Dimension).unwrap();
         assert_eq!(result, vec!["region", "status"]);
+    }
+
+    // -------------------------------------------------------------------
+    // SG-15 (code review 2026-07-02): base-alias wildcards must include
+    // items declared WITHOUT a source table (base-table items).
+    // -------------------------------------------------------------------
+
+    /// Base table `o` with items in BOTH spellings: `source_table == None`
+    /// (unqualified declaration) and `source_table == Some("o")`.
+    fn base_none_def() -> SemanticViewDefinition {
+        let mut def = test_def();
+        def.dimensions.push(Dimension {
+            name: "order_year".to_string(),
+            expr: "year(order_date)".to_string(),
+            source_table: None,
+            ..Default::default()
+        });
+        def.metrics.push(Metric {
+            name: "base_count".to_string(),
+            expr: "count(*)".to_string(),
+            source_table: None,
+            access: AccessModifier::Public,
+            ..Default::default()
+        });
+        def.facts.push(Fact {
+            name: "base_flag".to_string(),
+            expr: "flag".to_string(),
+            source_table: None,
+            access: AccessModifier::Public,
+            ..Default::default()
+        });
+        def
+    }
+
+    #[test]
+    fn test_base_alias_wildcard_includes_unqualified_dimensions() {
+        let def = base_none_def();
+        let items = vec!["o.*".to_string()];
+        let result = expand_wildcards(&items, &def, &WildcardItemType::Dimension).unwrap();
+        // Both spellings expand under the base alias: Some("o") dims AND the
+        // unqualified (None) dim.
+        assert_eq!(result, vec!["region", "status", "order_year"]);
+    }
+
+    #[test]
+    fn test_non_base_alias_wildcard_excludes_unqualified_dimensions() {
+        let def = base_none_def();
+        let items = vec!["li.*".to_string()];
+        let result = expand_wildcards(&items, &def, &WildcardItemType::Dimension).unwrap();
+        assert_eq!(
+            result,
+            vec!["product"],
+            "None-source items are base-table items, not li items"
+        );
+    }
+
+    #[test]
+    fn test_base_alias_wildcard_includes_unqualified_metrics() {
+        let def = base_none_def();
+        let items = vec!["o.*".to_string()];
+        let result = expand_wildcards(&items, &def, &WildcardItemType::Metric).unwrap();
+        // order_count (Some "o") + base_count (None); secret_metric stays
+        // excluded (PRIVATE).
+        assert_eq!(result, vec!["order_count", "base_count"]);
+    }
+
+    #[test]
+    fn test_base_alias_wildcard_includes_unqualified_facts() {
+        let def = base_none_def();
+        let items = vec!["o.*".to_string()];
+        let result = expand_wildcards(&items, &def, &WildcardItemType::Fact).unwrap();
+        assert_eq!(result, vec!["base_flag"]);
+    }
+
+    #[test]
+    fn test_base_alias_wildcard_case_insensitive() {
+        let def = base_none_def();
+        let items = vec!["O.*".to_string()];
+        let result = expand_wildcards(&items, &def, &WildcardItemType::Dimension).unwrap();
+        assert_eq!(result, vec!["region", "status", "order_year"]);
     }
 }

--- a/src/expand/window.rs
+++ b/src/expand/window.rs
@@ -13,7 +13,7 @@ use std::collections::{HashMap, HashSet};
 use crate::model::{Metric, NullsOrder, SemanticViewDefinition, SortOrder};
 use crate::util::replace_word_boundary;
 
-use super::join_resolver::{resolve_joins_pkfk, synthesize_on_clause, synthesize_on_clause_scoped};
+use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{qualify_and_quote_table_ref, quote_ident};
 use super::types::ExpandError;
 
@@ -160,49 +160,8 @@ pub(super) fn expand_window_metrics(
     }
 
     // CTE JOINs
-    let ordered_aliases = resolve_joins_pkfk(def, resolved_dims, resolved_mets);
-    for alias in &ordered_aliases {
-        if let Some(sep_pos) = alias.find("__") {
-            let rel_name = &alias[sep_pos + 2..];
-            let Some(join) = def.joins.iter().find(|j| {
-                j.name
-                    .as_ref()
-                    .is_some_and(|n| n.eq_ignore_ascii_case(rel_name))
-            }) else {
-                continue;
-            };
-            let bare_alias = &alias[..sep_pos];
-            let table_ref = def
-                .tables
-                .iter()
-                .find(|t| t.alias.to_ascii_lowercase() == bare_alias);
-            let physical_table = table_ref.map_or(bare_alias, |t| t.table.as_str());
-            sql.push_str("\n    LEFT JOIN ");
-            sql.push_str(&qualify_and_quote_table_ref(physical_table, def));
-            sql.push_str(" AS ");
-            sql.push_str(&quote_ident(alias));
-            sql.push_str(" ON ");
-            sql.push_str(&synthesize_on_clause_scoped(join, &def.tables, alias));
-        } else {
-            let Some(join) = def.joins.iter().find(|j| {
-                j.table.to_ascii_lowercase() == *alias
-                    || j.from_alias.to_ascii_lowercase() == *alias
-            }) else {
-                continue;
-            };
-            let table_ref = def
-                .tables
-                .iter()
-                .find(|t| t.alias.to_ascii_lowercase() == *alias);
-            let physical_table = table_ref.map_or(alias.as_str(), |t| t.table.as_str());
-            sql.push_str("\n    LEFT JOIN ");
-            sql.push_str(&qualify_and_quote_table_ref(physical_table, def));
-            sql.push_str(" AS ");
-            sql.push_str(&quote_ident(alias));
-            sql.push_str(" ON ");
-            sql.push_str(&synthesize_on_clause(join, &def.tables));
-        }
-    }
+    let resolved_joins = resolve_joins_pkfk(def, resolved_dims, resolved_mets, &[]);
+    push_join_clauses(&mut sql, &resolved_joins, def, "\n    LEFT JOIN ");
 
     // CTE GROUP BY (all dimension columns)
     if !resolved_dims.is_empty() {

--- a/src/expand/window.rs
+++ b/src/expand/window.rs
@@ -272,7 +272,7 @@ pub(super) fn expand_window_metrics(
 #[cfg(test)]
 mod tests {
     use crate::expand::test_helpers::{minimal_def, orders_view, TestFixtureExt};
-    use crate::expand::{expand, DimensionName, MetricName, QueryRequest};
+    use crate::expand::{expand, DimensionName, ExpandError, MetricName, QueryRequest};
     use crate::model::{NullsOrder, SortOrder, WindowOrderBy, WindowSpec};
 
     /// Single window metric with 3 dims -- CTE with GROUP BY all dims,
@@ -603,11 +603,17 @@ mod tests {
         );
     }
 
-    /// Fan trap check skips window metrics.
+    /// SG-6 (code review 2026-07-02): window metrics get the standard
+    /// fan-trap check. The previous unconditional `is_window()` skip was
+    /// based on the incorrect premise that the CTE pre-aggregation handles
+    /// fan-out — but the CTE's inner aggregate is computed OVER the
+    /// already-fanned join, so it is inflated before the window function
+    /// runs. This fixture (metric grain on `c`, dims on `a`, where a->c is
+    /// `ManyToOne`) fans `c`'s rows and must now error.
     #[test]
-    fn test_fan_trap_skips_window_metrics() {
-        // Multi-table view: window metric crosses many-to-one boundary.
-        // Without fan trap skip, this would error. With skip, it should succeed.
+    fn test_fan_trap_checks_window_metrics() {
+        // Multi-table view: window metric crosses many-to-one boundary
+        // in the fan-out direction.
         let def = orders_view()
             .with_table("customers", "customers", &[])
             .clear_dimensions()
@@ -641,12 +647,11 @@ mod tests {
             metrics: vec![MetricName::new("total_balance")],
         };
 
-        // Should NOT return a FanTrap error because window metrics are skipped
+        // Window metrics are checked like any other aggregate: fan-out error.
         let result = expand("test_view", &def, &req);
         assert!(
-            result.is_ok(),
-            "Window metric should skip fan trap: {:?}",
-            result.err()
+            matches!(result, Err(ExpandError::FanTrap { .. })),
+            "Window metric over a fanning join must be a fan trap error, got: {result:?}"
         );
     }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -2,6 +2,7 @@
 
 mod derived_metrics;
 mod facts;
+mod names;
 mod relationship;
 mod toposort;
 mod using;
@@ -12,5 +13,6 @@ mod test_helpers;
 // Public API (matches prior graph.rs surface exactly)
 pub use derived_metrics::{contains_aggregate_function, validate_derived_metrics};
 pub use facts::{find_fact_references, validate_facts};
+pub use names::validate_name_uniqueness;
 pub use relationship::{validate_graph, RelationshipGraph};
 pub use using::validate_using_relationships;

--- a/src/graph/names.rs
+++ b/src/graph/names.rs
@@ -1,0 +1,137 @@
+//! Define-time name-uniqueness validation (SG-13).
+//!
+//! Dimensions, metrics, and facts are resolved from one request namespace at
+//! query time: `semantic_view(...)` looks names up case-insensitively and the
+//! first declaration wins, so any collision — within a kind or across kinds —
+//! silently shadows (duplicate metrics) or emits duplicate output columns
+//! (dimension/metric sharing a name). Reject collisions when the definition
+//! is created or altered.
+//!
+//! This is define-time-only validation: read paths (`SHOW`, `DESCRIBE`,
+//! expansion) intentionally keep first-match behavior so legacy catalog rows
+//! that predate this check still load and query.
+
+use std::collections::HashMap;
+
+use crate::model::SemanticViewDefinition;
+
+/// Validate that dimension, metric, and fact names are unique
+/// (case-insensitively) across the shared namespace.
+///
+/// Returns `Err` naming the colliding item and the kinds involved.
+pub fn validate_name_uniqueness(def: &SemanticViewDefinition) -> Result<(), String> {
+    let mut seen: HashMap<String, (&str, &str)> = HashMap::new();
+    let items = def
+        .dimensions
+        .iter()
+        .map(|d| ("dimension", d.name.as_str()))
+        .chain(def.metrics.iter().map(|m| ("metric", m.name.as_str())))
+        .chain(def.facts.iter().map(|f| ("fact", f.name.as_str())));
+    for (kind, name) in items {
+        let key = name.to_ascii_lowercase();
+        if let Some((first_kind, first_name)) = seen.get(key.as_str()) {
+            return Err(format!(
+                "duplicate name '{name}': {kind} '{name}' collides with {first_kind} \
+                 '{first_name}' -- dimension, metric, and fact names share one namespace \
+                 and are case-insensitive"
+            ));
+        }
+        seen.insert(key, (kind, name));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_name_uniqueness;
+    use crate::model::{Dimension, Fact, Metric, SemanticViewDefinition};
+
+    fn def_with(dims: &[&str], metrics: &[&str], facts: &[&str]) -> SemanticViewDefinition {
+        SemanticViewDefinition {
+            dimensions: dims
+                .iter()
+                .map(|n| Dimension {
+                    name: (*n).to_string(),
+                    expr: (*n).to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+            metrics: metrics
+                .iter()
+                .map(|n| Metric {
+                    name: (*n).to_string(),
+                    expr: format!("sum({n})"),
+                    source_table: Some("o".to_string()),
+                    ..Default::default()
+                })
+                .collect(),
+            facts: facts
+                .iter()
+                .map(|n| Fact {
+                    name: (*n).to_string(),
+                    expr: (*n).to_string(),
+                    source_table: Some("o".to_string()),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn distinct_names_accepted() {
+        let def = def_with(&["region", "status"], &["revenue"], &["net_price"]);
+        assert!(validate_name_uniqueness(&def).is_ok());
+    }
+
+    #[test]
+    fn duplicate_metric_names_rejected_case_insensitively() {
+        let def = def_with(&[], &["Revenue", "revenue"], &[]);
+        let err = validate_name_uniqueness(&def).unwrap_err();
+        assert!(
+            err.contains("duplicate name 'revenue'")
+                && err.contains("metric 'revenue' collides with metric 'Revenue'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn dimension_metric_collision_rejected() {
+        let def = def_with(&["region"], &["REGION"], &[]);
+        let err = validate_name_uniqueness(&def).unwrap_err();
+        assert!(
+            err.contains("metric 'REGION' collides with dimension 'region'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn fact_dimension_collision_rejected() {
+        let def = def_with(&["amount"], &[], &["amount"]);
+        let err = validate_name_uniqueness(&def).unwrap_err();
+        assert!(
+            err.contains("fact 'amount' collides with dimension 'amount'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn duplicate_dimension_names_rejected() {
+        let def = def_with(&["region", "Region"], &[], &[]);
+        let err = validate_name_uniqueness(&def).unwrap_err();
+        assert!(
+            err.contains("dimension 'Region' collides with dimension 'region'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn metric_fact_collision_rejected() {
+        let def = def_with(&[], &["net_price"], &["Net_Price"]);
+        let err = validate_name_uniqueness(&def).unwrap_err();
+        assert!(
+            err.contains("fact 'Net_Price' collides with metric 'net_price'"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -944,25 +944,34 @@ mod extension {
             semantic_views_init_c_api_internal(info, access)
         }));
 
+        // FF-7 (code-review 2026-07-02): these arms run AFTER catch_unwind
+        // has returned, so a panic here (e.g. `.unwrap()` on a null
+        // `set_error`) would unwind out of this extern "C" fn — a guaranteed
+        // process abort in the host. A null callback instead degrades to a
+        // message-less failed load.
         match init_result {
             Ok(Ok(val)) => val,
             Ok(Err(x)) => {
-                let error_c_string = std::ffi::CString::new(x.to_string());
-                match error_c_string {
-                    Ok(e) => {
-                        (*access).set_error.unwrap()(info, e.as_ptr());
-                    }
-                    Err(_e) => {
-                        let error_alloc_failure = c"An error occurred but the extension failed to allocate memory for an error string";
-                        (*access).set_error.unwrap()(info, error_alloc_failure.as_ptr());
+                if let Some(set_error) = (*access).set_error {
+                    let error_c_string = std::ffi::CString::new(x.to_string());
+                    match error_c_string {
+                        Ok(e) => {
+                            set_error(info, e.as_ptr());
+                        }
+                        Err(_e) => {
+                            let error_alloc_failure = c"An error occurred but the extension failed to allocate memory for an error string";
+                            set_error(info, error_alloc_failure.as_ptr());
+                        }
                     }
                 }
                 false
             }
             Err(_panic) => {
-                let panic_msg =
-                    c"Extension init panicked unexpectedly. This is a bug in semantic_views.";
-                (*access).set_error.unwrap()(info, panic_msg.as_ptr());
+                if let Some(set_error) = (*access).set_error {
+                    let panic_msg =
+                        c"Extension init panicked unexpectedly. This is a bug in semantic_views.";
+                    set_error(info, panic_msg.as_ptr());
+                }
                 false
             }
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -181,7 +181,8 @@ pub struct Metric {
     #[serde(default, skip_serializing_if = "AccessModifier::is_default")]
     pub access: AccessModifier,
     /// Dimensions this metric is non-additive by (snapshot aggregation).
-    /// When non-empty, expansion uses `ROW_NUMBER` CTE for snapshot selection.
+    /// When non-empty, expansion uses a `RANK`-based CTE for snapshot
+    /// selection (rows tied at the snapshot value all aggregate).
     /// Old stored JSON without this field deserializes with empty Vec.
     /// Not serialized when empty to preserve backward-compatible JSON.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3944,6 +3944,39 @@ mod tests {
             );
         }
 
+        #[cfg(feature = "extension")]
+        #[test]
+        fn enrich_rejects_cross_kind_name_collision() {
+            // SG-13 (code review 2026-07-02): dimension/metric/fact names
+            // share one request namespace, so define-time validation
+            // (enrich_definition_for_create -> validate_name_uniqueness)
+            // must reject a dimension and metric sharing a name, even when
+            // no derived metrics exist (the old check was gated on them).
+            let def = crate::model::SemanticViewDefinition {
+                tables: vec![make_table("orders", &["id"], &[])],
+                dimensions: vec![crate::model::Dimension {
+                    name: "region".to_string(),
+                    expr: "orders.region".to_string(),
+                    source_table: Some("orders".to_string()),
+                    ..Default::default()
+                }],
+                metrics: vec![crate::model::Metric {
+                    name: "REGION".to_string(),
+                    expr: "count(orders.region)".to_string(),
+                    source_table: Some("orders".to_string()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            let err = crate::ddl::define::enrich_definition_for_create("v_dup", def)
+                .expect_err("cross-kind name collision must be rejected at define time");
+            assert!(
+                err.contains("duplicate name 'REGION'")
+                    && err.contains("metric 'REGION' collides with dimension 'region'"),
+                "SG-13 error shape mismatch: {err}"
+            );
+        }
+
         #[test]
         fn infers_one_to_one_from_pk_match() {
             // orders PK is (id), FK is (id) -> OneToOne

--- a/src/util.rs
+++ b/src/util.rs
@@ -58,8 +58,13 @@ pub fn replace_word_boundary(haystack: &str, needle: &str, replacement: &str) ->
                 continue;
             }
         }
-        result.push(haystack[i..].chars().next().unwrap());
-        i += 1;
+        // Advance by a full UTF-8 char so `i` stays on a char boundary
+        // (byte-wise advance both duplicated multi-byte chars in the output
+        // and panicked slicing `haystack[i..]` mid-codepoint — MS-3,
+        // code-review 2026-07-02; mirrors `replace_word_boundary_any`).
+        let ch = haystack[i..].chars().next().unwrap();
+        result.push(ch);
+        i += ch.len_utf8();
     }
     // Append remaining bytes that are shorter than needle
     if i < haystack.len() {
@@ -190,6 +195,41 @@ mod tests {
     fn replace_word_boundary_match_with_addition() {
         let result = replace_word_boundary("net_price + tax", "net_price", "(a + b)");
         assert_eq!(result, "(a + b) + tax");
+    }
+
+    #[test]
+    fn replace_word_boundary_non_ascii_haystack_no_panic_no_duplication() {
+        // MS-3 regression: byte-wise advance through a multi-byte char
+        // panicked on the next `haystack[i..]` slice ("byte index N is not
+        // a char boundary") and duplicated the char where it didn't panic.
+        // Reachable at query time via fact/derived-metric inlining over any
+        // expression containing non-ASCII (string literals, identifiers).
+        let result = replace_word_boundary("héllo + net_price", "net_price", "(x)");
+        assert_eq!(result, "héllo + (x)");
+
+        let result = replace_word_boundary("concat(city, ' – ') || net_price", "net_price", "(x)");
+        assert_eq!(result, "concat(city, ' – ') || (x)");
+
+        // Non-ASCII with no match at all must round-trip unchanged.
+        let result = replace_word_boundary("'São Paulo' || 'café'", "net_price", "(x)");
+        assert_eq!(result, "'São Paulo' || 'café'");
+    }
+
+    proptest! {
+        // Any (haystack, needle, replacement) triple must not panic, and a
+        // haystack containing no ASCII needle occurrence must round-trip
+        // byte-identical (guards the char-boundary advance).
+        #[test]
+        fn replace_word_boundary_never_panics_on_unicode(
+            haystack in "\\PC{0,40}",
+            needle in "[a-z_]{1,8}",
+            replacement in "\\PC{0,12}",
+        ) {
+            let out = replace_word_boundary(&haystack, &needle, &replacement);
+            if !haystack.contains(&needle) {
+                prop_assert_eq!(out, haystack);
+            }
+        }
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -88,13 +88,34 @@ pub fn replace_word_boundary(haystack: &str, needle: &str, replacement: &str) ->
 /// A single combined pass avoids that.
 #[must_use]
 pub fn replace_word_boundary_any(haystack: &str, needles: &[&str], replacement: &str) -> String {
+    let pairs: Vec<(&str, &str)> = needles.iter().map(|&n| (n, replacement)).collect();
+    replace_word_boundary_pairs(haystack, &pairs)
+}
+
+/// Replace word-boundary occurrences of each needle with its *own* replacement,
+/// in a single left-to-right pass.
+///
+/// Same scanning semantics as [`replace_word_boundary_any`] — at each position
+/// the pairs are tried in the given order, and on a match scanning resumes
+/// *after* the matched needle so inserted replacement text is never re-scanned.
+/// Callers that need deterministic output for overlapping needles should order
+/// the pairs deterministically (e.g. longest needle first, then lexicographic).
+///
+/// This is the safe substitution primitive for derived-metric inlining (SG-3,
+/// code-review 2026-07-02): sequential per-name [`replace_word_boundary`]
+/// calls re-scan earlier substitutions, so a metric name that also appears as
+/// a column reference inside another metric's resolved expression (`revenue`
+/// inside `SUM(o.revenue)` — `.` is a word boundary) got double-substituted
+/// into invalid nested-aggregate SQL, dependent on hash-map iteration order.
+#[must_use]
+pub fn replace_word_boundary_pairs(haystack: &str, pairs: &[(&str, &str)]) -> String {
     let h_bytes = haystack.as_bytes();
     let mut result = String::with_capacity(haystack.len());
     let mut i = 0;
 
     while i < h_bytes.len() {
         let mut matched = false;
-        for &needle in needles {
+        for &(needle, replacement) in pairs {
             let n_bytes = needle.as_bytes();
             let n_len = n_bytes.len();
             if n_len == 0 || i + n_len > h_bytes.len() {
@@ -213,6 +234,35 @@ mod tests {
         // Non-ASCII with no match at all must round-trip unchanged.
         let result = replace_word_boundary("'São Paulo' || 'café'", "net_price", "(x)");
         assert_eq!(result, "'São Paulo' || 'café'");
+    }
+
+    #[test]
+    fn replace_word_boundary_pairs_distinct_replacements_single_pass() {
+        let pairs = [
+            ("revenue", "(SUM(o.revenue))"),
+            ("tax", "(SUM(o.revenue * 0.1))"),
+        ];
+        let result = replace_word_boundary_pairs("revenue - tax", &pairs);
+        assert_eq!(result, "(SUM(o.revenue)) - (SUM(o.revenue * 0.1))");
+    }
+
+    #[test]
+    fn replace_word_boundary_pairs_inserted_text_not_rescanned() {
+        // "b"'s replacement contains needle "a" at a word boundary; a second
+        // scan over inserted text would corrupt it.
+        let pairs = [("a", "(X)"), ("b", "(a + 1)")];
+        let result = replace_word_boundary_pairs("a + b", &pairs);
+        assert_eq!(result, "(X) + (a + 1)");
+    }
+
+    #[test]
+    fn replace_word_boundary_any_still_shares_semantics_with_pairs() {
+        // _any delegates to _pairs; identical inputs must stay identical.
+        let via_any = replace_word_boundary_any("x + y", &["x", "y"], "(z)");
+        let pairs = [("x", "(z)"), ("y", "(z)")];
+        let via_pairs = replace_word_boundary_pairs("x + y", &pairs);
+        assert_eq!(via_any, via_pairs);
+        assert_eq!(via_any, "(z) + (z)");
     }
 
     proptest! {

--- a/test/integration/test_chunk_boundary.py
+++ b/test/integration/test_chunk_boundary.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = ["duckdb==1.5.4"]
+# requires-python = ">=3.10"
+# ///
+"""
+Regression test for chunked emission past DataChunk capacity (2048 rows)
+in the bind-materialized C++ table functions.
+
+Pre-fix, `sv_list_semantic_views_function`, `sv_emit_varchar_rows`, and
+`sv_emit_varchar_bool_rows` (cpp/src/shim.cpp) emitted their ENTIRE
+bind-materialized row set in a single exec call, gated by a one-shot
+`emitted` flag. The exec-callback `DataChunk` has capacity
+STANDARD_VECTOR_SIZE (2048); `Vector::SetValue` performs no bounds check
+in release builds, so row 2049 wrote a 16-byte string_t past the end of
+the vector's data buffer — silent heap corruption reachable from plain
+SQL (finding MS-1 in _notes/code-review-2026-07-02.md).
+
+Post-fix the local state carries a `next_row` cursor and each exec call
+emits at most STANDARD_VECTOR_SIZE rows.
+
+Covers all three fixed emitters:
+  A. sv_emit_varchar_rows      — show_semantic_dimensions_all() over a view
+                                 with 2,100 dimensions (also exercised via
+                                 describe_semantic_view on the same view).
+  B. sv_emit_varchar_bool_rows — show_semantic_dimensions_for_metric() on
+                                 the same view (join-free views return every
+                                 dimension, so 2,100 rows).
+  C. sv_list_semantic_views    — 2,100 registered views.
+
+Assertions check exact row counts AND full content integrity (every
+expected name present exactly once), so a pre-fix build that survives the
+overflow without crashing still fails on missing/garbled rows.
+
+Usage:
+    uv run test/integration/test_chunk_boundary.py
+
+Exit codes:
+    0 = all scenarios passed
+    1 = at least one scenario failed
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_ducklake_helpers import get_ext_dir, get_extension_path
+
+# One chunk is 2048 rows; 2100 forces a second chunk with a 52-row tail.
+N_DIMS = 2100
+N_VIEWS = 2100
+
+
+def build_wide_view_sql(view_name: str, num_dims: int) -> str:
+    dims = ",\n            ".join(
+        f"o.d_{i:04d} AS o.region" for i in range(num_dims)
+    )
+    return f"""
+        CREATE SEMANTIC VIEW {view_name} AS
+          TABLES (o AS cb_orders PRIMARY KEY (id))
+          DIMENSIONS (
+            {dims}
+          )
+          METRICS (o.revenue AS SUM(o.amount))
+    """
+
+
+def run_tests() -> int:
+    import duckdb
+
+    ext_dir = get_ext_dir()
+    ext_path = get_extension_path()
+    if not ext_path.exists():
+        print(f"ERROR: extension not found at {ext_path}")
+        print("Run `just build` first.")
+        return 1
+
+    conn = duckdb.connect(
+        config={
+            "allow_unsigned_extensions": "true",
+            "extension_directory": ext_dir,
+        }
+    )
+    conn.execute(f"FORCE INSTALL '{ext_path}'")
+    conn.execute("LOAD semantic_views")
+
+    conn.execute(
+        "CREATE TABLE cb_orders ("
+        "id INTEGER PRIMARY KEY, region VARCHAR, amount DECIMAL(10,2))"
+    )
+    conn.execute("INSERT INTO cb_orders VALUES (1, 'US', 100.00)")
+
+    failures = 0
+
+    def check(label: str, ok: bool, detail: str = "") -> None:
+        nonlocal failures
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}: {label}" + (f" — {detail}" if detail else ""))
+        if not ok:
+            failures += 1
+
+    # --- Scenario A: varchar emitter (show_semantic_dimensions_all) -------
+    print(f"Scenario A: view with {N_DIMS} dimensions")
+    conn.execute(build_wide_view_sql("cb_wide", N_DIMS))
+
+    expected_names = {f"d_{i:04d}" for i in range(N_DIMS)}
+    rows = conn.execute(
+        "SELECT name FROM show_semantic_dimensions_all()"
+    ).fetchall()
+    names = [r[0] for r in rows]
+    check(
+        f"show_semantic_dimensions_all row count == {N_DIMS}",
+        len(names) == N_DIMS,
+        f"got {len(names)}",
+    )
+    check(
+        "show_semantic_dimensions_all names intact across chunk boundary",
+        set(names) == expected_names and len(set(names)) == len(names),
+        f"missing={len(expected_names - set(names))} "
+        f"unexpected={len(set(names) - expected_names)} "
+        f"dupes={len(names) - len(set(names))}",
+    )
+
+    describe_count = conn.execute(
+        "SELECT count(*) FROM describe_semantic_view('cb_wide')"
+    ).fetchone()[0]
+    check(
+        f"describe_semantic_view emits >= {N_DIMS} rows without corruption",
+        describe_count >= N_DIMS,
+        f"got {describe_count}",
+    )
+
+    # --- Scenario B: varchar+bool emitter (dims for metric) ---------------
+    print(f"Scenario B: show_semantic_dimensions_for_metric over {N_DIMS} dims")
+    rows_b = conn.execute(
+        "SELECT name, required FROM show_semantic_dimensions_for_metric('cb_wide', 'revenue')"
+    ).fetchall()
+    names_b = [r[0] for r in rows_b]
+    check(
+        f"show_semantic_dimensions_for_metric row count == {N_DIMS}",
+        len(names_b) == N_DIMS,
+        f"got {len(names_b)}",
+    )
+    check(
+        "for_metric names intact across chunk boundary",
+        set(names_b) == expected_names,
+        f"missing={len(expected_names - set(names_b))}",
+    )
+    # `required` is True only for window-spec dims; a plain SUM metric marks
+    # every dim False. A corrupted BOOLEAN vector past row 2048 would show
+    # up as spurious True (or non-bool) values here.
+    check(
+        "for_metric BOOLEAN column intact (all False for plain SUM metric)",
+        all(r[1] is False for r in rows_b),
+        f"non-false={sum(1 for r in rows_b if r[1] is not False)}",
+    )
+
+    # --- Scenario C: list_semantic_views emitter ---------------------------
+    print(f"Scenario C: {N_VIEWS} registered views (this takes a few seconds)")
+    t0 = time.monotonic()
+    for i in range(N_VIEWS - 1):  # cb_wide is view #1
+        conn.execute(
+            f"CREATE SEMANTIC VIEW cb_v_{i:04d} AS "
+            "TABLES (o AS cb_orders PRIMARY KEY (id)) "
+            "DIMENSIONS (o.region AS o.region) "
+            "METRICS (o.n AS COUNT(*))"
+        )
+    print(f"  ({N_VIEWS - 1} CREATEs in {time.monotonic() - t0:.1f}s)")
+
+    expected_views = {"cb_wide"} | {f"cb_v_{i:04d}" for i in range(N_VIEWS - 1)}
+    view_names = [
+        r[0]
+        for r in conn.execute("SELECT name FROM list_semantic_views()").fetchall()
+    ]
+    check(
+        f"list_semantic_views row count == {N_VIEWS}",
+        len(view_names) == N_VIEWS,
+        f"got {len(view_names)}",
+    )
+    check(
+        "list_semantic_views names intact across chunk boundary",
+        set(view_names) == expected_views and len(set(view_names)) == len(view_names),
+        f"missing={len(expected_views - set(view_names))} "
+        f"dupes={len(view_names) - len(set(view_names))}",
+    )
+
+    print()
+    if failures:
+        print(f"FAILED: {failures} assertion(s)")
+        return 1
+    print("ALL PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_tests())

--- a/test/integration/test_differential.py
+++ b/test/integration/test_differential.py
@@ -25,6 +25,11 @@ fan-out SG-1, COUNT(*) on child tables SG-8, semi-additive ties SG-4, …)
 are intentionally NOT generated here yet — each R1 fix PR must extend
 this harness with the scenario it repairs, using this file's helpers.
 
+Extensions so far:
+  - SG-3 (single-pass derived-metric inlining): `net_revenue` is derived
+    from metrics whose expressions contain a column (`o.amount`) named
+    like another metric (`amount`) — the exact re-scan poison scenario.
+
 Usage:
     uv run test/integration/test_differential.py
 
@@ -56,13 +61,21 @@ DIMS = {
     "category": ("category", "p.category", "p"),
 }
 
-# Metric name -> reference SQL aggregate (all on the base table — see SCOPE)
+# Metric name -> reference SQL aggregate (all on the base table — see SCOPE).
+# `amount` deliberately shares its name with the orders.amount COLUMN, and
+# `net_revenue` is a derived metric whose resolution inlines `tax_total`
+# (whose expression contains `o.amount`): the SG-3 poison scenario — pre-fix,
+# derived-metric inlining could re-scan inserted text and corrupt this into
+# invalid SQL on a hash-seed-dependent fraction of runs.
 METRICS = {
     "revenue": "SUM(o.amount)",
     "order_count": "COUNT(*)",
     "avg_amount": "AVG(o.amount)",
     "max_qty": "MAX(o.qty)",
     "min_amount": "MIN(o.amount)",
+    "amount": "SUM(o.amount)",
+    "tax_total": "SUM(o.amount * 0.1)",
+    "net_revenue": "SUM(o.amount) - SUM(o.amount * 0.1)",
 }
 
 
@@ -119,7 +132,10 @@ CREATE SEMANTIC VIEW diff_sv AS
     o.order_count AS COUNT(*),
     o.avg_amount AS AVG(o.amount),
     o.max_qty AS MAX(o.qty),
-    o.min_amount AS MIN(o.amount)
+    o.min_amount AS MIN(o.amount),
+    o.amount AS SUM(o.amount),
+    o.tax_total AS SUM(o.amount * 0.1),
+    net_revenue AS revenue - tax_total
   )
 """
 

--- a/test/integration/test_differential.py
+++ b/test/integration/test_differential.py
@@ -29,6 +29,10 @@ Extensions so far:
   - SG-3 (single-pass derived-metric inlining): `net_revenue` is derived
     from metrics whose expressions contain a column (`o.amount`) named
     like another metric (`amount`) — the exact re-scan poison scenario.
+  - SG-2 (declaration-order-independent join emission): the `cat_name`
+    dimension is two joins away (orders -> products -> categories) with
+    the p->cat relationship declared FIRST — pre-fix this emitted a
+    forward-referencing join and dropped the o->p connecting join.
 
 Usage:
     uv run test/integration/test_differential.py
@@ -55,11 +59,18 @@ N_PRODUCTS = 30
 N_ORDERS = 4000
 
 # Dimension name -> (semantic dim name, reference SQL expr, table needed)
+# `cat_name` lives two joins away (orders -> products -> categories) and its
+# relationship is DECLARED FIRST in the view DDL — the SG-2 poison ordering:
+# pre-fix, join emission picked the first declared join mentioning an alias,
+# emitting `products ON p.category_id = cat.id` as a forward reference and
+# dropping the o->p connecting join entirely.
 DIMS = {
     "region": ("region", "o.region", None),
     "tier": ("tier", "c.tier", "c"),
     "category": ("category", "p.category", "p"),
+    "cat_name": ("cat_name", "cat.cat_name", "cat"),
 }
+N_CATEGORIES = 8
 
 # Metric name -> reference SQL aggregate (all on the base table — see SCOPE).
 # `amount` deliberately shares its name with the orders.amount COLUMN, and
@@ -82,7 +93,11 @@ METRICS = {
 def seed_schema(conn) -> None:
     rng = random.Random(SEED)
     conn.execute("CREATE TABLE customers (id INTEGER PRIMARY KEY, name VARCHAR, tier VARCHAR)")
-    conn.execute("CREATE TABLE products (id INTEGER PRIMARY KEY, name VARCHAR, category VARCHAR)")
+    conn.execute("CREATE TABLE categories (id INTEGER PRIMARY KEY, cat_name VARCHAR)")
+    conn.execute(
+        "CREATE TABLE products (id INTEGER PRIMARY KEY, name VARCHAR, "
+        "category VARCHAR, category_id INTEGER)"
+    )
     conn.execute(
         "CREATE TABLE orders (id INTEGER PRIMARY KEY, customer_id INTEGER, "
         "product_id INTEGER, region VARCHAR, amount DECIMAL(10,2), qty INTEGER)"
@@ -94,11 +109,14 @@ def seed_schema(conn) -> None:
             "INSERT INTO customers VALUES (?, ?, ?)",
             [i, f"cust_{i}", rng.choice(tiers)],
         )
+    for i in range(N_CATEGORIES):
+        conn.execute("INSERT INTO categories VALUES (?, ?)", [i, f"cat_{i}"])
     cats = ["alpha", "beta", "gamma"]
     for i in range(N_PRODUCTS):
+        cat_id = None if rng.random() < 0.10 else rng.randrange(N_CATEGORIES)
         conn.execute(
-            "INSERT INTO products VALUES (?, ?, ?)",
-            [i, f"prod_{i}", rng.choice(cats)],
+            "INSERT INTO products VALUES (?, ?, ?, ?)",
+            [i, f"prod_{i}", rng.choice(cats), cat_id],
         )
 
     regions = ["east", "west", "north", "south"]
@@ -116,16 +134,19 @@ CREATE SEMANTIC VIEW diff_sv AS
   TABLES (
     o AS orders PRIMARY KEY (id),
     c AS customers PRIMARY KEY (id),
-    p AS products PRIMARY KEY (id)
+    p AS products PRIMARY KEY (id),
+    cat AS categories PRIMARY KEY (id)
   )
   RELATIONSHIPS (
+    product_category AS p(category_id) REFERENCES cat,
     order_customer AS o(customer_id) REFERENCES c,
     order_product AS o(product_id) REFERENCES p
   )
   DIMENSIONS (
     o.region AS o.region,
     c.tier AS c.tier,
-    p.category AS p.category
+    p.category AS p.category,
+    cat.cat_name AS cat.cat_name
   )
   METRICS (
     o.revenue AS SUM(o.amount),
@@ -145,10 +166,14 @@ def reference_sql(dims: list[str], mets: list[str]) -> str:
     select_items = [DIMS[d][1] for d in dims] + [METRICS[m] for m in mets]
     joins = []
     needed = {DIMS[d][2] for d in dims} - {None}
+    if "cat" in needed:
+        needed.add("p")  # categories hangs off products
     if "c" in needed:
         joins.append("LEFT JOIN customers c ON o.customer_id = c.id")
     if "p" in needed:
         joins.append("LEFT JOIN products p ON o.product_id = p.id")
+    if "cat" in needed:
+        joins.append("LEFT JOIN categories cat ON p.category_id = cat.id")
     sql = f"SELECT {'DISTINCT ' if not mets else ''}{', '.join(select_items)}\n"
     sql += "FROM orders o\n" + "\n".join(joins)
     if dims and mets:

--- a/test/integration/test_differential.py
+++ b/test/integration/test_differential.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = ["duckdb==1.5.4"]
+# requires-python = ">=3.10"
+# ///
+"""
+Differential-testing harness (TC-2, code-review 2026-07-02).
+
+Compares `semantic_view()` results against independently hand-written
+SQL over a seeded, randomized star schema — thousands of rows with NULL
+foreign keys, NULL measures, and skewed group sizes. Every bounded
+combination of requested dimensions and metrics is executed through both
+paths and the result multisets must match exactly (floats within 1e-9
+relative tolerance).
+
+This harness is the acceptance net for the Phase R1 expansion-correctness
+work: SQL-string shape assertions can't prove the generated SQL computes
+the right numbers; this does.
+
+SCOPE (deliberate): the schema and requests stay inside the engine's
+*supported core* — all metrics live on the base (fact) table, dimension
+tables hang off it via ManyToOne PK relationships, one grain. Scenarios
+the 2026-07-02 review identified as broken (multi-grain metric×metric
+fan-out SG-1, COUNT(*) on child tables SG-8, semi-additive ties SG-4, …)
+are intentionally NOT generated here yet — each R1 fix PR must extend
+this harness with the scenario it repairs, using this file's helpers.
+
+Usage:
+    uv run test/integration/test_differential.py
+
+Exit codes:
+    0 = every combination matched
+    1 = at least one mismatch (details printed)
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_ducklake_helpers import get_ext_dir, get_extension_path
+
+SEED = 20260702
+N_CUSTOMERS = 50
+N_PRODUCTS = 30
+N_ORDERS = 4000
+
+# Dimension name -> (semantic dim name, reference SQL expr, table needed)
+DIMS = {
+    "region": ("region", "o.region", None),
+    "tier": ("tier", "c.tier", "c"),
+    "category": ("category", "p.category", "p"),
+}
+
+# Metric name -> reference SQL aggregate (all on the base table — see SCOPE)
+METRICS = {
+    "revenue": "SUM(o.amount)",
+    "order_count": "COUNT(*)",
+    "avg_amount": "AVG(o.amount)",
+    "max_qty": "MAX(o.qty)",
+    "min_amount": "MIN(o.amount)",
+}
+
+
+def seed_schema(conn) -> None:
+    rng = random.Random(SEED)
+    conn.execute("CREATE TABLE customers (id INTEGER PRIMARY KEY, name VARCHAR, tier VARCHAR)")
+    conn.execute("CREATE TABLE products (id INTEGER PRIMARY KEY, name VARCHAR, category VARCHAR)")
+    conn.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, customer_id INTEGER, "
+        "product_id INTEGER, region VARCHAR, amount DECIMAL(10,2), qty INTEGER)"
+    )
+
+    tiers = ["gold", "silver", "bronze", None]
+    for i in range(N_CUSTOMERS):
+        conn.execute(
+            "INSERT INTO customers VALUES (?, ?, ?)",
+            [i, f"cust_{i}", rng.choice(tiers)],
+        )
+    cats = ["alpha", "beta", "gamma"]
+    for i in range(N_PRODUCTS):
+        conn.execute(
+            "INSERT INTO products VALUES (?, ?, ?)",
+            [i, f"prod_{i}", rng.choice(cats)],
+        )
+
+    regions = ["east", "west", "north", "south"]
+    rows = []
+    for i in range(N_ORDERS):
+        cust = None if rng.random() < 0.10 else rng.randrange(N_CUSTOMERS)
+        prod = None if rng.random() < 0.10 else rng.randrange(N_PRODUCTS)
+        amount = None if rng.random() < 0.08 else round(rng.uniform(1, 500), 2)
+        rows.append((i, cust, prod, rng.choice(regions), amount, rng.randrange(1, 20)))
+    conn.executemany("INSERT INTO orders VALUES (?, ?, ?, ?, ?, ?)", rows)
+
+
+CREATE_VIEW = """
+CREATE SEMANTIC VIEW diff_sv AS
+  TABLES (
+    o AS orders PRIMARY KEY (id),
+    c AS customers PRIMARY KEY (id),
+    p AS products PRIMARY KEY (id)
+  )
+  RELATIONSHIPS (
+    order_customer AS o(customer_id) REFERENCES c,
+    order_product AS o(product_id) REFERENCES p
+  )
+  DIMENSIONS (
+    o.region AS o.region,
+    c.tier AS c.tier,
+    p.category AS p.category
+  )
+  METRICS (
+    o.revenue AS SUM(o.amount),
+    o.order_count AS COUNT(*),
+    o.avg_amount AS AVG(o.amount),
+    o.max_qty AS MAX(o.qty),
+    o.min_amount AS MIN(o.amount)
+  )
+"""
+
+
+def reference_sql(dims: list[str], mets: list[str]) -> str:
+    """Independent hand-written equivalent of the semantic_view() request."""
+    select_items = [DIMS[d][1] for d in dims] + [METRICS[m] for m in mets]
+    joins = []
+    needed = {DIMS[d][2] for d in dims} - {None}
+    if "c" in needed:
+        joins.append("LEFT JOIN customers c ON o.customer_id = c.id")
+    if "p" in needed:
+        joins.append("LEFT JOIN products p ON o.product_id = p.id")
+    sql = f"SELECT {'DISTINCT ' if not mets else ''}{', '.join(select_items)}\n"
+    sql += "FROM orders o\n" + "\n".join(joins)
+    if dims and mets:
+        sql += f"\nGROUP BY {', '.join(str(i + 1) for i in range(len(dims)))}"
+    return sql
+
+
+def _is_num(v) -> bool:
+    from decimal import Decimal
+
+    return isinstance(v, (int, float, Decimal)) and not isinstance(v, bool)
+
+
+def normalize(rows: list[tuple]) -> list[tuple]:
+    """Sort rows with None-safe, numeric-type-agnostic keys so both result
+    sets compare positionally even if one side returns e.g. DECIMAL where
+    the other returns DOUBLE for the same value."""
+
+    def key(row: tuple):
+        out = []
+        for v in row:
+            if v is None:
+                out.append((2, ""))
+            elif _is_num(v):
+                out.append((0, float(v)))
+            else:
+                out.append((1, str(v)))
+        return tuple(out)
+
+    return sorted(rows, key=key)
+
+
+def values_equal(a, b) -> bool:
+    if a is None or b is None:
+        return a is None and b is None
+    if _is_num(a) and _is_num(b):
+        return math.isclose(float(a), float(b), rel_tol=1e-9, abs_tol=1e-9)
+    return a == b
+
+
+def rows_equal(got: list[tuple], want: list[tuple]) -> bool:
+    if len(got) != len(want):
+        return False
+    return all(
+        len(g) == len(w) and all(values_equal(gv, wv) for gv, wv in zip(g, w))
+        for g, w in zip(got, want)
+    )
+
+
+def run_harness() -> int:
+    import duckdb
+
+    ext_dir = get_ext_dir()
+    ext_path = get_extension_path()
+    if not ext_path.exists():
+        print(f"ERROR: extension not found at {ext_path}")
+        print("Run `just build` first.")
+        return 1
+
+    conn = duckdb.connect(
+        config={
+            "allow_unsigned_extensions": "true",
+            "extension_directory": ext_dir,
+        }
+    )
+    conn.execute(f"FORCE INSTALL '{ext_path}'")
+    conn.execute("LOAD semantic_views")
+
+    seed_schema(conn)
+    conn.execute(CREATE_VIEW)
+
+    dim_names = list(DIMS)
+    met_names = list(METRICS)
+
+    # Bounded request set: every dims subset (incl. empty) × (each single
+    # metric, one representative pair, all metrics, and — for non-empty dims —
+    # no metrics at all). ~70 requests.
+    metric_choices: list[list[str]] = (
+        [[m] for m in met_names] + [["revenue", "order_count"]] + [met_names]
+    )
+    dim_choices: list[list[str]] = [
+        list(c) for r in range(len(dim_names) + 1) for c in itertools.combinations(dim_names, r)
+    ]
+
+    total = 0
+    failures = 0
+    for dims in dim_choices:
+        for mets in metric_choices + ([[]] if dims else []):
+            if not dims and not mets:
+                continue
+            total += 1
+            dim_arg = ", ".join(f"'{d}'" for d in dims)
+            met_arg = ", ".join(f"'{m}'" for m in mets)
+            parts = []
+            if dims:
+                parts.append(f"dimensions := [{dim_arg}]")
+            if mets:
+                parts.append(f"metrics := [{met_arg}]")
+            sv_sql = f"SELECT * FROM semantic_view('diff_sv', {', '.join(parts)})"
+            ref_sql = reference_sql(dims, mets)
+
+            try:
+                got = normalize(conn.execute(sv_sql).fetchall())
+                want = normalize(conn.execute(ref_sql).fetchall())
+            except Exception as exc:  # noqa: BLE001 — report and continue
+                failures += 1
+                print(f"FAIL dims={dims} mets={mets}: query error: {exc}")
+                continue
+
+            if not rows_equal(got, want):
+                failures += 1
+                print(f"FAIL dims={dims} mets={mets}: result mismatch")
+                print(f"  semantic_view rows={len(got)}, reference rows={len(want)}")
+                for g, w in list(zip(got, want))[:3]:
+                    if not (len(g) == len(w) and all(values_equal(a, b) for a, b in zip(g, w))):
+                        print(f"  first differing row: got={g!r} want={w!r}")
+                        break
+
+    print()
+    print(f"Ran {total} dims×metrics combinations over {N_ORDERS} orders "
+          f"({N_CUSTOMERS} customers, {N_PRODUCTS} products, seed={SEED})")
+    if failures:
+        print(f"FAILED: {failures}/{total} combinations mismatched")
+        return 1
+    print("ALL PASSED — semantic_view() matches hand-written SQL on every combination")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_harness())

--- a/test/integration/test_differential.py
+++ b/test/integration/test_differential.py
@@ -292,6 +292,53 @@ def run_harness() -> int:
                         print(f"  first differing row: got={g!r} want={w!r}")
                         break
 
+    # --- Multi-grain guard (SG-1): mixing grains must ERROR, not inflate ----
+    # A separate view with a metric on a ManyToOne child of the base: the
+    # pre-fix engine silently joined the child and inflated the base-grain
+    # SUM per child row. Post-fix the request must raise the fan-trap error.
+    # (item_count alone is NOT compared against reference SQL here until
+    # SG-8 — COUNT(*) over LEFT JOIN NULL-extension — lands.)
+    conn.execute(
+        "CREATE TABLE line_items (id INTEGER PRIMARY KEY, order_id INTEGER, "
+        "line_amount DECIMAL(10,2))"
+    )
+    conn.execute(
+        "INSERT INTO line_items SELECT s.range, s.range % 500, 5.00 "
+        "FROM range(1500) s"
+    )
+    conn.execute(
+        "CREATE SEMANTIC VIEW diff_mg AS "
+        "TABLES (o AS orders PRIMARY KEY (id), li AS line_items PRIMARY KEY (id)) "
+        "RELATIONSHIPS (li_order AS li(order_id) REFERENCES o) "
+        "DIMENSIONS (o.region AS o.region) "
+        "METRICS (o.revenue AS SUM(o.amount), li.item_count AS COUNT(*))"
+    )
+    total += 2
+    try:
+        conn.execute(
+            "SELECT * FROM semantic_view('diff_mg', metrics := ['revenue', 'item_count'])"
+        ).fetchall()
+        failures += 1
+        print("FAIL multi-grain: expected fan-trap error, query succeeded")
+    except Exception as exc:  # noqa: BLE001
+        if "fan trap detected" in str(exc):
+            print("  PASS: multi-grain metric pair raises fan-trap error")
+        else:
+            failures += 1
+            print(f"FAIL multi-grain: wrong error: {exc}")
+    # Base-grain metric alone must still prune the child join and match.
+    got = normalize(
+        conn.execute(
+            "SELECT * FROM semantic_view('diff_mg', metrics := ['revenue'])"
+        ).fetchall()
+    )
+    want = normalize(conn.execute("SELECT SUM(amount) FROM orders").fetchall())
+    if rows_equal(got, want):
+        print("  PASS: base-grain metric alone matches (child join pruned)")
+    else:
+        failures += 1
+        print(f"FAIL multi-grain: revenue-alone mismatch got={got} want={want}")
+
     print()
     print(f"Ran {total} dims×metrics combinations over {N_ORDERS} orders "
           f"({N_CUSTOMERS} customers, {N_PRODUCTS} products, seed={SEED})")

--- a/test/integration/test_differential.py
+++ b/test/integration/test_differential.py
@@ -339,6 +339,45 @@ def run_harness() -> int:
         failures += 1
         print(f"FAIL multi-grain: revenue-alone mismatch got={got} want={want}")
 
+    # Child-grain COUNT(*) alone (SG-8): the engine rewrites COUNT(*) to
+    # COUNT(<child pk>) so NULL-extended rows from childless parents are not
+    # counted. Reference uses COUNT(li.id) — the semantically correct count.
+    # (Orders 500+ in the fixture have no line items.)
+    total += 2
+    got = normalize(
+        conn.execute(
+            "SELECT * FROM semantic_view('diff_mg', metrics := ['item_count'])"
+        ).fetchall()
+    )
+    want = normalize(
+        conn.execute(
+            "SELECT COUNT(li.id) FROM orders o "
+            "LEFT JOIN line_items li ON li.order_id = o.id"
+        ).fetchall()
+    )
+    if rows_equal(got, want):
+        print("  PASS: child-grain COUNT(*) alone matches COUNT(pk) reference")
+    else:
+        failures += 1
+        print(f"FAIL SG-8: item_count-alone mismatch got={got} want={want}")
+    got = normalize(
+        conn.execute(
+            "SELECT * FROM semantic_view('diff_mg', "
+            "dimensions := ['region'], metrics := ['item_count'])"
+        ).fetchall()
+    )
+    want = normalize(
+        conn.execute(
+            "SELECT o.region, COUNT(li.id) FROM orders o "
+            "LEFT JOIN line_items li ON li.order_id = o.id GROUP BY 1"
+        ).fetchall()
+    )
+    if rows_equal(got, want):
+        print("  PASS: child-grain COUNT(*) by region matches COUNT(pk) reference")
+    else:
+        failures += 1
+        print(f"FAIL SG-8: item_count-by-region mismatch got={got} want={want}")
+
     print()
     print(f"Ran {total} dims×metrics combinations over {N_ORDERS} orders "
           f"({N_CUSTOMERS} customers, {N_PRODUCTS} products, seed={SEED})")

--- a/test/sql/TEST_LIST
+++ b/test/sql/TEST_LIST
@@ -59,3 +59,4 @@ test/sql/phase67_quoted_source_tables.test
 test/sql/phase68_quoted_idents_non_additive.test
 test/sql/phase68_quoted_idents_window.test
 test/sql/identity_fact_passthrough.test
+test/sql/count_star_left_join.test

--- a/test/sql/count_star_left_join.test
+++ b/test/sql/count_star_left_join.test
@@ -1,0 +1,130 @@
+# SG-8 (code review 2026-07-02): COUNT(*) on a non-base source table.
+# All synthesized joins are LEFT JOINs, so a childless base row NULL-extends
+# the child table and COUNT(*) silently over-counted by one per childless
+# parent. The expansion now rewrites COUNT(*) to COUNT(<pk>) for non-base
+# source tables; if the source table declares no PRIMARY KEY the query
+# errors instead of returning an inflated count.
+
+require semantic_views
+
+# ============================================================
+# Setup: orders with one CHILDLESS order (id 3)
+# ============================================================
+
+statement ok
+CREATE TABLE sg8_orders (id INTEGER, region VARCHAR);
+
+statement ok
+INSERT INTO sg8_orders VALUES (1, 'East'), (2, 'West'), (3, 'East');
+
+statement ok
+CREATE TABLE sg8_line_items (id INTEGER, order_id INTEGER, qty INTEGER);
+
+statement ok
+INSERT INTO sg8_line_items VALUES (1, 1, 2), (2, 1, 3), (3, 2, 5);
+
+statement ok
+CREATE SEMANTIC VIEW sg8_sales AS
+  TABLES (
+    o AS sg8_orders PRIMARY KEY (id),
+    li AS sg8_line_items PRIMARY KEY (id)
+  )
+  RELATIONSHIPS (
+    li_to_order AS li(order_id) REFERENCES o
+  )
+  DIMENSIONS (
+    o.region AS o.region
+  )
+  METRICS (
+    li.item_count AS COUNT(*)
+  );
+
+# ============================================================
+# Test 1: metric alone. 3 line items exist; the join produces 4 rows
+# (order 3 is NULL-extended). COUNT(*) used to return 4; the COUNT(pk)
+# rewrite returns the true count 3.
+# ============================================================
+
+query I
+SELECT * FROM semantic_view('sg8_sales', metrics := ['item_count']);
+----
+3
+
+# ============================================================
+# Test 2: grouped by region. East = orders 1 (2 items) + 3 (childless,
+# contributes NO items -- previously counted as 1). West = order 2 (1 item).
+# ============================================================
+
+query TI rowsort
+SELECT * FROM semantic_view('sg8_sales', dimensions := ['region'], metrics := ['item_count']);
+----
+East	2
+West	1
+
+# ============================================================
+# Test 3: without a PRIMARY KEY on the child table the rewrite is
+# impossible -- the query errors instead of silently over-counting.
+# (CREATE succeeds: li is the FK source, so D-06 does not require a PK.)
+# ============================================================
+
+statement ok
+CREATE SEMANTIC VIEW sg8_nopk AS
+  TABLES (
+    o AS sg8_orders PRIMARY KEY (id),
+    li AS sg8_line_items
+  )
+  RELATIONSHIPS (
+    li_to_order AS li(order_id) REFERENCES o
+  )
+  DIMENSIONS (
+    o.region AS o.region
+  )
+  METRICS (
+    li.item_count AS COUNT(*)
+  );
+
+statement error
+SELECT * FROM semantic_view('sg8_nopk', metrics := ['item_count']);
+----
+COUNT(*) on joined table 'li'
+
+# ============================================================
+# Test 4: base-table COUNT(*) is untouched (the base table is never
+# NULL-extended by the synthesized LEFT JOINs).
+# ============================================================
+
+statement ok
+CREATE SEMANTIC VIEW sg8_base AS
+  TABLES (
+    o AS sg8_orders PRIMARY KEY (id)
+  )
+  DIMENSIONS (
+    o.region AS o.region
+  )
+  METRICS (
+    o.order_count AS COUNT(*)
+  );
+
+query I
+SELECT * FROM semantic_view('sg8_base', metrics := ['order_count']);
+----
+3
+
+# ============================================================
+# Cleanup
+# ============================================================
+
+statement ok
+DROP SEMANTIC VIEW sg8_sales;
+
+statement ok
+DROP SEMANTIC VIEW sg8_nopk;
+
+statement ok
+DROP SEMANTIC VIEW sg8_base;
+
+statement ok
+DROP TABLE sg8_line_items;
+
+statement ok
+DROP TABLE sg8_orders;

--- a/test/sql/phase30_derived_metrics.test
+++ b/test/sql/phase30_derived_metrics.test
@@ -322,6 +322,61 @@ CREATE SEMANTIC VIEW p30_avg_agg AS
 must not contain aggregate function
 
 # ============================================================
+# Test 13 (SG-13, code review 2026-07-02): name uniqueness is enforced
+# unconditionally at define time. Duplicate BASE metrics used to be
+# accepted silently when no derived metric existed (the old check was
+# gated on derived metrics); cross-kind collisions (dimension/metric,
+# fact/dimension) emitted duplicate output columns at query time.
+# Names are case-insensitive across one shared namespace.
+# ============================================================
+
+statement error
+CREATE SEMANTIC VIEW p30_dup_base_metrics AS
+  TABLES (
+    o AS p30_orders PRIMARY KEY (id)
+  )
+  DIMENSIONS (
+    o.region AS o.region
+  )
+  METRICS (
+    o.revenue AS SUM(o.id),
+    o.Revenue AS SUM(o.id * 2)
+  );
+----
+duplicate name 'Revenue'
+
+statement error
+CREATE SEMANTIC VIEW p30_dup_dim_metric AS
+  TABLES (
+    o AS p30_orders PRIMARY KEY (id)
+  )
+  DIMENSIONS (
+    o.region AS o.region
+  )
+  METRICS (
+    o.region AS COUNT(o.region)
+  );
+----
+metric 'region' collides with dimension 'region'
+
+statement error
+CREATE SEMANTIC VIEW p30_dup_fact_dim AS
+  TABLES (
+    o AS p30_orders PRIMARY KEY (id)
+  )
+  FACTS (
+    o.region AS o.region
+  )
+  DIMENSIONS (
+    o.region AS o.region
+  )
+  METRICS (
+    o.revenue AS SUM(o.id)
+  );
+----
+fact 'region' collides with dimension 'region'
+
+# ============================================================
 # Cleanup
 # ============================================================
 

--- a/test/sql/phase31_fan_trap.test
+++ b/test/sql/phase31_fan_trap.test
@@ -81,6 +81,19 @@ SELECT * FROM semantic_view('p31_sales', dimensions := ['status'], metrics := ['
 fan trap detected
 
 # ============================================================
+# Test 3b (SG-1, code review 2026-07-02): metric x metric fan trap.
+# order_count (from o) + revenue (from li) sit at different grains:
+# joining li multiplies o's rows per line item, silently inflating
+# order_count (East would count 2 instead of 1). No dimension is needed
+# to trigger the join -- multi-grain metric combinations are blocked.
+# ============================================================
+
+statement error
+SELECT * FROM semantic_view('p31_sales', metrics := ['order_count', 'revenue']);
+----
+fan trap detected
+
+# ============================================================
 # Test 4: Safe query -- metric from li, dimension from c
 # li.revenue (from li) + c.segment (from c): li->o->c is ManyToOne chain, safe
 # Enterprise: SUM(100+200) = 300, SMB: SUM(150) = 150

--- a/test/sql/phase46_wildcard.test
+++ b/test/sql/phase46_wildcard.test
@@ -123,6 +123,21 @@ FROM semantic_view('p46_analytics', dimensions := ['*'], metrics := ['o.order_co
 ----
 unqualified wildcard
 
+# SG-14 (code review 2026-07-02): a qualified name whose table part doesn't
+# match errors instead of silently resolving to another table's item
+# ('region' lives on o, not li).
+statement error
+FROM semantic_view('p46_analytics', dimensions := ['li.region'], metrics := ['o.order_count']);
+----
+unknown dimension 'li.region'
+
+# SG-14: bare + qualified spellings of the SAME dimension are a duplicate
+# request (previously both passed the seen-set and emitted the column twice).
+statement error
+FROM semantic_view('p46_analytics', dimensions := ['region', 'o.region'], metrics := ['o.order_count']);
+----
+duplicate dimension 'o.region'
+
 # ============================================================
 # explain_semantic_view with wildcards
 # ============================================================

--- a/test/sql/phase47_semi_additive.test
+++ b/test/sql/phase47_semi_additive.test
@@ -66,12 +66,14 @@ Bob	250.00
 
 # ========================================
 # Phase 67 A2: shape assertions pinning semi-additive snapshot CTE emission
-# Pin ROW_NUMBER() OVER, __sv_rn alias, and qualified 3-part FROM.
+# Pin RANK() OVER, __sv_rn alias, and qualified 3-part FROM.
+# (SG-4: RANK, not ROW_NUMBER, so rows tied at the snapshot value all
+# aggregate; the __sv_rn column name is unchanged.)
 # Idiom: explain_semantic_view + WHERE explain_output LIKE '%fragment%' (D-02/D-07).
 # ========================================
 
 query I
-SELECT count(*) > 0 FROM explain_semantic_view('p47_account_view', dimensions := ['customer_name'], metrics := ['total_balance']) WHERE explain_output LIKE '%ROW_NUMBER() OVER%';
+SELECT count(*) > 0 FROM explain_semantic_view('p47_account_view', dimensions := ['customer_name'], metrics := ['total_balance']) WHERE explain_output LIKE '%RANK() OVER%';
 ----
 true
 
@@ -116,10 +118,11 @@ does not match any declared dimension
 
 # ========================================
 # Test 5: Mixed regular + semi-additive metrics
-# row_count: counts ALL rows per customer (regular)
-# total_balance: latest snapshot only (semi-additive, report_date not in query)
-# Alice: 3 rows, latest balance = 200.00
-# Bob: 2 rows, latest balance = 250.00
+# SG-5: a metric co-queried with an ACTIVE semi-additive metric must be a
+# single decomposable aggregate call (SUM/COUNT/AVG/MIN/MAX over a plain
+# argument). COUNT(*) is NOT decomposable — the snapshot CTE cannot capture
+# `*` as a per-row column — so co-querying it now errors instead of
+# producing a silently wrong (NULL-sensitive, arbitrary-column) count.
 # ========================================
 
 statement ok
@@ -140,8 +143,43 @@ METRICS (
     a.total_balance NON ADDITIVE BY (report_date DESC) AS SUM(a.balance)
 )
 
+statement error
+SELECT * FROM semantic_view('p47_mixed_view', dimensions := ['customer_name'], metrics := ['row_count', 'total_balance']);
+----
+cannot be co-queried with semi-additive metric 'total_balance'
+
+# COUNT(*) alone (no active semi-additive metric in the query) still takes
+# the standard aggregation path: Alice has 3 account rows, Bob has 2.
+query TI
+SELECT * FROM semantic_view('p47_mixed_view', dimensions := ['customer_name'], metrics := ['row_count']) ORDER BY 1;
+----
+Alice	3
+Bob	2
+
+# A decomposable regular metric CAN be co-queried: COUNT(a.id) counts all
+# rows while total_balance snapshots the latest date.
+# Alice: 3 rows, latest (2024-01-03) balance = 200.00
+# Bob:   2 rows, latest (2024-01-02) balance = 250.00
+statement ok
+CREATE SEMANTIC VIEW p47_mixed_view2 AS
+TABLES (
+    a AS p47_accounts PRIMARY KEY (id),
+    c AS p47_customers PRIMARY KEY (id)
+)
+RELATIONSHIPS (
+    acct_cust AS a(customer_id) REFERENCES c
+)
+DIMENSIONS (
+    c.customer_name AS c.name,
+    a.report_date AS a.report_date
+)
+METRICS (
+    a.row_count AS COUNT(a.id),
+    a.total_balance NON ADDITIVE BY (report_date DESC) AS SUM(a.balance)
+)
+
 query TIR
-SELECT * FROM semantic_view('p47_mixed_view', dimensions := ['customer_name'], metrics := ['row_count', 'total_balance']) ORDER BY 1;
+SELECT * FROM semantic_view('p47_mixed_view2', dimensions := ['customer_name'], metrics := ['row_count', 'total_balance']) ORDER BY 1;
 ----
 Alice	3	200.00
 Bob	2	250.00
@@ -199,17 +237,145 @@ SELECT * FROM semantic_view('p47_global_view', metrics := ['latest_balance']);
 200.00
 
 # ========================================
+# Test 9 (TC-7a / SG-4 data-level): ties at the snapshot value aggregate
+# Alice has TWO rows at her latest date 2024-01-03. RANK() gives both rows
+# rank 1, so the snapshot SUM includes both: 120.00 + 80.00 = 200.00.
+# (ROW_NUMBER() = 1 would have kept ONE arbitrary row: 120.00 or 80.00,
+# nondeterministic run to run.)
+# Alice rows: (2024-01-01, 999.00), (2024-01-03, 120.00), (2024-01-03, 80.00)
+#   -> snapshot sum = 200.00
+# Bob rows: (2024-01-02, 300.00) -> 300.00
+# ========================================
+
+statement ok
+CREATE TABLE p47_tie_accounts (
+    id INTEGER PRIMARY KEY,
+    customer_name VARCHAR,
+    report_date DATE,
+    balance DECIMAL(10,2)
+);
+
+statement ok
+INSERT INTO p47_tie_accounts VALUES
+    (1, 'Alice', '2024-01-01', 999.00),
+    (2, 'Alice', '2024-01-03', 120.00),
+    (3, 'Alice', '2024-01-03', 80.00),
+    (4, 'Bob',   '2024-01-02', 300.00);
+
+statement ok
+CREATE SEMANTIC VIEW p47_tie_view AS
+TABLES (a AS p47_tie_accounts PRIMARY KEY (id))
+DIMENSIONS (
+    a.customer_name AS a.customer_name,
+    a.report_date AS a.report_date
+)
+METRICS (
+    a.total_balance NON ADDITIVE BY (report_date DESC) AS SUM(a.balance)
+)
+
+query TR
+SELECT * FROM semantic_view('p47_tie_view', dimensions := ['customer_name'], metrics := ['total_balance']) ORDER BY 1;
+----
+Alice	200.00
+Bob	300.00
+
+# Global aggregate (no dims): the latest date overall is 2024-01-03, held by
+# Alice's two tied rows -> 120.00 + 80.00 = 200.00.
+query R
+SELECT * FROM semantic_view('p47_tie_view', metrics := ['total_balance']);
+----
+200.00
+
+# ========================================
+# Test 10 (TC-7b): NULLs in the NA ordering column
+# `report_date DESC` defaults to NULLS FIRST (matches DuckDB/Snowflake DESC
+# defaults), so a NULL-dated row outranks every dated row. An explicit
+# NULLS LAST makes the latest non-NULL date win instead.
+# Alice rows: (NULL, 40.00), (2024-01-02, 150.00), (2024-01-01, 100.00)
+#   DESC [NULLS FIRST]: rank 1 = the NULL row       -> 40.00
+#   DESC NULLS LAST:    rank 1 = 2024-01-02          -> 150.00
+# Bob rows: (2024-01-01, 300.00) only -> 300.00 under both orderings
+# ========================================
+
+statement ok
+CREATE TABLE p47_null_accounts (
+    id INTEGER PRIMARY KEY,
+    customer_name VARCHAR,
+    report_date DATE,
+    balance DECIMAL(10,2)
+);
+
+statement ok
+INSERT INTO p47_null_accounts VALUES
+    (1, 'Alice', NULL,         40.00),
+    (2, 'Alice', '2024-01-02', 150.00),
+    (3, 'Alice', '2024-01-01', 100.00),
+    (4, 'Bob',   '2024-01-01', 300.00);
+
+statement ok
+CREATE SEMANTIC VIEW p47_nulls_first_view AS
+TABLES (a AS p47_null_accounts PRIMARY KEY (id))
+DIMENSIONS (
+    a.customer_name AS a.customer_name,
+    a.report_date AS a.report_date
+)
+METRICS (
+    a.latest_balance NON ADDITIVE BY (report_date DESC) AS SUM(a.balance)
+)
+
+query TR
+SELECT * FROM semantic_view('p47_nulls_first_view', dimensions := ['customer_name'], metrics := ['latest_balance']) ORDER BY 1;
+----
+Alice	40.00
+Bob	300.00
+
+statement ok
+CREATE SEMANTIC VIEW p47_nulls_last_view AS
+TABLES (a AS p47_null_accounts PRIMARY KEY (id))
+DIMENSIONS (
+    a.customer_name AS a.customer_name,
+    a.report_date AS a.report_date
+)
+METRICS (
+    a.latest_balance NON ADDITIVE BY (report_date DESC NULLS LAST) AS SUM(a.balance)
+)
+
+query TR
+SELECT * FROM semantic_view('p47_nulls_last_view', dimensions := ['customer_name'], metrics := ['latest_balance']) ORDER BY 1;
+----
+Alice	150.00
+Bob	300.00
+
+# ========================================
 # Cleanup
 # ========================================
 
 statement ok
+DROP SEMANTIC VIEW IF EXISTS p47_nulls_last_view;
+
+statement ok
+DROP SEMANTIC VIEW IF EXISTS p47_nulls_first_view;
+
+statement ok
+DROP SEMANTIC VIEW IF EXISTS p47_tie_view;
+
+statement ok
 DROP SEMANTIC VIEW IF EXISTS p47_global_view;
+
+statement ok
+DROP SEMANTIC VIEW IF EXISTS p47_mixed_view2;
 
 statement ok
 DROP SEMANTIC VIEW IF EXISTS p47_mixed_view;
 
 statement ok
 DROP SEMANTIC VIEW IF EXISTS p47_account_view;
+
+statement ok
+DROP TABLE IF EXISTS p47_null_accounts;
+
+statement ok
+DROP TABLE IF EXISTS p47_tie_accounts;
 
 statement ok
 DROP TABLE IF EXISTS p47_single_acct;

--- a/test/sql/phase48_window_metrics.test
+++ b/test/sql/phase48_window_metrics.test
@@ -208,9 +208,11 @@ METRIC	avg_qty	p48_sales	WINDOW_SPEC	AVG(total_qty) OVER (PARTITION BY EXCLUDING
 METRIC	qty_lag	p48_sales	WINDOW_SPEC	LAG(total_qty, 1) OVER (PARTITION BY EXCLUDING date ORDER BY date)
 
 # ========================================
-# Test 9: Fan trap skip for window metrics
-# Create a view where metric crosses many-to-one boundary
-# Window metric should NOT trigger fan trap error
+# Test 9: Window metric over a safe many-to-one join direction
+# SG-6 (code review 2026-07-02): window metrics no longer skip the fan trap
+# check — their inner aggregate is computed over the joined rows. This query
+# stays valid because the metric's grain is on o (the FK side); joining o to
+# its parent c (o->c many-to-one, forward direction) never fans o's rows.
 # ========================================
 
 statement ok
@@ -251,8 +253,7 @@ METRICS (
     o.running_avg AS AVG(total_amount) OVER (PARTITION BY EXCLUDING order_date ORDER BY order_date ASC NULLS LAST)
 )
 
-# This would be a fan trap for regular aggregate on o queried with c.customer_name,
-# but window metrics skip fan trap check.
+# Metric grain on o (child), dims on c (parent) and o: safe direction, no error.
 query TTR rowsort
 SELECT * FROM semantic_view('p48_fan_view', dimensions := ['customer_name', 'order_date'], metrics := ['running_avg']);
 ----

--- a/test/sql/phase55_materialization_routing.test
+++ b/test/sql/phase55_materialization_routing.test
@@ -348,8 +348,60 @@ East	777.77
 West	888.88
 
 # ============================================================
-# Section 9: Cleanup
+# Section 9: Dims-only routed queries apply SELECT DISTINCT (SG-11)
 # ============================================================
+
+# The pre-agg table deliberately contains a DUPLICATE 'East' row plus a
+# sentinel 'North' row that does not exist in the base data. The result
+# containing 'North' proves the query routed to the materialization; 'East'
+# appearing once proves the routed SQL applies SELECT DISTINCT, matching
+# the raw expansion path's dims-only semantics.
+
+statement ok
+CREATE TABLE p55_region_list (region VARCHAR);
+
+statement ok
+INSERT INTO p55_region_list VALUES ('East'), ('East'), ('West'), ('North');
+
+statement ok
+CREATE SEMANTIC VIEW p55_dims_routed AS
+TABLES (
+    o AS p55_orders PRIMARY KEY (id)
+)
+DIMENSIONS (
+    o.region AS o.region
+)
+METRICS (
+    o.total_revenue AS SUM(o.amount)
+)
+MATERIALIZATIONS (
+    region_list AS (
+        TABLE p55_region_list,
+        DIMENSIONS (region)
+    )
+)
+
+query T rowsort
+SELECT * FROM semantic_view('p55_dims_routed', dimensions := ['region'])
+----
+East
+North
+West
+
+query I
+SELECT count(*) FROM semantic_view('p55_dims_routed', dimensions := ['region'])
+----
+3
+
+# ============================================================
+# Section 10: Cleanup
+# ============================================================
+
+statement ok
+DROP SEMANTIC VIEW IF EXISTS p55_dims_routed
+
+statement ok
+DROP TABLE IF EXISTS p55_region_list
 
 statement ok
 DROP SEMANTIC VIEW IF EXISTS p55_routed

--- a/test/sql/phase55_materialization_routing.test
+++ b/test/sql/phase55_materialization_routing.test
@@ -183,7 +183,7 @@ MATERIALIZATIONS (
 )
 
 # Semi-additive metric should NOT route to materialization (MAT-04)
-# Falls back to raw expansion with ROW_NUMBER CTE snapshot selection
+# Falls back to raw expansion with RANK CTE snapshot selection
 # Latest amount per region: East -> 150.00 (2024-01-03), West -> 50.00 (2024-01-04)
 query TR rowsort
 SELECT * FROM semantic_view('p55_semi_add', dimensions := ['region'], metrics := ['latest_amount'])

--- a/test/sql/phase67_qualified_emission.test
+++ b/test/sql/phase67_qualified_emission.test
@@ -186,8 +186,8 @@ DETACH db2;
 
 # ============================================================
 # Scenario A1.5 — Semi-additive snapshot CTE × non-default schema (PREPEND)
-# customer_name not in NA group so __sv_rn snapshot fires
-# (src/expand/semi_additive.rs:195).
+# customer_name not in NA group so the __sv_rn RANK snapshot fires
+# (src/expand/semi_additive.rs).
 # ============================================================
 
 statement ok
@@ -222,7 +222,7 @@ statement ok
 USE memory.main;
 
 query I
-SELECT count(*) > 0 FROM explain_semantic_view('p67_semi.p67_semi_sch', dimensions := ['customer_name'], metrics := ['latest_balance']) WHERE explain_output LIKE '%ROW_NUMBER() OVER%';
+SELECT count(*) > 0 FROM explain_semantic_view('p67_semi.p67_semi_sch', dimensions := ['customer_name'], metrics := ['latest_balance']) WHERE explain_output LIKE '%RANK() OVER%';
 ----
 true
 
@@ -268,7 +268,7 @@ METRICS (
 );
 
 query I
-SELECT count(*) > 0 FROM explain_semantic_view('p67_semi_db2', dimensions := ['customer_name'], metrics := ['latest_balance']) WHERE explain_output LIKE '%ROW_NUMBER() OVER%';
+SELECT count(*) > 0 FROM explain_semantic_view('p67_semi_db2', dimensions := ['customer_name'], metrics := ['latest_balance']) WHERE explain_output LIKE '%RANK() OVER%';
 ----
 true
 

--- a/test/sql/phase68_quoted_idents_non_additive.test
+++ b/test/sql/phase68_quoted_idents_non_additive.test
@@ -45,7 +45,7 @@ true
 # `o."order date"` must be parsed AND name-resolved to the dimension whose
 # (source_alias, name) is (`o`, `"order date"`). End-to-end semi-additive query
 # expansion for dotted-NA-dim is NOT validated here — semi_additive expansion
-# emits the raw NA dim text into the ROW_NUMBER() OVER ORDER BY of the
+# emits the raw NA dim text into the RANK() OVER ORDER BY of the
 # snapshot CTE, which produces `"o.""order date"""` (single-quoted-identifier
 # shape) instead of `"o"."order date"`. The expand-side dotted-path emission
 # fix is out of scope for Plan 03 (D-10 renegotiation: pure-DDL validation


### PR DESCRIPTION
## Summary

Completes Phases **R0 (memory safety / data loss)** and **R1 (silent-wrong-results correctness)** of `_notes/code-review-2026-07-02.md` — the follow-up to the CI-enforcement work merged in #48. Eight commits, one review finding cluster each; every fix carries regression coverage and each commit's rationale is in its message.

## Memory safety & data loss (R0)

- **MS-1 (critical)**: the bind-materialized table functions in `cpp/src/shim.cpp` (`list_semantic_views`, the `show_*`/`describe`/`explain` family) emitted their entire row set into a single DataChunk of capacity 2048 — row 2049 wrote past the vector's buffer (no bounds check in release builds), reachable from plain SQL. Emitters now carry a row cursor and emit per-chunk. Regression: `test_chunk_boundary.py` drives all three emitters past 2048 rows with full content-integrity assertions.
- **MS-2**: the v0.1.0 companion-file migration deleted the sidecar even when it was unreadable/corrupt — permanent loss of pre-v0.2 definitions. Now deletes only after a successful import; failures surface with actionable messages.
- **MS-3**: `replace_word_boundary` advanced byte-wise through UTF-8 — panic ("internal error") plus char duplication on any non-ASCII expression at query time.
- **FF-7**: the extension entrypoint called `set_error.unwrap()` *outside* `catch_unwind` — a null callback would abort the host process instead of failing the load.

## Expansion correctness (R1) — all 17 SG findings

- **Differential harness** (`test_differential.py`): 159 randomized dims×metrics combinations over a seeded star schema (NULL FKs/measures, snowflake chain, childless parents) compared against independently hand-written SQL in CI on every push — the acceptance net for everything below, extended with each fix's poison scenario.
- **SG-3**: derived-metric inlining substituted names in nondeterministic HashMap order and re-scanned inserted text — corrupted expressions on a hash-seed-dependent fraction of runs. Single combined left-to-right pass now (one substitution primitive crate-wide).
- **SG-2/10/12**: join emission picked the *first declared* join mentioning an alias (declaration-order-dependent forward references / dropped joins), missed intermediates on FK-side chains, and re-parsed role-playing aliases by splitting at `__`. The resolver now returns ordered structured edges (BFS tree-parent selection) consumed by all four emission sites; generated SQL is byte-identical wherever the old code was correct.
- **SG-1 (critical) /6/7/16**: fan-trap detection never compared metric×metric grains — `SUM` on the base table co-queried with `COUNT(*)` on a child was silently inflated per child row. Multi-grain requests now error (per-grain CTE aggregation is future work). The wrong unconditional skips for window/semi-additive metrics are corrected against the actual CTE routing predicate; an unbuildable relationship graph is now a loud error instead of a skipped safety check; role-playing edges no longer mask each other's cardinality.
- **SG-4/5/9**: semi-additive snapshots used `ROW_NUMBER()=1` (dropped ties, nondeterministic — now `RANK()`, ties aggregate); co-queried metrics were decomposed by first-paren splitting that silently dropped arithmetic and miscounted `COUNT(*)` (the old phase47 expectations passed by accident — now validated with clear errors); NA dims on non-queried tables produced binder errors (their source tables are now joined). Data-level tie/NULL fixtures added.
- **SG-8/13/14/15/17**: `COUNT(*)` on non-base tables is rewritten to `COUNT(pk)` so LEFT-JOIN NULL-extension isn't counted; name uniqueness is enforced at define time across dims/metrics/facts (was only checked when derived metrics existed); qualified names no longer fall back to a same-named item on the wrong table; base-table items appear in base-alias wildcards; the facts path runs role-playing ambiguity detection.
- **SG-11**: dims-only queries routed to a materialization now emit `SELECT DISTINCT` (matching the raw path); the staleness contract of user-owned pre-aggregation tables is documented instead of implied.

## Test surface

Lib tests 891 → 961; new sqllogictests (`count_star_left_join.test`, phase47 tie/NULL fixtures, phase55 DISTINCT-routing section, phase31 multi-grain error pin); docs corrected where they described retired behavior or validation that never existed.

## Behavior changes to review deliberately

1. Multi-grain metric requests, fanning window/semi-additive requests, and unverifiable legacy definitions now **error** instead of returning wrong numbers (wording in `ExpandError`).
2. Semi-additive results **change where real ties exist** (they now aggregate) — and `COUNT(*)`/wrapped/DISTINCT metrics can no longer be co-queried with an active snapshot metric.
3. Child-table `COUNT(*)` no longer counts childless parents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMiykq7WiBuxeCCkLmHpbr