### PR TITLE
R3 AR-4 (PR-1): schema_version + upgrade pass + SG-7 fan-trap guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Machine-checked round-trip guarantee between `CREATE SEMANTIC VIEW` parsing and `GET_DDL` rendering: a property test asserts `parse(render(definition)) == definition` over generated definitions (including quoted, unicode, and keyword-bearing identifiers), and two new fuzz targets exercise the body parser directly and enforce render/parse fixpoint stability.
+- Stored semantic view definitions now carry a storage-format `schema_version`. Freshly created (or replaced) views are stamped with the current version, and a one-time, non-destructive upgrade pass on extension load stamps existing definitions that are verifiably current-format — giving future format changes a clean migration point (following the v0.1.0 companion-file migration precedent).
 
 ### Fixed
 
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET_DDL` output now re-parses to the same definition: relationships declared against a `UNIQUE` key render their `REFERENCES (columns)` list (previously dropped, silently rewiring the join to the primary key on re-parse), and view names that need quoting (mixed case, whitespace, non-ASCII) are quoted in the rendered header.
 - `SHOW ... STARTS WITH` / `LIMIT` require word boundaries (`STARTSWITH`, `LIMIT5` are rejected); `NON ADDITIVE BY` accepts flexible whitespace including the no-space `BY(dim)` form; `READ_YAML_FROM_SEMANTIC_VIEW` resolves qualified names with quote awareness instead of splitting at dots inside quoted parts.
 - Fact and metric queries combining a child-table fact/metric with a dimension on a shared parent table no longer raise a spurious ambiguity error when the parent is referenced by multiple child tables (regression in the previous role-playing ambiguity hardening).
+- Querying a semantic view whose stored relationships lack foreign-key column metadata (a legacy pre-Phase-24 definition format) now fails with a clear "re-create it with `CREATE OR REPLACE SEMANTIC VIEW`" error instead of silently skipping the fan-trap safety check and returning mis-aggregated results — the relationship graph builds empty for such rows, so the check would otherwise pass vacuously.
 
 ## [0.10.4] - 2026-06-27
 

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -129,6 +129,62 @@ pub fn init_catalog(
         }
     }
 
+    // AR-4: one-time storage-format upgrade pass. Runs after the v0.1.0
+    // companion import so freshly-imported rows are considered too. Only on
+    // writable DBs (guarded by the is_read_only early-return above).
+    upgrade_definitions_schema(con)?;
+
+    Ok(())
+}
+
+/// One-time `schema_version` upgrade pass over `_definitions` (AR-4).
+///
+/// For every stored row still below [`crate::model::CURRENT_SCHEMA_VERSION`]:
+/// stamp it to the current version **iff** it can be positively verified as
+/// current-format (parses cleanly and every relationship carries `fk_columns`).
+/// Rows that fail to parse, or whose relationships lack FK metadata (legacy
+/// pre-Phase-24 encodings), are left untouched at version 0 — the fan-trap
+/// safety check (`expand::fan_trap`) then hard-errors on read rather than
+/// silently trusting them. Non-destructive: no row is deleted or rewritten
+/// beyond the version stamp.
+///
+/// Idempotent: rows already at the current version are skipped, so subsequent
+/// loads are no-ops. The `schema_version` integer is inlined from a
+/// compile-time constant (no user input), so the `json_object` embed is safe.
+fn upgrade_definitions_schema(con: &Connection) -> Result<(), Box<dyn std::error::Error>> {
+    let rows: Vec<(String, String)> = {
+        let mut stmt = con.prepare(&format!("SELECT name, definition FROM {DEFINITIONS_TABLE}"))?;
+        let mapped =
+            stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?;
+        mapped.collect::<Result<Vec<_>, _>>()?
+    };
+
+    for (name, json) in rows {
+        if crate::model::SemanticViewDefinition::stored_schema_version(&json)
+            >= crate::model::CURRENT_SCHEMA_VERSION
+        {
+            continue; // already current
+        }
+        // Only stamp rows we can positively verify as current-format. A parse
+        // failure or missing FK metadata => un-upgradeable legacy row; leave it
+        // at version 0 so reads hard-error rather than silently under-checking.
+        let upgradeable = crate::model::SemanticViewDefinition::from_json(&name, &json)
+            .is_ok_and(|def| !def.has_incomplete_relationships());
+        if !upgradeable {
+            continue;
+        }
+        con.execute(
+            &format!(
+                "UPDATE {DEFINITIONS_TABLE} \
+                 SET definition = json_merge_patch(definition::JSON, \
+                     json_object('schema_version', {version}))::VARCHAR \
+                 WHERE name = ?",
+                version = crate::model::CURRENT_SCHEMA_VERSION
+            ),
+            duckdb::params![name],
+        )?;
+    }
+
     Ok(())
 }
 
@@ -517,6 +573,74 @@ mod tests {
             .map(|r| r.unwrap())
             .collect();
         assert_eq!(names, vec!["b".to_string()]);
+    }
+
+    // AR-4: the schema_version upgrade pass stamps verifiable current-format
+    // rows and leaves un-upgradeable legacy rows at version 0.
+    #[cfg(not(feature = "extension"))]
+    #[test]
+    fn upgrade_stamps_complete_rows_and_skips_incomplete() {
+        use crate::model::{SemanticViewDefinition, CURRENT_SCHEMA_VERSION};
+        let con = in_memory_con();
+        init_catalog(&con, ":memory:", false).unwrap();
+
+        // Complete row: every relationship carries fk_columns, no schema_version.
+        let complete = r#"{"tables":[{"alias":"o","table":"orders","pk_columns":["id"]},
+            {"alias":"c","table":"customers","pk_columns":["id"]}],
+            "dimensions":[],"metrics":[],
+            "joins":[{"table":"c","from_alias":"o","fk_columns":["cid"],"ref_columns":["id"]}]}"#;
+        // Incomplete row: a relationship in the legacy `on`-only encoding (no fk_columns).
+        let incomplete = r#"{"tables":[{"alias":"o","table":"orders"}],
+            "dimensions":[],"metrics":[],
+            "joins":[{"table":"c","on":"o.cid = c.id"}]}"#;
+        // A no-join single-table view: trivially complete, should be stamped.
+        let single = r#"{"tables":[{"alias":"o","table":"orders"}],"dimensions":[],"metrics":[]}"#;
+
+        for (name, def) in [
+            ("complete_v", complete),
+            ("incomplete_v", incomplete),
+            ("single_v", single),
+        ] {
+            con.execute(
+                "INSERT INTO semantic_layer._definitions (name, definition) VALUES (?, ?)",
+                duckdb::params![name, def],
+            )
+            .unwrap();
+        }
+
+        // Re-run init_catalog: triggers the one-time upgrade pass.
+        init_catalog(&con, ":memory:", false).unwrap();
+
+        let stored = |name: &str| -> String {
+            con.query_row(
+                "SELECT definition FROM semantic_layer._definitions WHERE name = ?",
+                duckdb::params![name],
+                |r| r.get::<_, String>(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            SemanticViewDefinition::stored_schema_version(&stored("complete_v")),
+            CURRENT_SCHEMA_VERSION,
+            "complete row must be stamped current"
+        );
+        assert_eq!(
+            SemanticViewDefinition::stored_schema_version(&stored("single_v")),
+            CURRENT_SCHEMA_VERSION,
+            "no-join view is trivially complete and must be stamped"
+        );
+        assert_eq!(
+            SemanticViewDefinition::stored_schema_version(&stored("incomplete_v")),
+            0,
+            "un-upgradeable legacy row must be left at version 0"
+        );
+
+        // Idempotent: a second pass changes nothing and does not error.
+        init_catalog(&con, ":memory:", false).unwrap();
+        assert_eq!(
+            SemanticViewDefinition::stored_schema_version(&stored("complete_v")),
+            CURRENT_SCHEMA_VERSION
+        );
     }
 
     #[cfg(not(feature = "extension"))]

--- a/src/expand/fan_trap.rs
+++ b/src/expand/fan_trap.rs
@@ -198,11 +198,27 @@ pub(super) fn check_fan_traps(
 /// SKIPPED the fan-trap safety check (`return Ok(())`), so queries over
 /// legacy/invalid stored definitions produced mis-aggregated results with no
 /// warning. The correct bias for a safety check is loud failure.
+///
+/// SG-7 residual (AR-4): a build *failure* was the rare case. The common
+/// legacy hazard is a definition whose relationships lack `fk_columns` — an
+/// empty-FK join is silently skipped by both `RelationshipGraph::from_definition`
+/// and `build_card_map`, so the graph builds *successfully but empty* and the
+/// fan-trap check passes vacuously. Reject such definitions up front so an
+/// un-upgradeable legacy row (which the `init_catalog` upgrade pass leaves at
+/// `schema_version` 0) fails loudly here instead of under-checking.
 #[allow(clippy::result_large_err)]
 fn build_relationship_graph(
     view_name: &str,
     def: &SemanticViewDefinition,
 ) -> Result<crate::graph::RelationshipGraph, ExpandError> {
+    if def.has_incomplete_relationships() {
+        return Err(ExpandError::UncheckableDefinition {
+            view_name: view_name.to_string(),
+            reason: "one or more relationships are missing foreign-key column metadata \
+                     (a legacy pre-Phase-24 definition format)"
+                .to_string(),
+        });
+    }
     crate::graph::RelationshipGraph::from_definition(def).map_err(|reason| {
         ExpandError::UncheckableDefinition {
             view_name: view_name.to_string(),
@@ -936,6 +952,32 @@ mod tests {
             matches!(result, Err(ExpandError::UncheckableDefinition { .. })),
             "validate_fact_table_path must also error on an unbuildable graph, got: {result:?}"
         );
+    }
+
+    /// SG-7 residual (AR-4): a legacy join lacking `fk_columns` builds an empty
+    /// graph *successfully* — the pre-fix check passed vacuously and produced
+    /// mis-aggregated results. It must now ERROR instead.
+    #[test]
+    fn test_check_fan_traps_incomplete_relationships_error() {
+        let mut def = minimal_def("orders", "region", "region", "total", "sum(amount)");
+        def.joins.push(crate::model::Join {
+            table: "customers".to_string(),
+            from_alias: "orders".to_string(),
+            fk_columns: vec![], // legacy: FK metadata never captured
+            ..Default::default()
+        });
+        let resolved_dims: Vec<&_> = def.dimensions.iter().collect();
+        let resolved_mets: Vec<&_> = def.metrics.iter().collect();
+        match check_fan_traps("test", &def, &resolved_dims, &resolved_mets) {
+            Err(ExpandError::UncheckableDefinition { view_name, reason }) => {
+                assert_eq!(view_name, "test");
+                assert!(
+                    reason.contains("foreign-key column metadata"),
+                    "reason should name the missing FK metadata: {reason}"
+                );
+            }
+            other => panic!("Expected UncheckableDefinition, got: {other:?}"),
+        }
     }
 
     /// SG-16: two named relationships between the same table pair with

--- a/src/expand/sql_gen.rs
+++ b/src/expand/sql_gen.rs
@@ -921,8 +921,9 @@ GROUP BY
         #[test]
         fn test_join_excluded_when_not_needed() {
             let def = orders_view()
+                .with_table("customers", "customers", &["id"])
                 .with_dimension("customer_name", "customers.name", Some("customers"))
-                .with_join_on("customers", "orders.customer_id = customers.id");
+                .with_pkfk_join("cust", "orders", "customers", &["customer_id"], &["id"]);
             // Request only "region" which comes from base table
             let req = QueryRequest {
                 facts: vec![],
@@ -1097,7 +1098,7 @@ GROUP BY
 
     mod phase11_1_expand_tests {
         use super::*;
-        use crate::model::{AccessModifier, JoinColumn, TableRef};
+        use crate::model::{AccessModifier, TableRef};
 
         fn def_with_join_columns() -> crate::model::SemanticViewDefinition {
             crate::model::SemanticViewDefinition {
@@ -1147,13 +1148,13 @@ GROUP BY
                 }],
 
                 joins: vec![crate::model::Join {
-                    table: "customers".to_string(),
-                    on: String::new(),
-                    from_cols: vec![],
-                    join_columns: vec![JoinColumn {
-                        from: "customer_id".to_string(),
-                        to: "id".to_string(),
-                    }],
+                    // Modern (Phase 24) FK encoding: source alias `o`, target
+                    // alias `c`, with fk/ref columns so the fan-trap safety
+                    // check can build the relationship graph (SG-7 / AR-4).
+                    table: "c".to_string(),
+                    from_alias: "o".to_string(),
+                    fk_columns: vec!["customer_id".to_string()],
+                    ref_columns: vec!["id".to_string()],
                     ..Default::default()
                 }],
                 facts: vec![],

--- a/src/expand/test_helpers.rs
+++ b/src/expand/test_helpers.rs
@@ -138,7 +138,6 @@ pub(super) fn minimal_def(
 pub(super) trait TestFixtureExt {
     fn with_dimension(self, name: &str, expr: &str, source_table: Option<&str>) -> Self;
     fn with_metric(self, name: &str, expr: &str, source_table: Option<&str>) -> Self;
-    fn with_join_on(self, table: &str, on: &str) -> Self;
     fn with_table(self, alias: &str, table: &str, pk_columns: &[&str]) -> Self;
     fn with_fact(self, name: &str, expr: &str, source_table: &str) -> Self;
     fn with_private_fact(self, name: &str, expr: &str, source_table: &str) -> Self;
@@ -193,17 +192,6 @@ impl TestFixtureExt for SemanticViewDefinition {
             access: AccessModifier::Public,
             non_additive_by: vec![],
             window_spec: None,
-        });
-        self
-    }
-
-    fn with_join_on(mut self, table: &str, on: &str) -> Self {
-        self.joins.push(Join {
-            table: table.to_string(),
-            on: on.to_string(),
-            from_cols: vec![],
-            join_columns: vec![],
-            ..Default::default()
         });
         self
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -355,6 +355,17 @@ pub struct Join {
     pub cardinality: Cardinality,
 }
 
+/// Current storage-format version stamped into freshly written definitions
+/// (AR-4). A `schema_version` key is injected into the stored JSON at write
+/// time via the same `json_merge_patch` that records `created_on` etc.
+/// (see `parse::native_sql::emit_native_create_sql`), so it is not a field
+/// on [`SemanticViewDefinition`] — it never appears in YAML export and adds
+/// no construction-site burden. Absent / `0` in stored JSON denotes a
+/// pre-versioning ("legacy") row; the `init_catalog` upgrade pass stamps
+/// completed rows up to this value. Bump when the stored JSON shape changes
+/// in a way the upgrade pass must normalise.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
 /// Top-level definition of a semantic view.
 ///
 /// Stored as JSON in `semantic_layer._definitions`.
@@ -459,6 +470,36 @@ impl SemanticViewDefinition {
             .map_err(|e| format!("invalid definition for semantic view '{name}': {e}"))?;
         Ok(def)
     }
+
+    /// Read the `schema_version` recorded in a stored definition's JSON
+    /// without fully deserializing it (AR-4).
+    ///
+    /// The version lives only in the stored JSON (injected at write time via
+    /// `json_merge_patch`), not on this struct, so it is read with a minimal
+    /// probe. Absent, non-integer, or unparseable JSON all map to `0` — the
+    /// "legacy / pre-versioning" sentinel — so callers treat anything they
+    /// cannot positively identify as current-format as legacy.
+    #[must_use]
+    pub fn stored_schema_version(json: &str) -> u32 {
+        #[derive(Deserialize)]
+        struct Probe {
+            #[serde(default)]
+            schema_version: u32,
+        }
+        serde_json::from_str::<Probe>(json).map_or(0, |p| p.schema_version)
+    }
+
+    /// True when any relationship lacks foreign-key column metadata
+    /// (`fk_columns`) — a legacy (pre-Phase-24) encoding the graph/fan-trap
+    /// machinery silently skips.
+    ///
+    /// Such a row cannot be verified for fan-trap safety (SG-7) and cannot be
+    /// completed by the `init_catalog` upgrade pass, so it is treated as an
+    /// un-upgradeable legacy definition that hard-errors on read.
+    #[must_use]
+    pub fn has_incomplete_relationships(&self) -> bool {
+        self.joins.iter().any(|j| j.fk_columns.is_empty())
+    }
 }
 
 impl SemanticViewDefinition {
@@ -497,6 +538,57 @@ impl SemanticViewDefinition {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- AR-4: schema_version probe + incomplete-relationship detection ---
+
+    #[test]
+    fn stored_schema_version_reads_injected_value() {
+        assert_eq!(
+            SemanticViewDefinition::stored_schema_version(r#"{"schema_version":1}"#),
+            1
+        );
+        assert_eq!(
+            SemanticViewDefinition::stored_schema_version(r#"{"schema_version":7,"tables":[]}"#),
+            7
+        );
+    }
+
+    #[test]
+    fn stored_schema_version_absent_or_bad_is_zero() {
+        assert_eq!(
+            SemanticViewDefinition::stored_schema_version(r#"{"tables":[]}"#),
+            0
+        );
+        assert_eq!(SemanticViewDefinition::stored_schema_version("not json"), 0);
+        assert_eq!(
+            SemanticViewDefinition::stored_schema_version(r#"{"schema_version":"x"}"#),
+            0
+        );
+    }
+
+    #[test]
+    fn has_incomplete_relationships_detects_empty_fk() {
+        let mut def = SemanticViewDefinition::default();
+        assert!(!def.has_incomplete_relationships(), "no joins is complete");
+        def.joins.push(Join {
+            table: "c".into(),
+            from_alias: "o".into(),
+            fk_columns: vec!["cid".into()],
+            ..Default::default()
+        });
+        assert!(
+            !def.has_incomplete_relationships(),
+            "join with fk_columns is complete"
+        );
+        def.joins.push(Join {
+            table: "x".into(),
+            ..Default::default()
+        });
+        assert!(
+            def.has_incomplete_relationships(),
+            "join without fk_columns is incomplete"
+        );
+    }
 
     #[test]
     fn valid_definition_roundtrips() {

--- a/src/parse/native_sql.rs
+++ b/src/parse/native_sql.rs
@@ -204,13 +204,18 @@ fn emit_native_create_sql(
     // the patch. Phase 39 metadata behaviour is preserved because the
     // enriched JSON omits the three metadata keys (Vec::is_empty /
     // Option::is_none skip_serializing) so the patch is the sole source.
+    // AR-4: stamp the storage-format version alongside the metadata so every
+    // freshly written row records `schema_version`. It is injected here (not
+    // carried on the struct) so it never leaks into YAML export.
+    let schema_version = crate::model::CURRENT_SCHEMA_VERSION;
     let metadata_patched_definition = format!(
         "json_merge_patch( \
             '{enriched_escaped}'::JSON, \
             json_object( \
               'created_on', strftime(now(), '%Y-%m-%dT%H:%M:%SZ'), \
               'database_name', current_database(), \
-              'schema_name', current_schema() \
+              'schema_name', current_schema(), \
+              'schema_version', {schema_version} \
             ) \
          )::VARCHAR"
     );
@@ -311,15 +316,21 @@ fn emit_native_create_from_yaml_file(
     // overrides keys present in the patch. The helper TF's new_def omits the
     // three metadata keys (skip_serializing_if on the struct), so the patch
     // is the sole source -- no risk of overwriting a user-supplied value.
-    let metadata_patched = "json_merge_patch( \
+    // AR-4: stamp schema_version alongside the metadata (see the inline-CREATE
+    // sibling above). Injected here rather than carried on the struct so it
+    // stays out of YAML export.
+    let metadata_patched = format!(
+        "json_merge_patch( \
             new_def::JSON, \
             json_object( \
               'created_on', strftime(now(), '%Y-%m-%dT%H:%M:%SZ'), \
               'database_name', current_database(), \
-              'schema_name', current_schema() \
+              'schema_name', current_schema(), \
+              'schema_version', {schema_version} \
             ) \
-         )::VARCHAR"
-        .to_string();
+         )::VARCHAR",
+        schema_version = crate::model::CURRENT_SCHEMA_VERSION
+    );
     let helper_from = format!(
         "FROM __sv_compute_create_from_yaml('{path_escaped}', \
             '{name_escaped}', '{comment_escaped}')"

--- a/test/sql/TEST_LIST
+++ b/test/sql/TEST_LIST
@@ -4,6 +4,7 @@ test/sql/65_json_merge_patch_smoke.test
 test/sql/65_metadata_via_sql.test
 test/sql/65_pk_error.test
 test/sql/65_read_bridge_spike.test
+test/sql/ar4_schema_version.test
 test/sql/count_star_left_join.test
 test/sql/error_caret_alter.test
 test/sql/error_caret_create.test

--- a/test/sql/ar4_schema_version.test
+++ b/test/sql/ar4_schema_version.test
@@ -1,0 +1,64 @@
+# AR-4: schema_version stamp + SG-7 legacy-relationship hard error.
+#
+# Covers the end-to-end integration paths the Rust unit tests cannot:
+#   A. CREATE / CREATE OR REPLACE inject schema_version into the stored JSON
+#      via the parser_override json_merge_patch emission.
+#   B. A legacy definition whose relationship lacks fk_columns is rejected at
+#      query time (SG-7) instead of silently mis-aggregating.
+
+require semantic_views
+
+statement ok
+CREATE TABLE ar4_orders (id INTEGER PRIMARY KEY, amount DECIMAL(10,2), region VARCHAR);
+
+statement ok
+INSERT INTO ar4_orders VALUES (1, 100.00, 'US'), (2, 200.00, 'EU');
+
+statement ok
+CREATE SEMANTIC VIEW ar4_sv
+AS
+  TABLES (o AS ar4_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+# A1: the freshly written definition carries schema_version = 1.
+query I
+SELECT CAST(json_extract(definition, '$.schema_version') AS INTEGER)
+FROM semantic_layer._definitions WHERE name = 'ar4_sv'
+----
+1
+
+# A2: CREATE OR REPLACE re-stamps it.
+statement ok
+CREATE OR REPLACE SEMANTIC VIEW ar4_sv
+AS
+  TABLES (o AS ar4_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount))
+
+query I
+SELECT CAST(json_extract(definition, '$.schema_version') AS INTEGER)
+FROM semantic_layer._definitions WHERE name = 'ar4_sv'
+----
+1
+
+# A3: the normal view still queries correctly.
+query TI rowsort
+SELECT region, total FROM semantic_view('ar4_sv', dimensions := ['region'], metrics := ['total'])
+----
+EU	200.00
+US	100.00
+
+# B: inject a legacy row whose relationship carries no fk_columns (the
+# pre-Phase-24 `on`-only encoding), bypassing the parser. Querying it must
+# hard-error rather than silently under-checking fan traps (SG-7).
+statement ok
+INSERT INTO semantic_layer._definitions (name, definition) VALUES (
+  'ar4_legacy',
+  '{"tables":[{"alias":"o","table":"ar4_orders"}],"dimensions":[{"name":"region","expr":"o.region","source_table":"o"}],"metrics":[{"name":"total","expr":"SUM(o.amount)","source_table":"o"}],"joins":[{"table":"c","on":"o.cid = c.id"}]}'
+)
+
+statement error
+SELECT * FROM semantic_view('ar4_legacy', dimensions := ['region'], metrics := ['total'])
+----
+foreign-key column metadata

--- a/tests/expand_proptest.rs
+++ b/tests/expand_proptest.rs
@@ -1,6 +1,8 @@
 use proptest::prelude::*;
 use semantic_views::expand::{expand, DimensionName, MetricName, QueryRequest};
-use semantic_views::model::{AccessModifier, Dimension, Join, Metric, SemanticViewDefinition};
+use semantic_views::model::{
+    AccessModifier, Cardinality, Dimension, Join, Metric, SemanticViewDefinition,
+};
 
 // ---------------------------------------------------------------------------
 // Test fixture definitions
@@ -102,14 +104,32 @@ fn simple_definition() -> SemanticViewDefinition {
 /// 3 metrics (2 with source_table), 2 joins, 1 filter.
 fn joined_definition() -> SemanticViewDefinition {
     SemanticViewDefinition {
-        tables: vec![semantic_views::model::TableRef {
-            alias: "orders".to_string(),
-            table: "orders".to_string(),
-            pk_columns: vec![],
-            unique_constraints: vec![],
-            comment: None,
-            synonyms: vec![],
-        }],
+        tables: vec![
+            semantic_views::model::TableRef {
+                alias: "orders".to_string(),
+                table: "orders".to_string(),
+                pk_columns: vec![],
+                unique_constraints: vec![],
+                comment: None,
+                synonyms: vec![],
+            },
+            semantic_views::model::TableRef {
+                alias: "customers".to_string(),
+                table: "customers".to_string(),
+                pk_columns: vec!["id".to_string()],
+                unique_constraints: vec![],
+                comment: None,
+                synonyms: vec![],
+            },
+            semantic_views::model::TableRef {
+                alias: "products".to_string(),
+                table: "products".to_string(),
+                pk_columns: vec!["id".to_string()],
+                unique_constraints: vec![],
+                comment: None,
+                synonyms: vec![],
+            },
+        ],
         dimensions: vec![
             Dimension {
                 name: "region".to_string(),
@@ -188,18 +208,22 @@ fn joined_definition() -> SemanticViewDefinition {
         ],
 
         joins: vec![
+            // OneToOne so the fan-trap safety check passes for every generated
+            // request — this property tests join *exclusion*, not cardinality.
             Join {
                 table: "customers".to_string(),
-                on: "\"orders\".\"customer_id\" = \"customers\".\"id\"".to_string(),
-                from_cols: vec![],
-                join_columns: vec![],
+                from_alias: "orders".to_string(),
+                fk_columns: vec!["customer_id".to_string()],
+                ref_columns: vec!["id".to_string()],
+                cardinality: Cardinality::OneToOne,
                 ..Default::default()
             },
             Join {
                 table: "products".to_string(),
-                on: "\"orders\".\"product_id\" = \"products\".\"id\"".to_string(),
-                from_cols: vec![],
-                join_columns: vec![],
+                from_alias: "orders".to_string(),
+                fk_columns: vec!["product_id".to_string()],
+                ref_columns: vec!["id".to_string()],
+                cardinality: Cardinality::OneToOne,
                 ..Default::default()
             },
         ],


### PR DESCRIPTION
## Summary

First of two PRs for **AR-4** (from the 2026-07-02 code-review, §4 Phase R3). Adds a storage-format version to stored definitions and closes the residual **SG-7** fan-trap safety gap. **No dead-field deletion here** — that's the follow-up (PR-2), kept separate so this behavior change lands with its own test net.

### `schema_version`
Stored definitions now record a storage-format version. Rather than add a struct field (which would churn ~80 construction sites and leak into YAML export), the version is **injected into the stored JSON at write time via the same `json_merge_patch`** that already records `created_on` / `database_name` / `schema_name`, and read back with a lightweight probe (`SemanticViewDefinition::stored_schema_version`). `CURRENT_SCHEMA_VERSION = 1`.

### One-time upgrade pass in `init_catalog`
On load (writable DBs only, mirroring the v0.1.0 companion-file migration precedent), every stored row still below the current version is stamped up **iff it is verifiably current-format** — it parses and every relationship carries `fk_columns`. Rows that fail to parse, or carry a legacy relationship encoding with no FK metadata, are **left at version 0**. Non-destructive (no row is deleted or rewritten beyond the version stamp) and idempotent.

### SG-7 (residual)
The review's cited build-*failure* case was already fixed (`3bfa39b`). The residual hazard: `RelationshipGraph::from_definition` silently **skips** any join lacking `fk_columns`, so a legacy row with joins-but-no-FK-metadata builds an **empty graph successfully** and the fan-trap check passes vacuously → mis-aggregated results, no error. `build_relationship_graph` now hard-errors (`UncheckableDefinition`, "re-create with `CREATE OR REPLACE SEMANTIC VIEW`") when any relationship is missing `fk_columns`.

### Test-fixture modernization
A handful of expand tests and one proptest used the pre-Phase-24 `on`-only / `join_columns` encodings (no `fk_columns`) incidentally. These are exactly the uncheckable case SG-7 now rejects, so they're converted to the current FK-join form (and the now-unused `with_join_on` helper removed).

## Verification

Full `just test-all` gate:
- `just build` (extension) ✓
- `cargo test` — 1050 lib tests + integration/proptest ✓
- `cargo clippy -- -D warnings` + `cargo fmt --check` ✓
- `just test-sql` — 65/65 (new `test/sql/ar4_schema_version.test` pins the end-to-end write-time stamp + legacy-row query error) ✓
- `just test-ducklake-ci` — 6/6 ✓

## Follow-up (PR-2)
Delete the now-dead fields — `Join.{on, from_cols, join_columns}` and `SemanticViewDefinition.{column_type_names, column_types_inferred}` (+ `inferred_types()` and the `table_function.rs` read branch) — and update the format tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqhLSyyvEeLBwUufXhdSiz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqhLSyyvEeLBwUufXhdSiz)_