### PR TITLE
R3 FF-6 + FF-8: read-path wire-format &amp; SQL-quoting hardening

### DIFF
--- a/src/ddl/describe.rs
+++ b/src/ddl/describe.rs
@@ -100,7 +100,13 @@ pub unsafe extern "C" fn sv_describe_semantic_view_bind_rust(
                 r.property_value,
             ]);
         }
-        let buf = serialize_varchar_rows(&rows);
+        let buf = match serialize_varchar_rows(&rows) {
+            Ok(b) => b,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));

--- a/src/ddl/list.rs
+++ b/src/ddl/list.rs
@@ -85,7 +85,10 @@ pub unsafe extern "C" fn sv_list_semantic_views_bind_rust(
     error_buf: *mut u8,
     error_buf_len: usize,
 ) -> u8 {
-    use crate::ddl::read_ffi::{probe_catalog_table_present, write_err, BorrowedConnection};
+    use crate::ddl::read_ffi::{
+        probe_catalog_table_present, publish_owned_buffer, serialize_varchar_rows, write_err,
+        BorrowedConnection,
+    };
     use std::panic::AssertUnwindSafe;
     let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
         // Wrap the raw FFI handle in a BorrowedConnection at the boundary
@@ -118,7 +121,7 @@ pub unsafe extern "C" fn sv_list_semantic_views_bind_rust(
         // Reconstruct the 6-column rows exactly like the Rust VTab did
         // (ListBindData::rows) — sort by name so output ordering is
         // byte-identical to the v0.9.0 behavior.
-        let mut rows: Vec<[String; 6]> = Vec::with_capacity(entries.len());
+        let mut rows: Vec<Vec<String>> = Vec::with_capacity(entries.len());
         for (name, json) in &entries {
             let def = SemanticViewDefinition::from_json(name, json).ok();
             let (created_on, database_name, schema_name, comment) = match &def {
@@ -130,7 +133,7 @@ pub unsafe extern "C" fn sv_list_semantic_views_bind_rust(
                 ),
                 None => (String::new(), String::new(), String::new(), String::new()),
             };
-            rows.push([
+            rows.push(vec![
                 created_on,
                 name.clone(),
                 "SEMANTIC_VIEW".to_string(),
@@ -141,39 +144,20 @@ pub unsafe extern "C" fn sv_list_semantic_views_bind_rust(
         }
         rows.sort_by(|a, b| a[1].cmp(&b[1]));
 
-        // Serialize to the flat binary buffer. Wire format:
-        //   u32 row_count (LE)
-        //   for each row:
-        //     for each of 6 cols:
-        //       u32 byte_len (LE) | bytes
-        let row_count = rows.len() as u32;
-        let mut buf: Vec<u8> = Vec::with_capacity(
-            4 + rows
-                .iter()
-                .map(|r| r.iter().map(|s| 4 + s.len()).sum::<usize>())
-                .sum::<usize>(),
-        );
-        buf.extend_from_slice(&row_count.to_le_bytes());
-        for row in &rows {
-            for col in row {
-                let len = col.len() as u32;
-                buf.extend_from_slice(&len.to_le_bytes());
-                buf.extend_from_slice(col.as_bytes());
+        // FF-6: the shared serializer returns an error (rather than clamping a
+        // length to u32::MAX and desyncing the header from the payload) if a
+        // cell or the row count overflows the wire format's u32 fields. The
+        // previous inline copy used bare `as u32` casts. `publish_owned_buffer`
+        // hands the heap-owned buffer to C++ under the both-or-drop contract;
+        // the caller releases it via sv_free_buffer with the exact (ptr, len).
+        let buf = match serialize_varchar_rows(&rows) {
+            Ok(b) => b,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
             }
-        }
-
-        // Hand the heap-owned buffer to the C++ side. Caller releases via
-        // sv_free_buffer with the exact (ptr, len) pair. Matches the
-        // convention established in src/parse.rs and src/ddl/alter_helpers_ffi.rs.
-        let boxed: Box<[u8]> = buf.into_boxed_slice();
-        let len = boxed.len();
-        let raw = Box::into_raw(boxed) as *mut u8;
-        if !out_ptr.is_null() {
-            *out_ptr = raw;
-        }
-        if !out_len.is_null() {
-            *out_len = len;
-        }
+        };
+        publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));
     match result {
@@ -281,7 +265,13 @@ pub unsafe extern "C" fn sv_list_terse_semantic_views_bind_rust(
         }
         rows.sort_by(|a, b| a[1].cmp(&b[1]));
 
-        let buf = serialize_varchar_rows(&rows);
+        let buf = match serialize_varchar_rows(&rows) {
+            Ok(b) => b,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));

--- a/src/ddl/read_ffi.rs
+++ b/src/ddl/read_ffi.rs
@@ -163,51 +163,66 @@ pub unsafe fn write_err(buf: *mut u8, buf_len: usize, msg: &str) {
     crate::ffi_util::write_error_to_buffer(buf, buf_len, msg);
 }
 
+/// Encode a length as a little-endian `u32`, erroring rather than clamping
+/// when it exceeds `u32::MAX` (FF-6). A silent `unwrap_or(u32::MAX)` would
+/// write a length prefix that disagrees with the bytes actually appended,
+/// desyncing the header from the payload for every subsequent field on the
+/// C++ read side. The overflow is unreachable for real catalog metadata (a
+/// single row/cell would need >4 GiB), so the error is a hard corruption
+/// signal, not a routine path.
+fn wire_len(n: usize, what: &str) -> Result<u32, String> {
+    u32::try_from(n).map_err(|_| format!("{what} ({n} bytes) exceeds the wire-format u32 limit"))
+}
+
 /// Serialize a vector of VARCHAR rows into the wire format described above.
 ///
 /// `rows` is a `Vec<Vec<String>>` where every inner Vec has the same length
 /// (number of columns). The function does NOT validate that — callers are
 /// expected to construct rectangular row sets.
-#[must_use]
-pub fn serialize_varchar_rows(rows: &[Vec<String>]) -> Vec<u8> {
+///
+/// Returns `Err` if the row count or any cell length overflows the wire
+/// format's `u32` fields (see [`wire_len`]).
+pub fn serialize_varchar_rows(rows: &[Vec<String>]) -> Result<Vec<u8>, String> {
     let cap = 4 + rows
         .iter()
         .map(|r| r.iter().map(|s| 4 + s.len()).sum::<usize>())
         .sum::<usize>();
     let mut buf = Vec::with_capacity(cap);
-    let row_count = u32::try_from(rows.len()).unwrap_or(u32::MAX);
+    let row_count = wire_len(rows.len(), "row count")?;
     buf.extend_from_slice(&row_count.to_le_bytes());
     for row in rows {
         for col in row {
-            let len = u32::try_from(col.len()).unwrap_or(u32::MAX);
+            let len = wire_len(col.len(), "cell")?;
             buf.extend_from_slice(&len.to_le_bytes());
             buf.extend_from_slice(col.as_bytes());
         }
     }
-    buf
+    Ok(buf)
 }
 
 /// Serialize a vector of (VARCHAR-cells, BOOL) rows. Each row's strings are
 /// emitted first (same shape as `serialize_varchar_rows`) followed by a
 /// single trailing `u8` (1 = TRUE, 0 = FALSE).
-#[must_use]
-pub fn serialize_varchar_bool_rows(rows: &[(Vec<String>, bool)]) -> Vec<u8> {
+///
+/// Returns `Err` on the same overflow conditions as
+/// [`serialize_varchar_rows`].
+pub fn serialize_varchar_bool_rows(rows: &[(Vec<String>, bool)]) -> Result<Vec<u8>, String> {
     let cap = 4 + rows
         .iter()
         .map(|(strs, _)| strs.iter().map(|s| 4 + s.len()).sum::<usize>() + 1)
         .sum::<usize>();
     let mut buf = Vec::with_capacity(cap);
-    let row_count = u32::try_from(rows.len()).unwrap_or(u32::MAX);
+    let row_count = wire_len(rows.len(), "row count")?;
     buf.extend_from_slice(&row_count.to_le_bytes());
     for (strs, b) in rows {
         for col in strs {
-            let len = u32::try_from(col.len()).unwrap_or(u32::MAX);
+            let len = wire_len(col.len(), "cell")?;
             buf.extend_from_slice(&len.to_le_bytes());
             buf.extend_from_slice(col.as_bytes());
         }
         buf.push(u8::from(*b));
     }
-    buf
+    Ok(buf)
 }
 
 /// Hand a heap-owned `Vec<u8>` to the C++ side via the (ptr, len)
@@ -320,14 +335,14 @@ mod tests {
 
     #[test]
     fn serialize_empty_row_set() {
-        let buf = serialize_varchar_rows(&[]);
+        let buf = serialize_varchar_rows(&[]).unwrap();
         assert_eq!(buf, vec![0, 0, 0, 0]);
     }
 
     #[test]
     fn serialize_single_row() {
         let rows = vec![vec!["a".to_string(), "bc".to_string()]];
-        let buf = serialize_varchar_rows(&rows);
+        let buf = serialize_varchar_rows(&rows).unwrap();
         let expected: Vec<u8> = vec![
             1, 0, 0, 0, // row_count = 1
             1, 0, 0, 0,    // len("a") = 1
@@ -344,7 +359,7 @@ mod tests {
             (vec!["x".to_string()], true),
             (vec!["y".to_string()], false),
         ];
-        let buf = serialize_varchar_bool_rows(&rows);
+        let buf = serialize_varchar_bool_rows(&rows).unwrap();
         let expected: Vec<u8> = vec![
             2, 0, 0, 0, // row_count = 2
             1, 0, 0, 0, b'x', 1, // ("x", true)

--- a/src/ddl/show_columns.rs
+++ b/src/ddl/show_columns.rs
@@ -87,7 +87,13 @@ pub unsafe extern "C" fn sv_show_columns_in_semantic_view_bind_rust(
                 r.comment,
             ]);
         }
-        let buf = serialize_varchar_rows(&rows);
+        let buf = match serialize_varchar_rows(&rows) {
+            Ok(b) => b,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));

--- a/src/ddl/show_dims_for_metric.rs
+++ b/src/ddl/show_dims_for_metric.rs
@@ -198,7 +198,7 @@ unsafe fn show_dims_for_metric(
             .collect()
     };
     rows.sort_by(|a, b| a.0[1].cmp(&b.0[1]));
-    Ok(serialize_varchar_bool_rows(&rows))
+    serialize_varchar_bool_rows(&rows)
 }
 
 /// Check if a dimension is reachable from a given set of metric source tables

--- a/src/ddl/show_entities.rs
+++ b/src/ddl/show_entities.rs
@@ -152,7 +152,7 @@ fn show_entities_all(kind: EntityKind, borrowed: &BorrowedConnection) -> Result<
         }
     }
     rows.sort_by(|a, b| a[2].cmp(&b[2]).then_with(|| a[4].cmp(&b[4])));
-    Ok(serialize_varchar_rows(&rows))
+    serialize_varchar_rows(&rows)
 }
 
 /// Single-view body: collect `kind` rows for one view, sorted by `name`.
@@ -171,7 +171,7 @@ fn show_entities_one(
     let mut internal = collect_entities(kind, view_name, &json);
     internal.sort_by(|a, b| a.name.cmp(&b.name));
     let rows: Vec<Vec<String>> = internal.into_iter().map(EntityRow::into_cells).collect();
-    Ok(serialize_varchar_rows(&rows))
+    serialize_varchar_rows(&rows)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ddl/show_materializations.rs
+++ b/src/ddl/show_materializations.rs
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn sv_show_semantic_materializations_all_bind_rust(
                 }
             }
             rows.sort_by(|a, b| a[2].cmp(&b[2]).then_with(|| a[3].cmp(&b[3])));
-            Ok(serialize_varchar_rows(&rows))
+            serialize_varchar_rows(&rows)
         },
     )
 }
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn sv_show_semantic_materializations_bind_rust(
             let mut internal = collect_mats(&view_name, &json);
             internal.sort_by(|a, b| a.name.cmp(&b.name));
             let rows: Vec<Vec<String>> = internal.into_iter().map(ShowMatRow::into_cells).collect();
-            Ok(serialize_varchar_rows(&rows))
+            serialize_varchar_rows(&rows)
         },
     )
 }

--- a/src/query/explain.rs
+++ b/src/query/explain.rs
@@ -92,11 +92,12 @@ unsafe fn parse_string_list(buf: *const u8, len: usize) -> Result<Vec<String>, S
     };
     let count = read_u32(slice, &mut off)? as usize;
     // FF-6: cap the pre-allocation at the largest element count the buffer
-    // could actually hold (each element carries at least a 4-byte length
-    // prefix). A corrupt `count` near u32::MAX would otherwise request a
-    // ~100 GB allocation up front; the per-element bounds check below still
-    // rejects a genuinely truncated payload.
-    let mut out = Vec::with_capacity(count.min(len / 4));
+    // could actually hold. The 4-byte count prefix has already been consumed,
+    // and each remaining element carries at least a 4-byte length prefix, so
+    // the ceiling is `(len - 4) / 4`. A corrupt `count` near u32::MAX would
+    // otherwise request a ~100 GB allocation up front; the per-element bounds
+    // check below still rejects a genuinely truncated payload.
+    let mut out = Vec::with_capacity(count.min(len.saturating_sub(4) / 4));
     for i in 0..count {
         let n = read_u32(slice, &mut off)
             .map_err(|e| format!("reading length for element {i} of {count}: {e}"))?

--- a/src/query/explain.rs
+++ b/src/query/explain.rs
@@ -91,7 +91,12 @@ unsafe fn parse_string_list(buf: *const u8, len: usize) -> Result<Vec<String>, S
         Ok(v)
     };
     let count = read_u32(slice, &mut off)? as usize;
-    let mut out = Vec::with_capacity(count);
+    // FF-6: cap the pre-allocation at the largest element count the buffer
+    // could actually hold (each element carries at least a 4-byte length
+    // prefix). A corrupt `count` near u32::MAX would otherwise request a
+    // ~100 GB allocation up front; the per-element bounds check below still
+    // rejects a genuinely truncated payload.
+    let mut out = Vec::with_capacity(count.min(len / 4));
     for i in 0..count {
         let n = read_u32(slice, &mut off)
             .map_err(|e| format!("reading length for element {i} of {count}: {e}"))?
@@ -346,7 +351,13 @@ pub unsafe extern "C" fn sv_explain_semantic_view_bind_rust(
 
         // Serialise as 1-column VARCHAR rows.
         let rows: Vec<Vec<String>> = lines.into_iter().map(|l| vec![l]).collect();
-        let buf = serialize_varchar_rows(&rows);
+        let buf = match serialize_varchar_rows(&rows) {
+            Ok(b) => b,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));

--- a/src/query/table_function.rs
+++ b/src/query/table_function.rs
@@ -4,7 +4,7 @@ use libduckdb_sys as ffi;
 
 use crate::catalog::CatalogReader;
 use crate::expand::wildcard::{expand_wildcards, WildcardItemType};
-use crate::expand::{expand, QueryRequest};
+use crate::expand::{expand, quote_ident, QueryRequest};
 use crate::model::SemanticViewDefinition;
 use crate::util::suggest_closest;
 
@@ -83,7 +83,12 @@ unsafe fn sv_parse_string_list(buf: *const u8, len: usize) -> Result<Vec<String>
         Ok(v)
     };
     let count = read_u32(slice, &mut off)? as usize;
-    let mut out = Vec::with_capacity(count);
+    // FF-6: cap the pre-allocation at the largest element count the buffer
+    // could actually hold (each element carries at least a 4-byte length
+    // prefix). A corrupt `count` near u32::MAX would otherwise request a
+    // ~100 GB allocation up front; the per-element bounds check below still
+    // rejects a genuinely truncated payload.
+    let mut out = Vec::with_capacity(count.min(len / 4));
     for i in 0..count {
         let n = read_u32(slice, &mut off)
             .map_err(|e| format!("reading length for element {i} of {count}: {e}"))?
@@ -348,23 +353,14 @@ pub unsafe extern "C" fn sv_semantic_view_bind_rust(
         let execution_sql = build_execution_sql(&expanded_sql, &column_names, &column_type_ids);
 
         // Serialise schema + execution_sql into a flat binary buffer.
-        let n_cols = column_names.len() as u32;
-        let cap = 4 // n_cols
-            + column_names.iter().map(|n| 4 + n.len()).sum::<usize>()
-            + column_type_ids.len() * 4
-            + 4 + execution_sql.len();
-        let mut buf: Vec<u8> = Vec::with_capacity(cap);
-        buf.extend_from_slice(&n_cols.to_le_bytes());
-        for (name, tid) in column_names.iter().zip(column_type_ids.iter()) {
-            let nl = name.len() as u32;
-            buf.extend_from_slice(&nl.to_le_bytes());
-            buf.extend_from_slice(name.as_bytes());
-            buf.extend_from_slice(&tid.to_le_bytes());
-        }
-        let sql_len = execution_sql.len() as u32;
-        buf.extend_from_slice(&sql_len.to_le_bytes());
-        buf.extend_from_slice(execution_sql.as_bytes());
-
+        let buf = match serialize_register_payload(&column_names, &column_type_ids, &execution_sql)
+        {
+            Ok(b) => b,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));
@@ -532,6 +528,49 @@ fn type_id_to_cast_sql(type_id: u32) -> Option<&'static str> {
     }
 }
 
+/// Serialize the inferred schema + execution SQL into the flat register wire
+/// format consumed by the C++ `semantic_view` bind:
+///
+/// ```text
+/// u32 n_cols
+/// for each col: u32 name_len | name bytes | u32 type_id
+/// u32 sql_len | sql bytes
+/// ```
+///
+/// FF-6: every length goes through a checked `u32::try_from` and the function
+/// returns an error rather than a bare `as u32` truncation, which would write a
+/// length prefix that disagrees with the bytes appended and desync the header
+/// from the payload on the C++ read side. Overflow is unreachable for real
+/// queries (a column name or the execution SQL would each need to exceed 4 GiB).
+fn serialize_register_payload(
+    column_names: &[String],
+    column_type_ids: &[u32],
+    execution_sql: &str,
+) -> Result<Vec<u8>, String> {
+    let wire_len = |n: usize, what: &str| -> Result<u32, String> {
+        u32::try_from(n)
+            .map_err(|_| format!("{what} ({n} bytes) exceeds the wire-format u32 limit"))
+    };
+    let n_cols = wire_len(column_names.len(), "column count")?;
+    let cap = 4
+        + column_names.iter().map(|n| 4 + n.len()).sum::<usize>()
+        + column_type_ids.len() * 4
+        + 4
+        + execution_sql.len();
+    let mut buf: Vec<u8> = Vec::with_capacity(cap);
+    buf.extend_from_slice(&n_cols.to_le_bytes());
+    for (name, tid) in column_names.iter().zip(column_type_ids.iter()) {
+        let nl = wire_len(name.len(), "column name")?;
+        buf.extend_from_slice(&nl.to_le_bytes());
+        buf.extend_from_slice(name.as_bytes());
+        buf.extend_from_slice(&tid.to_le_bytes());
+    }
+    let sql_len = wire_len(execution_sql.len(), "execution SQL")?;
+    buf.extend_from_slice(&sql_len.to_le_bytes());
+    buf.extend_from_slice(execution_sql.as_bytes());
+    Ok(buf)
+}
+
 /// Build the SQL used at execution time, wrapping the expanded SQL with explicit
 /// type casts for EVERY output column.
 ///
@@ -557,9 +596,17 @@ fn build_execution_sql(
     let clauses: Vec<String> = column_names
         .iter()
         .zip(column_type_ids.iter())
-        .map(|(name, &tid)| match type_id_to_cast_sql(tid) {
-            Some(cast_type) => format!("\"{name}\"::{cast_type} AS \"{name}\""),
-            None => format!("\"{name}\""),
+        .map(|(name, &tid)| {
+            // FF-8: quote_ident escapes an embedded `"` in the inferred column
+            // name (`"` → `""`); a raw format!("\"{name}\"") would break the
+            // cast wrapper and mis-alias the column. Names come from
+            // duckdb_column_name on the LIMIT-0 probe, so a fact/dimension
+            // alias containing `"` reaches here verbatim.
+            let quoted = quote_ident(name);
+            match type_id_to_cast_sql(tid) {
+                Some(cast_type) => format!("{quoted}::{cast_type} AS {quoted}"),
+                None => quoted,
+            }
         })
         .collect();
 

--- a/src/query/table_function.rs
+++ b/src/query/table_function.rs
@@ -84,11 +84,12 @@ unsafe fn sv_parse_string_list(buf: *const u8, len: usize) -> Result<Vec<String>
     };
     let count = read_u32(slice, &mut off)? as usize;
     // FF-6: cap the pre-allocation at the largest element count the buffer
-    // could actually hold (each element carries at least a 4-byte length
-    // prefix). A corrupt `count` near u32::MAX would otherwise request a
-    // ~100 GB allocation up front; the per-element bounds check below still
-    // rejects a genuinely truncated payload.
-    let mut out = Vec::with_capacity(count.min(len / 4));
+    // could actually hold. The 4-byte count prefix has already been consumed,
+    // and each remaining element carries at least a 4-byte length prefix, so
+    // the ceiling is `(len - 4) / 4`. A corrupt `count` near u32::MAX would
+    // otherwise request a ~100 GB allocation up front; the per-element bounds
+    // check below still rejects a genuinely truncated payload.
+    let mut out = Vec::with_capacity(count.min(len.saturating_sub(4) / 4));
     for i in 0..count {
         let n = read_u32(slice, &mut off)
             .map_err(|e| format!("reading length for element {i} of {count}: {e}"))?
@@ -551,6 +552,19 @@ fn serialize_register_payload(
         u32::try_from(n)
             .map_err(|_| format!("{what} ({n} bytes) exceeds the wire-format u32 limit"))
     };
+    // Guard against slice desync: the header writes `n_cols` from
+    // `column_names.len()`, but the body serializes via `zip`, which would
+    // silently truncate to the shorter slice and emit a header that disagrees
+    // with the payload. Today both vectors come from the same
+    // `duckdb_column_count` loop, but reject mismatch explicitly so a future
+    // caller cannot desync the wire format.
+    if column_names.len() != column_type_ids.len() {
+        return Err(format!(
+            "column name count ({}) disagrees with type id count ({})",
+            column_names.len(),
+            column_type_ids.len()
+        ));
+    }
     let n_cols = wire_len(column_names.len(), "column count")?;
     let cap = 4
         + column_names.iter().map(|n| 4 + n.len()).sum::<usize>()


### PR DESCRIPTION
First of three small PRs from the R3 §4 "small FF/AR hardening batch" in the code-review brief. This one covers the read-path FFI robustness cluster (FF-6, FF-8). FF-4 + FF-9 and AR-7 + AR-9 follow as separate PRs so each stays easy to review.

## FF-6 — wire-format length safety across the read-side FFI bridge

The Rust↔C++ read path serializes result rows into a length-prefixed binary format (`u32 row_count`, then per-cell `u32 len` + bytes). Two hazards:

- **Encoders clamped on overflow.** `serialize_varchar_rows` / `serialize_varchar_bool_rows` wrote `u32::try_from(len).unwrap_or(u32::MAX)`. A clamp writes a length prefix that disagrees with the bytes actually appended, desyncing the header from the payload for every field the C++ side reads afterwards. These now return `Result` and error (via a shared `wire_len` helper) instead of clamping. The two remaining inline encoders adopt the same discipline: the 6-column `list_semantic_views` encoder now reuses `serialize_varchar_rows` (dropping a hand-rolled copy with bare `as u32` casts), and the `semantic_view` register payload moves into a checked `serialize_register_payload` helper.
- **Decoders trusted an unvalidated count.** `sv_parse_string_list` and `explain::parse_string_list` did `Vec::with_capacity(count)` on a `u32` read straight off the wire — a corrupt count near `u32::MAX` requests a ~100 GB allocation up front. Capacity is now capped at `len/4` (the largest element count the buffer could hold, since each element carries at least a 4-byte length prefix). The existing per-element bounds check still rejects a genuinely truncated payload.

Overflow is unreachable for real catalog metadata (a row or cell would need to exceed 4 GiB), so the new errors are hard corruption signals, not routine paths.

## FF-8 — escape identifiers in `build_execution_sql`

`build_execution_sql` formatted `format!("\"{name}\"::{cast} AS \"{name}\"")` — the one raw-format exception to otherwise-correct identifier quoting. Column names come from `duckdb_column_name` on the LIMIT-0 probe, so a fact/dimension alias containing a `"` reached the cast wrapper verbatim and would break it. It now routes names through `quote_ident` (`"` → `""`).

## Verification

- `just build` ✓
- `cargo test` ✓ (unit + proptest + doctests)
- `cargo fmt --check` ✓
- `just test-sql` — 65/65 ✓
- `just test-ducklake-ci` — 6/6 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqhLSyyvEeLBwUufXhdSiz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqhLSyyvEeLBwUufXhdSiz)_