### PR TITLE
R3 FF-4 + FF-9: wave-2 TF argument handling & catalog-probe error propagation

### DIFF
--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -1387,6 +1387,14 @@ static void sv_run_varchar_bind_with_name(ClientContext &context,
                                           const char *fn_name,
                                           DispatcherFn &&dispatcher) {
     bd.expected_cols = expected_cols;
+    // FF-4: guard the positional view-name argument. Without this a NULL
+    // argument (e.g. describe_semantic_view(NULL)) reached GetValue<string>()
+    // and surfaced as the confusing "view 'NULL' does not exist"; match the
+    // semantic_view() binder's up-front BinderException instead.
+    if (input.inputs.empty() || input.inputs[0].IsNull()) {
+        throw BinderException(std::string(fn_name) +
+                              ": view name is required (positional arg 0)");
+    }
     std::string name = input.inputs[0].GetValue<std::string>();
     Connection probe(*context.db);
     duckdb_connection borrowed = reinterpret_cast<duckdb_connection>(&probe);
@@ -1413,6 +1421,15 @@ static void sv_run_varchar_bool_bind_with_two_names(
     const char *fn_name,
     DispatcherFn &&dispatcher) {
     bd.expected_varchar_cols = expected_varchar_cols;
+    // FF-4: guard both positional arguments (view_name, metric_name) before
+    // GetValue<string>() so a NULL argument raises a clear BinderException
+    // rather than resolving to a spurious "'NULL' does not exist".
+    if (input.inputs.size() < 2 || input.inputs[0].IsNull() ||
+        input.inputs[1].IsNull()) {
+        throw BinderException(
+            std::string(fn_name) +
+            ": view name and metric name are required (positional args 0, 1)");
+    }
     std::string name1 = input.inputs[0].GetValue<std::string>();
     std::string name2 = input.inputs[1].GetValue<std::string>();
     Connection probe(*context.db);

--- a/src/ddl/describe.rs
+++ b/src/ddl/describe.rs
@@ -40,14 +40,35 @@ pub unsafe extern "C" fn sv_describe_semantic_view_bind_rust(
             return 1_u8;
         }
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let name = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s.to_string(),
+        let raw_name = match std::str::from_utf8(name_bytes) {
+            Ok(s) => s,
             Err(_) => {
                 write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
                 return 1_u8;
             }
         };
-        let reader = CatalogReader::new(&borrowed, probe_catalog_table_present(&borrowed));
+        // FF-4: normalize so quoted-identifier inputs resolve like `semantic_view()`.
+        let name = match crate::ident::normalize_view_name(raw_name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_err(
+                    error_buf,
+                    error_buf_len,
+                    &format!("Invalid view name '{raw_name}': {e}"),
+                );
+                return 1_u8;
+            }
+        };
+        // FF-9: surface a probe-query failure as an error distinct from "no
+        // views" instead of silently folding it into absence.
+        let present = match probe_catalog_table_present(&borrowed) {
+            Ok(p) => p,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
+        let reader = CatalogReader::new(&borrowed, present);
         let json = match reader.lookup(&name) {
             Ok(Some(j)) => j,
             Ok(None) => {

--- a/src/ddl/get_ddl.rs
+++ b/src/ddl/get_ddl.rs
@@ -87,7 +87,16 @@ pub unsafe extern "C" fn sv_get_ddl_exec_rust(
             return 1_u8;
         }
 
-        let reader = CatalogReader::new(&borrowed, probe_catalog_table_present(&borrowed));
+        // FF-9: surface a probe-query failure as an error distinct from "no
+        // views" instead of silently folding it into absence.
+        let present = match probe_catalog_table_present(&borrowed) {
+            Ok(p) => p,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
+        let reader = CatalogReader::new(&borrowed, present);
         let json = match reader.lookup(name) {
             Ok(Some(j)) => j,
             Ok(None) => {

--- a/src/ddl/list.rs
+++ b/src/ddl/list.rs
@@ -104,8 +104,16 @@ pub unsafe extern "C" fn sv_list_semantic_views_bind_rust(
         // Probe whether semantic_layer._definitions exists on the caller's
         // connection. Cheap (single query); matches Phase 63's RO-load
         // short-circuit semantics so an attached read-only DB without a
-        // bootstrapped catalog returns 0 rows instead of an error.
-        let table_present = probe_catalog_table_present(&borrowed);
+        // bootstrapped catalog returns Ok(false) (0 rows) instead of an error.
+        // FF-9: a genuine probe-query failure now surfaces as an error rather
+        // than being silently folded into "no views".
+        let table_present = match probe_catalog_table_present(&borrowed) {
+            Ok(p) => p,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
 
         // CatalogReader::new only stores the raw pointer extracted via
         // borrowed.as_raw() — no transfer of ownership.
@@ -234,7 +242,15 @@ pub unsafe extern "C" fn sv_list_terse_semantic_views_bind_rust(
             return 1_u8;
         }
 
-        let table_present = probe_catalog_table_present(&borrowed);
+        // FF-9: a genuine probe-query failure now surfaces as an error rather
+        // than being silently folded into "no views".
+        let table_present = match probe_catalog_table_present(&borrowed) {
+            Ok(p) => p,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
         let reader = CatalogReader::new(&borrowed, table_present);
         let entries = match reader.list_all() {
             Ok(e) => e,

--- a/src/ddl/read_ffi.rs
+++ b/src/ddl/read_ffi.rs
@@ -41,7 +41,7 @@
 #![cfg(feature = "extension")]
 
 use libduckdb_sys as ffi;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 
 /// Borrowed `duckdb_connection` handle. The bridge contract: this handle is
 /// owned by a stack `Connection probe(*context.db)` constructed in a C++
@@ -117,10 +117,20 @@ impl BorrowedConnection {
 // unwrapping intent at each FFI boundary.
 
 /// Probe whether `semantic_layer._definitions` exists on the given borrowed
-/// connection. Returns `false` if the schema/table is missing OR if the
-/// probe query itself fails (defensive — never raises). Mirrors the Phase
-/// 63 read-only short-circuit logic at `src/lib.rs:393-403` and the inline
-/// probe in `src/ddl/list.rs`.
+/// connection.
+///
+/// Returns:
+/// * `Ok(true)` — the catalog table is present.
+/// * `Ok(false)` — the probe query succeeded but the table is absent (0 rows).
+///   This is the Phase 63 read-only short-circuit path: an attached read-only
+///   DB whose `_definitions` table was never bootstrapped returns 0 rows here,
+///   which callers treat as "no views", not an error. Mirrors the read-only
+///   short-circuit logic at `src/lib.rs` and the inline probe in
+///   `src/ddl/list.rs`.
+/// * `Err(msg)` — the probe query itself failed to execute (FF-9). Previously
+///   any such failure was silently folded into `false` ("no views"), masking
+///   catalog corruption or a broken connection as an empty result. Callers now
+///   surface it as an error distinct from genuine absence.
 ///
 /// # Safety
 ///
@@ -128,24 +138,28 @@ impl BorrowedConnection {
 /// and must outlive this call — the typical caller is a bind dispatcher
 /// running inside a C++ bind callback that owns a stack `Connection
 /// probe(*context.db)`.
-pub unsafe fn probe_catalog_table_present(borrowed: &BorrowedConnection) -> bool {
+pub unsafe fn probe_catalog_table_present(borrowed: &BorrowedConnection) -> Result<bool, String> {
     let conn = borrowed.as_raw();
-    let sql = match CString::new(
+    let sql = CString::new(
         "SELECT 1 FROM information_schema.tables \
          WHERE table_schema = 'semantic_layer' AND table_name = '_definitions' LIMIT 1",
-    ) {
-        Ok(s) => s,
-        Err(_) => return false,
-    };
+    )
+    .map_err(|_| "catalog probe SQL contains an interior null byte".to_string())?;
     let mut result: ffi::duckdb_result = std::mem::zeroed();
     let rc = ffi::duckdb_query(conn, sql.as_ptr(), &mut result);
-    let present = if rc == ffi::DuckDBSuccess {
-        ffi::duckdb_row_count(&mut result) > 0
+    let out = if rc == ffi::DuckDBSuccess {
+        Ok(ffi::duckdb_row_count(&mut result) > 0)
     } else {
-        false
+        let err_ptr = ffi::duckdb_result_error(&mut result);
+        let msg = if err_ptr.is_null() {
+            "catalog presence probe failed".to_string()
+        } else {
+            CStr::from_ptr(err_ptr).to_string_lossy().into_owned()
+        };
+        Err(msg)
     };
     ffi::duckdb_destroy_result(&mut result);
-    present
+    out
 }
 
 /// Write a NUL-terminated error message into the C-side `error_buf`,

--- a/src/ddl/read_yaml.rs
+++ b/src/ddl/read_yaml.rs
@@ -78,7 +78,16 @@ pub unsafe extern "C" fn sv_read_yaml_from_semantic_view_exec_rust(
         };
         let bare_name = resolve_bare_name(raw_name);
 
-        let reader = CatalogReader::new(&borrowed, probe_catalog_table_present(&borrowed));
+        // FF-9: surface a probe-query failure as an error distinct from "no
+        // views" instead of silently folding it into absence.
+        let present = match probe_catalog_table_present(&borrowed) {
+            Ok(p) => p,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
+        let reader = CatalogReader::new(&borrowed, present);
         let json = match reader.lookup(&bare_name) {
             Ok(Some(j)) => j,
             Ok(None) => {

--- a/src/ddl/show_columns.rs
+++ b/src/ddl/show_columns.rs
@@ -43,14 +43,35 @@ pub unsafe extern "C" fn sv_show_columns_in_semantic_view_bind_rust(
             return 1_u8;
         }
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let view_name = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s.to_string(),
+        let raw_name = match std::str::from_utf8(name_bytes) {
+            Ok(s) => s,
             Err(_) => {
                 write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
                 return 1_u8;
             }
         };
-        let reader = CatalogReader::new(&borrowed, probe_catalog_table_present(&borrowed));
+        // FF-4: normalize so quoted-identifier inputs resolve like `semantic_view()`.
+        let view_name = match crate::ident::normalize_view_name(raw_name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_err(
+                    error_buf,
+                    error_buf_len,
+                    &format!("Invalid view name '{raw_name}': {e}"),
+                );
+                return 1_u8;
+            }
+        };
+        // FF-9: surface a probe-query failure as an error distinct from "no
+        // views" instead of silently folding it into absence.
+        let present = match probe_catalog_table_present(&borrowed) {
+            Ok(p) => p,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
+        let reader = CatalogReader::new(&borrowed, present);
         let json = match reader.lookup(&view_name) {
             Ok(Some(j)) => j,
             Ok(None) => {

--- a/src/ddl/show_dims_for_metric.rs
+++ b/src/ddl/show_dims_for_metric.rs
@@ -74,8 +74,12 @@ unsafe fn show_dims_for_metric(
 ) -> Result<Vec<u8>, String> {
     let view_name = read_str_arg(view_name_ptr, view_name_len, "view name")?;
     let metric_name = read_str_arg(metric_name_ptr, metric_name_len, "metric name")?;
+    // FF-4: normalize the view name so quoted-identifier inputs resolve the
+    // same way they do through `semantic_view()`.
+    let view_name = crate::ident::normalize_view_name(&view_name)
+        .map_err(|e| format!("Invalid view name '{view_name}': {e}"))?;
 
-    let present = probe_catalog_table_present(borrowed);
+    let present = probe_catalog_table_present(borrowed)?;
     let reader = CatalogReader::new(borrowed, present);
     let json = match reader.lookup(&view_name)? {
         Some(j) => j,

--- a/src/ddl/show_entities.rs
+++ b/src/ddl/show_entities.rs
@@ -63,13 +63,15 @@ impl EntityRow {
     }
 }
 
-/// Collect the entity rows of `kind` for a single stored view. Unparseable
-/// JSON yields no rows (the SHOW surface is display-only). `table_name` is
-/// resolved from each entity's `source_table` alias via the view's alias map.
-fn collect_entities(kind: EntityKind, view_name: &str, json: &str) -> Vec<EntityRow> {
-    let Ok(def) = SemanticViewDefinition::from_json(view_name, json) else {
-        return Vec::new();
-    };
+/// Collect the entity rows of `kind` for a single already-parsed view.
+/// `table_name` is resolved from each entity's `source_table` alias via the
+/// view's alias map. Parsing (and the FF-9 decision of whether an unparseable
+/// definition is a hard error or a skipped row) happens at the call site.
+fn collect_entities(
+    kind: EntityKind,
+    view_name: &str,
+    def: &SemanticViewDefinition,
+) -> Vec<EntityRow> {
     let db_name = def.database_name.clone().unwrap_or_default();
     let sch_name = def.schema_name.clone().unwrap_or_default();
     let alias_map = def.alias_to_table_map();
@@ -142,12 +144,18 @@ fn collect_entities(kind: EntityKind, view_name: &str, json: &str) -> Vec<Entity
 /// Cross-view `_all` body: collect `kind` rows over every stored view, sorted
 /// by `(semantic_view_name, name)`.
 fn show_entities_all(kind: EntityKind, borrowed: &BorrowedConnection) -> Result<Vec<u8>, String> {
-    let present = unsafe { probe_catalog_table_present(borrowed) };
+    let present = unsafe { probe_catalog_table_present(borrowed) }?;
     let reader = CatalogReader::new(borrowed, present);
     let entries = reader.list_all()?;
     let mut rows: Vec<Vec<String>> = Vec::new();
     for (name, json) in &entries {
-        for r in collect_entities(kind, name, json) {
+        // FF-9: the cross-view `_all` listing stays tolerant — a single view
+        // whose stored JSON won't parse is skipped rather than failing the
+        // whole listing. The named single-view path below is the strict one.
+        let Ok(def) = SemanticViewDefinition::from_json(name, json) else {
+            continue;
+        };
+        for r in collect_entities(kind, name, &def) {
             rows.push(r.into_cells());
         }
     }
@@ -162,13 +170,22 @@ fn show_entities_one(
     borrowed: &BorrowedConnection,
     view_name: &str,
 ) -> Result<Vec<u8>, String> {
-    let present = unsafe { probe_catalog_table_present(borrowed) };
+    // FF-4: normalize the requested name so quoted-identifier inputs resolve
+    // the same way they do through `semantic_view()` (unquoted folds to
+    // lowercase; quoted preserves case).
+    let view_name = crate::ident::normalize_view_name(view_name)
+        .map_err(|e| format!("Invalid view name '{view_name}': {e}"))?;
+    let present = unsafe { probe_catalog_table_present(borrowed) }?;
     let reader = CatalogReader::new(borrowed, present);
-    let json = match reader.lookup(view_name)? {
+    let json = match reader.lookup(&view_name)? {
         Some(j) => j,
-        None => return Err(crate::catalog::view_not_found_msg(view_name)),
+        None => return Err(crate::catalog::view_not_found_msg(&view_name)),
     };
-    let mut internal = collect_entities(kind, view_name, &json);
+    // FF-9: named single-view SHOW propagates a parse error — the user asked
+    // for this specific view, so a corrupt definition must surface loudly
+    // instead of silently returning zero rows.
+    let def = SemanticViewDefinition::from_json(&view_name, &json)?;
+    let mut internal = collect_entities(kind, &view_name, &def);
     internal.sort_by(|a, b| a.name.cmp(&b.name));
     let rows: Vec<Vec<String>> = internal.into_iter().map(EntityRow::into_cells).collect();
     serialize_varchar_rows(&rows)

--- a/src/ddl/show_materializations.rs
+++ b/src/ddl/show_materializations.rs
@@ -42,12 +42,10 @@ impl ShowMatRow {
     }
 }
 
-/// Collect materialization rows for a single view. Unparseable JSON yields no
-/// rows (display-only surface).
-fn collect_mats(view_name: &str, json: &str) -> Vec<ShowMatRow> {
-    let Ok(def) = SemanticViewDefinition::from_json(view_name, json) else {
-        return Vec::new();
-    };
+/// Collect materialization rows for a single already-parsed view. Parsing
+/// (and the FF-9 decision of whether an unparseable definition is a hard error
+/// or a skipped row) happens at the call site.
+fn collect_mats(view_name: &str, def: &SemanticViewDefinition) -> Vec<ShowMatRow> {
     let db_name = def.database_name.clone().unwrap_or_default();
     let sch_name = def.schema_name.clone().unwrap_or_default();
     def.materializations
@@ -84,12 +82,17 @@ pub unsafe extern "C" fn sv_show_semantic_materializations_all_bind_rust(
         error_buf_len,
         "sv_show_semantic_materializations_all_bind_rust",
         |borrowed| {
-            let present = unsafe { probe_catalog_table_present(borrowed) };
+            let present = unsafe { probe_catalog_table_present(borrowed) }?;
             let reader = CatalogReader::new(borrowed, present);
             let entries = reader.list_all()?;
             let mut rows: Vec<Vec<String>> = Vec::new();
             for (name, json) in &entries {
-                for r in collect_mats(name, json) {
+                // FF-9: `_all` stays tolerant — skip a view whose stored JSON
+                // won't parse rather than failing the whole listing.
+                let Ok(def) = SemanticViewDefinition::from_json(name, json) else {
+                    continue;
+                };
+                for r in collect_mats(name, &def) {
                     rows.push(r.into_cells());
                 }
             }
@@ -122,13 +125,20 @@ pub unsafe extern "C" fn sv_show_semantic_materializations_bind_rust(
         "sv_show_semantic_materializations_bind_rust",
         |borrowed| {
             let view_name = unsafe { read_str_arg(name_ptr, name_len, "view name") }?;
-            let present = unsafe { probe_catalog_table_present(borrowed) };
+            // FF-4: normalize so quoted-identifier inputs resolve like
+            // `semantic_view()` does.
+            let view_name = crate::ident::normalize_view_name(&view_name)
+                .map_err(|e| format!("Invalid view name '{view_name}': {e}"))?;
+            let present = unsafe { probe_catalog_table_present(borrowed) }?;
             let reader = CatalogReader::new(borrowed, present);
             let json = match reader.lookup(&view_name)? {
                 Some(j) => j,
                 None => return Err(crate::catalog::view_not_found_msg(&view_name)),
             };
-            let mut internal = collect_mats(&view_name, &json);
+            // FF-9: named single-view SHOW propagates a parse error rather than
+            // silently returning zero rows for a corrupt definition.
+            let def = SemanticViewDefinition::from_json(&view_name, &json)?;
+            let mut internal = collect_mats(&view_name, &def);
             internal.sort_by(|a, b| a.name.cmp(&b.name));
             let rows: Vec<Vec<String>> = internal.into_iter().map(ShowMatRow::into_cells).collect();
             serialize_varchar_rows(&rows)

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -98,12 +98,17 @@ enum Trailing {
     Allow,
 }
 
-/// Extract just the view name from a name-only DDL statement (DROP, DESCRIBE,
-/// SHOW COLUMNS; ALTER uses [`Trailing::Allow`] since its sub-operation
-/// follows the name).
+/// Extract the RAW (un-normalized) view name from a name-only DDL statement.
+///
+/// The read-side DESCRIBE / SHOW COLUMNS rewrites embed this raw name into a
+/// table-function call and defer identifier folding to the TF dispatcher —
+/// exactly like `semantic_view()` (FF-4), so every read TF normalizes uniformly
+/// at the catalog-read boundary. DROP / ALTER, which emit native catalog SQL
+/// with the name baked in (no later normalize opportunity), use the normalizing
+/// [`extract_name_only`] wrapper instead.
 ///
 /// `prefix_len` is the byte length of the already-matched prefix.
-fn extract_name_only(
+fn extract_raw_name_only(
     trimmed: &str,
     prefix_len: usize,
     trailing: Trailing,
@@ -127,8 +132,21 @@ fn extract_name_only(
             return Err(format!("Unexpected tokens after view name: '{rest}'"));
         }
     }
-    let name = normalize_view_name(raw_name).map_err(|e| format!("Invalid view name: {e}"))?;
-    Ok(name)
+    Ok(raw_name.to_string())
+}
+
+/// Extract and normalize the view name from a name-only DDL statement (DROP;
+/// ALTER uses [`Trailing::Allow`] since its sub-operation follows the name).
+/// Folds unquoted names to lowercase and reduces a qualified name to its bare
+/// last part at parse time — appropriate for the native-SQL emitters that bake
+/// the name in. Read-side rewrites use [`extract_raw_name_only`] instead.
+fn extract_name_only(
+    trimmed: &str,
+    prefix_len: usize,
+    trailing: Trailing,
+) -> Result<String, String> {
+    let raw = extract_raw_name_only(trimmed, prefix_len, trailing)?;
+    normalize_view_name(&raw).map_err(|e| format!("Invalid view name: {e}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -298,10 +316,16 @@ fn plan_ddl(query: &str) -> Result<RewriteAction, String> {
                 if_exists: kind == DdlKind::DropIfExists,
             })
         }
-        // Read-side name-only forms (DESCRIBE, SHOW COLUMNS IN SEMANTIC VIEW):
-        // run the read-side table function as-is.
+        // Read-side name-only forms (DESCRIBE, SHOW COLUMNS IN SEMANTIC VIEW).
+        // FF-4: embed the RAW name and let the TF dispatcher fold it, matching
+        // the other read TFs (`semantic_view`, `show_semantic_* IN`) which all
+        // normalize once at the catalog-read boundary. Normalizing here as well
+        // would double-fold a quoted mixed-case name (`"MyView"` → `myview`).
+        // The single-quote escape keeps the literal well-formed; the dispatcher
+        // reads the view via a prepared statement, so the raw name never reaches
+        // SQL text on the read side.
         DdlKind::Describe | DdlKind::ShowColumns => {
-            let name = extract_name_only(trimmed, plen, Trailing::Reject)?;
+            let name = extract_raw_name_only(trimmed, plen, Trailing::Reject)?;
             let safe_name = name.replace('\'', "''");
             Ok(RewriteAction::Passthrough(format!(
                 "SELECT * FROM {fn_name}('{safe_name}')"
@@ -1196,8 +1220,11 @@ mod tests {
             }
         );
 
+        // FF-4: DESCRIBE / SHOW COLUMNS now embed the RAW name and fold at the
+        // TF dispatcher (like `semantic_view`), so the rewrite carries 'SALES'
+        // verbatim; the dispatcher's normalize_view_name resolves it to 'sales'.
         let sql = passthrough_sql("DESCRIBE SEMANTIC VIEW SALES");
-        assert_eq!(sql, "SELECT * FROM describe_semantic_view('sales')");
+        assert_eq!(sql, "SELECT * FROM describe_semantic_view('SALES')");
 
         assert_eq!(
             extract_ddl_name("CREATE SEMANTIC VIEW Sales (body)").unwrap(),
@@ -3515,14 +3542,23 @@ $$"#;
 
         #[test]
         fn describe_with_quoted_fqn() {
+            // FF-4: the raw qualified name is embedded verbatim; the dispatcher's
+            // normalize_view_name reduces it to the bare 'v' at lookup time.
             let sql = passthrough_sql("DESCRIBE SEMANTIC VIEW \"memory\".\"main\".\"v\"");
-            assert_eq!(sql, "SELECT * FROM describe_semantic_view('v')");
+            assert_eq!(
+                sql,
+                "SELECT * FROM describe_semantic_view('\"memory\".\"main\".\"v\"')"
+            );
         }
 
         #[test]
         fn show_columns_with_quoted_fqn() {
+            // FF-4: raw qualified name embedded verbatim; dispatcher reduces to 'v'.
             let sql = passthrough_sql("SHOW COLUMNS IN SEMANTIC VIEW \"memory\".\"main\".\"v\"");
-            assert_eq!(sql, "SELECT * FROM show_columns_in_semantic_view('v')");
+            assert_eq!(
+                sql,
+                "SELECT * FROM show_columns_in_semantic_view('\"memory\".\"main\".\"v\"')"
+            );
         }
 
         #[test]

--- a/src/query/explain.rs
+++ b/src/query/explain.rs
@@ -233,7 +233,16 @@ pub unsafe extern "C" fn sv_explain_semantic_view_bind_rust(
             return 1_u8;
         }
 
-        let reader = CatalogReader::new(&borrowed, probe_catalog_table_present(&borrowed));
+        // FF-9: surface a probe-query failure as an error distinct from "no
+        // views" instead of silently folding it into absence.
+        let present = match probe_catalog_table_present(&borrowed) {
+            Ok(p) => p,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
+        let reader = CatalogReader::new(&borrowed, present);
         let json_str = match reader.lookup(&view_name) {
             Ok(Some(j)) => j,
             Ok(None) => {

--- a/src/query/table_function.rs
+++ b/src/query/table_function.rs
@@ -218,7 +218,16 @@ pub unsafe extern "C" fn sv_semantic_view_bind_rust(
             return 1_u8;
         }
 
-        let reader = CatalogReader::new(&borrowed, probe_catalog_table_present(&borrowed));
+        // FF-9: surface a probe-query failure as an error distinct from "no
+        // views" instead of silently folding it into absence.
+        let present = match probe_catalog_table_present(&borrowed) {
+            Ok(p) => p,
+            Err(e) => {
+                write_err(error_buf, error_buf_len, &e);
+                return 1_u8;
+            }
+        };
+        let reader = CatalogReader::new(&borrowed, present);
         let json_str = match reader.lookup(&view_name) {
             Ok(Some(j)) => j,
             Ok(None) => {

--- a/test/sql/TEST_LIST
+++ b/test/sql/TEST_LIST
@@ -12,6 +12,7 @@ test/sql/error_caret_drop.test
 test/sql/error_caret_multiline.test
 test/sql/error_caret_unicode.test
 test/sql/extension_reload.test
+test/sql/ff4_wave2_name_handling.test
 test/sql/identity_fact_passthrough.test
 test/sql/lru_removed_isolation.test
 test/sql/pa8_case_normalization.test

--- a/test/sql/ff4_wave2_name_handling.test
+++ b/test/sql/ff4_wave2_name_handling.test
@@ -1,0 +1,99 @@
+# FF-4 (code-review 2026-07-02): wave-2 read table functions
+# (DESCRIBE / SHOW COLUMNS / SHOW SEMANTIC {DIMENSIONS,...} IN /
+# ... FOR METRIC) now handle view-name identifiers exactly like
+# semantic_view():
+#   * unquoted names fold to lowercase, quoted names preserve case
+#     (folding happens once, at the TF dispatcher — see FF-4 in
+#     src/parse/mod.rs and the ddl/ dispatchers), and
+#   * a NULL positional argument raises a clear BinderException instead
+#     of the confusing "'NULL' does not exist".
+# Previously DESCRIBE / SHOW COLUMNS double-normalized (folding a quoted
+# mixed-case name to lowercase and failing the lookup), and the SHOW ... IN
+# forms skipped normalization entirely.
+
+require semantic_views
+
+statement ok
+CREATE TABLE ff4_orders (id INTEGER PRIMARY KEY, amount DECIMAL(10,2), region VARCHAR);
+
+statement ok
+INSERT INTO ff4_orders VALUES (1, 100.00, 'US'), (2, 50.00, 'EU');
+
+# Case-preserved (quoted) view name.
+statement ok
+CREATE SEMANTIC VIEW "MixedCaseView" AS
+  TABLES (o AS ff4_orders PRIMARY KEY (id))
+  DIMENSIONS (o.region AS o.region)
+  METRICS (o.total AS SUM(o.amount));
+
+query I
+SELECT name FROM list_semantic_views();
+----
+MixedCaseView
+
+# ============================================================
+# Quoted mixed-case name resolves through every wave-2 read form
+# (regression: DESCRIBE / SHOW COLUMNS previously double-folded to
+# 'mixedcaseview' and failed; SHOW ... IN kept the literal quotes).
+# ============================================================
+
+statement ok
+DESCRIBE SEMANTIC VIEW "MixedCaseView";
+
+statement ok
+SHOW COLUMNS IN SEMANTIC VIEW "MixedCaseView";
+
+statement ok
+SHOW SEMANTIC DIMENSIONS IN "MixedCaseView";
+
+statement ok
+SHOW SEMANTIC METRICS IN "MixedCaseView";
+
+statement ok
+SHOW SEMANTIC DIMENSIONS IN "MixedCaseView" FOR METRIC total;
+
+# Direct table-function calls fold identically to semantic_view(): the
+# quoted-in-string form preserves case and resolves.
+query I
+SELECT count(*) > 0 FROM describe_semantic_view('"MixedCaseView"');
+----
+true
+
+query I
+SELECT count(*) > 0 FROM show_columns_in_semantic_view('"MixedCaseView"');
+----
+true
+
+# An unquoted reference folds to lowercase and does NOT find the
+# case-preserved view — consistent with semantic_view().
+statement error
+DESCRIBE SEMANTIC VIEW MixedCaseView;
+----
+does not exist
+
+statement error
+SELECT * FROM describe_semantic_view('MixedCaseView');
+----
+does not exist
+
+# ============================================================
+# NULL positional argument raises a BinderException up front
+# ============================================================
+
+statement error
+SELECT * FROM describe_semantic_view(NULL);
+----
+view name is required
+
+statement error
+SELECT * FROM show_columns_in_semantic_view(NULL);
+----
+view name is required
+
+statement error
+SELECT * FROM show_semantic_dimensions_for_metric(NULL, 'total');
+----
+view name and metric name are required
+
+statement ok
+DROP SEMANTIC VIEW "MixedCaseView";

--- a/tests/parse_proptest.rs
+++ b/tests/parse_proptest.rs
@@ -374,15 +374,17 @@ proptest! {
         let extracted = extract_ddl_name(&ddl).unwrap();
         prop_assert_eq!(extracted, Some(content.clone()));
 
-        // The rewrite embeds the bare content: DROP carries the view name
-        // structurally; DESCRIBE passes through read-side SQL with the name
-        // single-quote-escaped.
+        // DROP carries the normalized view name structurally (quoted content is
+        // preserved by normalize_view_name). FF-4: DESCRIBE / SHOW COLUMNS now
+        // embed the RAW quoted name verbatim (single-quote-escaped) and defer
+        // folding to the TF dispatcher, matching every other read TF — so the
+        // passthrough SQL carries the quoted form, not the bare content.
         let action = rewrite_result(&ddl).unwrap();
         match action {
             RewriteAction::Drop { name, .. } => prop_assert_eq!(name, content.clone()),
             RewriteAction::Passthrough(sql) => {
                 let expected =
-                    format!("SELECT * FROM {fn_name}('{}')", content.replace('\'', "''"));
+                    format!("SELECT * FROM {fn_name}('{}')", quoted.replace('\'', "''"));
                 prop_assert_eq!(sql, expected);
             }
             other => prop_assert!(false, "unexpected rewrite action: {:?}", other),


### PR DESCRIPTION
Second of three small PRs from the R3 §4 "small FF/AR hardening batch". This one covers the wave-2 read-table-function argument cluster (FF-4) and the catalog-probe / unparseable-definition fallbacks (FF-9). AR-7 + AR-9 follow as the final PR.

## FF-4 — NULL-argument guards + uniform view-name normalization for wave-2 read TFs

Applies to `DESCRIBE`, `SHOW COLUMNS`, `SHOW SEMANTIC {DIMENSIONS,METRICS,FACTS} IN`, `... FOR METRIC`, and `SHOW SEMANTIC MATERIALIZATIONS`.

- **NULL guard (C++).** `sv_run_varchar_bind_with_name` and `sv_run_varchar_bool_bind_with_two_names` now throw a `BinderException` when a positional name argument is NULL, *before* `GetValue<std::string>()` — matching the `semantic_view()` binder. Previously `describe_semantic_view(NULL)` surfaced as the confusing `view 'NULL' does not exist`.
- **Uniform normalization (Rust).** The wave-2 dispatchers now route the view name through `normalize_view_name`, so quoted-identifier inputs resolve exactly like `semantic_view()` (unquoted folds to lowercase; quoted preserves case). The `SHOW … IN <view>` forms previously skipped normalization entirely (quoted names never resolved).
- **No double-fold.** `DESCRIBE` / `SHOW COLUMNS` already *pre-normalized* in the parser rewrite, so adding a dispatcher-side normalize would double-fold a quoted mixed-case name (`"MyView"` → `myview`) and break the lookup. The parser rewrites for these two now embed the **raw** name and defer folding to the dispatcher — the same shape every other read TF already uses. A new `extract_raw_name_only` splits the raw capture from the normalizing `extract_name_only`; DROP/ALTER keep parse-time folding because they emit native catalog SQL with no later normalize opportunity.

## FF-9 — defensive fallbacks no longer mask corruption

- **Probe errors distinct from absence.** `probe_catalog_table_present` now returns `Result<bool, String>`: `Ok(false)` is genuine absence (the Phase 63 read-only short-circuit is preserved — an attached read-only DB without a bootstrapped catalog still reads as empty), while `Err` is a probe-query failure that previously folded silently into "no views". Threaded through all read-side dispatchers (`?` in the `Result`-returning bodies, `match` in the hand-written `catch_unwind` dispatchers).
- **Surface unparseable definitions.** Named single-view SHOW paths now propagate a definition parse error instead of silently returning zero rows, while the cross-view `_all` listings stay tolerant and skip an unparseable row. `collect_entities` / `collect_mats` now take an already-parsed `&SemanticViewDefinition`, so the parse/skip-vs-propagate decision lives at the call site.

## Tests

Adds `test/sql/ff4_wave2_name_handling.test` (the trace found no existing coverage for quoted mixed-case names or NULL args through these TFs): quoted mixed-case resolution through every wave-2 form, direct-TF consistency with `semantic_view()`, unquoted-vs-quoted case-sensitivity, and the NULL-argument guards. Three parser unit/property assertions updated to reflect the raw-name embedding (the resolved view is unchanged — only the intermediate rewrite SQL string differs).

## Verification

- `just build` ✓
- `cargo test` ✓ (unit + proptest + doctests)
- `cargo fmt --check` ✓ / `cargo clippy -- -D warnings` ✓
- `just test-sql` — 66/66 ✓
- `just test-ducklake-ci` — 6/6 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqhLSyyvEeLBwUufXhdSiz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqhLSyyvEeLBwUufXhdSiz)_