### PR TITLE
R3 AR-7 + AR-9: retire dead OverrideContext FFI; hard-fail Win32 amalgamation patch miss

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -405,15 +405,25 @@ fn patch_duckdb_cpp_for_windows() -> String {
         #endif\n\n\
         #endif\n\n#else\n#include <sys/mman.h>";
 
+    // AR-9: a patch-2 miss is a HARD error, not a `cargo:warning`. This
+    // function only runs on Windows builds (build.rs `is_windows` guard), and
+    // the bundled amalgamation is version-pinned, so the marker is present for
+    // every version we ship against. If it moves (a DuckDB bump reshaping the
+    // <windows.h> block) the #undef is silently dropped and the second
+    // windows.h include re-defines the C++ identifier `interface` — the MSVC
+    // build then fails much later with opaque C2xxxx errors far from the cause.
+    // Fail the build here, at the patch site, with an actionable message.
     let content = if content.contains(patch2_before) {
         content.replace(patch2_before, patch2_after)
     } else {
-        println!(
-            "cargo:warning=duckdb.cpp Win32 patch 2 skipped: expected marker not found. \
-                  This may indicate a DuckDB version change — verify interface macro is not \
-                  causing build failures."
+        panic!(
+            "duckdb.cpp Win32 patch 2 FAILED: expected marker not found. The bundled \
+             DuckDB amalgamation changed shape (most likely a version bump), so this \
+             Windows-only #undef patch no longer applies. Left unpatched, the MSVC build \
+             fails later with opaque errors when the second <windows.h> include re-defines \
+             the C++ identifier `interface`. Update `patch2_before` in \
+             build.rs::patch_duckdb_cpp_for_windows to match the new amalgamation."
         );
-        content
     };
 
     // --- Patch 3: neutralize fmt's removed-MSVC-API reference ---
@@ -441,15 +451,21 @@ fn patch_duckdb_cpp_for_windows() -> String {
     let patch3_before = "#ifdef _SECURE_SCL\n// Make a checked iterator to avoid MSVC warnings.\ntemplate <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;";
     let patch3_after = "#if 0 // semantic-views patch: stdext::checked_array_iterator removed from modern MSVC STL — force fmt's portable raw-pointer path\n// Make a checked iterator to avoid MSVC warnings.\ntemplate <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;";
 
+    // AR-9: like patch 2, a patch-3 miss is a HARD error. Without it, MSVC
+    // takes fmt's `stdext::checked_array_iterator` branch — removed from modern
+    // MSVC STL — and fails with `error C2653: 'stdext' is not a namespace`.
+    // Fail loudly at the patch site rather than deep in the fmt headers.
     let content = if content.contains(patch3_before) {
         content.replace(patch3_before, patch3_after)
     } else {
-        println!(
-            "cargo:warning=duckdb.cpp Win32 patch 3 skipped: expected _SECURE_SCL marker not \
-                  found. This may indicate a DuckDB/fmt version change — verify \
-                  stdext::checked_array_iterator is not causing build failures."
+        panic!(
+            "duckdb.cpp Win32 patch 3 FAILED: expected _SECURE_SCL marker not found. The \
+             bundled DuckDB/fmt amalgamation changed shape (most likely a version bump), so \
+             this Windows-only fmt patch no longer applies. Left unpatched, MSVC selects \
+             fmt's removed `stdext::checked_array_iterator` and fails with `error C2653: \
+             'stdext' is not a class or namespace name`. Update `patch3_before` in \
+             build.rs::patch_duckdb_cpp_for_windows to match the new amalgamation."
         );
-        content
     };
 
     std::fs::write(&patched, content).expect("failed to write duckdb_patched.cpp to OUT_DIR");

--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -373,9 +373,10 @@ struct SvOwnedBuffer {
 // this used to carry an opaque Box<OverrideContext>* (rust_state), but the
 // OverrideContext was empty after Phase 65 Plan 06's H1 catalog_conn
 // retirement, so it now holds no state. It is kept purely as the
-// `dynamic_cast<SemanticViewsParserInfo *>` marker type that the
-// sv_parser_override / sv_parse_stub hooks use to confirm the parser_info is
-// ours.
+// `dynamic_cast<SemanticViewsParserInfo *>` marker type that `sv_parser_override`
+// uses to confirm the parser_info is ours. (`sv_parse_stub` no longer consults
+// parser_info at all — validation needs no per-DB state — so it ignores the
+// marker.)
 struct SemanticViewsParserInfo : public ParserExtensionInfo {};
 
 // ---------------------------------------------------------------------------

--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -67,14 +67,12 @@ extern "C" {
     //                error_out_len-1 bytes); *sql_out_ptr left untouched.
     //                (Phase 62: unused — Err branches now return rc=2 and
     //                let parse_function render caret via DISPLAY_EXTENSION_ERROR.)
-    //   2 = not ours: defer to default parser. Also used for null ctx_ptr.
+    //   2 = not ours: defer to default parser.
     //
-    // Phase 62: ctx_ptr is an opaque Box<OverrideContext>* produced by
-    // sv_make_override_context. It carries the catalog connection +
-    // is_file_backed flag for THIS database. The legacy db_token LRU
-    // lookup is gone (TECH-DEBT 20).
+    // AR-7: the opaque Box<OverrideContext>* context parameter was removed.
+    // It was empty after Phase 65 Plan 06 moved catalog pre-checks into the
+    // emitted SQL, so the hook no longer needs any per-DB state.
     uint8_t sv_parser_override_rust(
-        const void *ctx_ptr,
         const char *query_ptr, size_t query_len,
         char **sql_out_ptr, size_t *sql_out_len,
         char *error_out, size_t error_out_len);
@@ -93,7 +91,6 @@ extern "C" {
     //       setting reset by disable_peg_parser). error_buf gets an
     //       actionable hint; position_out gets 0.
     uint8_t sv_parse_function_rust(
-        const void *ctx_ptr,
         const char *query_ptr, size_t query_len,
         char *error_buf, size_t error_buf_len,
         uint32_t *position_out);
@@ -102,19 +99,6 @@ extern "C" {
     // Safe to call with a null pointer (no-op). ptr/len must be the exact
     // pair the Rust side returned.
     void sv_free_buffer(char *ptr, size_t len);
-
-    // Box<OverrideContext> ownership FFI. The Rust side allocates a
-    // Box<OverrideContext> (empty struct after Phase 65 Plan 06) and
-    // returns the leaked raw pointer. The C++ shim stashes the pointer
-    // inside SemanticViewsParserInfo::rust_state and hands it back to
-    // sv_parser_override_rust on every parse. ~SemanticViewsParserInfo
-    // calls sv_drop_override_context to free the Rust allocation.
-    //
-    // Plan 06: the struct carries no state — there is no longer a
-    // long-lived duckdb_connection to leak. The Box allocation itself
-    // is reclaimed cleanly by sv_drop_override_context.
-    void *sv_make_override_context();
-    void  sv_drop_override_context(void *ctx_ptr);
 
     // Phase 65 Plan 04 (Task 2 Step C) — Rust FFI bridge for the
     // `__sv_compute_create_from_yaml` helper TF. Reads file content from
@@ -385,24 +369,14 @@ struct SvOwnedBuffer {
     }
 };
 
-// Per-extension-load info struct attached to ParserExtension::parser_info.
-// Holds an opaque Box<OverrideContext>* (rust_state). After Phase 65
-// Plan 06's H1 catalog_conn retirement the OverrideContext is empty —
-// no per-DB state is carried — but the pointer round-trip is preserved
-// so the `dynamic_cast<SemanticViewsParserInfo *>` null-guard pattern
-// in sv_parser_override / sv_parse_stub stays byte-identical with the
-// pre-Plan-06 shape.
-struct SemanticViewsParserInfo : public ParserExtensionInfo {
-    void *rust_state;  // Box<OverrideContext>* opaque pointer (Rust-owned).
-    explicit SemanticViewsParserInfo(void *state) : rust_state(state) {}
-
-    ~SemanticViewsParserInfo() override {
-        if (rust_state) {
-            sv_drop_override_context(rust_state);
-            rust_state = nullptr;
-        }
-    }
-};
+// Per-extension-load marker attached to ParserExtension::parser_info. AR-7:
+// this used to carry an opaque Box<OverrideContext>* (rust_state), but the
+// OverrideContext was empty after Phase 65 Plan 06's H1 catalog_conn
+// retirement, so it now holds no state. It is kept purely as the
+// `dynamic_cast<SemanticViewsParserInfo *>` marker type that the
+// sv_parser_override / sv_parse_stub hooks use to confirm the parser_info is
+// ours.
+struct SemanticViewsParserInfo : public ParserExtensionInfo {};
 
 // ---------------------------------------------------------------------------
 // Parser-override hook: sv_parser_override
@@ -418,12 +392,12 @@ struct SemanticViewsParserInfo : public ParserExtensionInfo {
 static ParserOverrideResult sv_parser_override(
     ParserExtensionInfo *info, const string &query, ParserOptions &) {
 
-    // Identify the OverrideContext for this DB's catalog. info is the
-    // per-extension-load SemanticViewsParserInfo attached at registration
-    // time; if missing or its Rust state is null we cannot route correctly,
-    // so defer to the default parser.
+    // Confirm this is our parser_info. info is the per-extension-load
+    // SemanticViewsParserInfo attached at registration time; if it isn't ours
+    // (dynamic_cast fails) defer to the default parser. AR-7: there is no
+    // longer any per-DB Rust state to route through.
     auto *sv_info = dynamic_cast<SemanticViewsParserInfo *>(info);
-    if (!sv_info || !sv_info->rust_state) {
+    if (!sv_info) {
         return ParserOverrideResult();
     }
 
@@ -432,7 +406,6 @@ static ParserOverrideResult sv_parser_override(
     memset(error_buf, 0, sizeof(error_buf));
 
     uint8_t rc = sv_parser_override_rust(
-        sv_info->rust_state,
         query.c_str(), query.size(),
         &sql_buf.ptr, &sql_buf.len,
         error_buf, sizeof(error_buf));
@@ -484,19 +457,15 @@ static ParserOverrideResult sv_parser_override(
 //   2 — not ours: DISPLAY_ORIGINAL_ERROR (let the default parser's error stand)
 //   3 — valid-but-override-disabled: actionable hint; position=0
 static ParserExtensionParseResult sv_parse_stub(
-    ParserExtensionInfo *info, const string &query) {
-    auto *sv_info = dynamic_cast<SemanticViewsParserInfo *>(info);
-    // ctx_ptr is unused by sv_parse_function_rust today (validation does
-    // not need the catalog), so a null sv_info / rust_state is OK — we
-    // still get correct rc/error/position. Pass through whatever we have.
-    const void *ctx = (sv_info != nullptr) ? sv_info->rust_state : nullptr;
-
+    ParserExtensionInfo * /*info*/, const string &query) {
+    // AR-7: sv_parse_function_rust no longer takes a context pointer — the
+    // validation path never needed the catalog — so the SemanticViewsParserInfo
+    // marker is not consulted here.
     char error_buf[1024];
     std::memset(error_buf, 0, sizeof(error_buf));
     uint32_t position = UINT32_MAX;
 
     uint8_t rc = sv_parse_function_rust(
-        ctx,
         query.c_str(), query.size(),
         error_buf, sizeof(error_buf),
         &position);
@@ -2708,11 +2677,10 @@ extern "C" {
 // ---------------------------------------------------------------------------
 // Extracts DatabaseInstance& from the C API handle and registers the
 // parser_override hook on DBConfig. Phase 65 Plan 06: signature slimmed
-// to `(db_handle)` after H1 catalog_conn retirement. The
-// SemanticViewsParserInfo's rust_state still holds a Box<OverrideContext>*,
-// but the struct is empty — preserved for FFI shape compatibility with
-// sv_parser_override_rust's ctx_ptr parameter and the dynamic_cast
-// null-guard pattern in sv_parser_override / sv_parse_stub.
+// to `(db_handle)` after H1 catalog_conn retirement. AR-7: the
+// SemanticViewsParserInfo carries no Rust state anymore — it is just the
+// dynamic_cast marker used by sv_parser_override / sv_parse_stub to confirm
+// the parser_info is ours.
 //
 // Phase 65.1 Plan 10 (WR-06 D-12/D-13): the signature now carries the
 // trailing `(char *error_buf, size_t error_buf_len)` pair — matching the
@@ -2791,13 +2759,11 @@ extern "C" {
             // identical pointer value.
             //
             // CRITICAL: the entire `ParserExtension ext; ...; Register(...)` block
-            // — including the `SemanticViewsParserInfo` allocation AND the
-            // `sv_make_override_context()` allocation — must be guarded. The
-            // `OverrideContext` allocation is taken into the `SemanticViewsParserInfo`
-            // dtor for cleanup; on the skip path no ctor runs, so any allocation
-            // performed before the guard would leak unboundedly across repeated
-            // re-LOAD cycles (the precise leak shape WR-09 / CR-01 (65.1) was
-            // meant to fix).
+            // — including the `SemanticViewsParserInfo` allocation — must be
+            // guarded. `Register` unconditionally appends to
+            // `DBConfig::parser_extensions`; on the skip path re-registering
+            // would grow the list unboundedly across repeated re-LOAD cycles
+            // (the precise leak shape WR-09 / CR-01 (65.1) was meant to fix).
             //
             // The target is same-process repeat LOAD (e.g. a long-lived host
             // re-invoking `LOAD semantic_views` across sessions, or partial-failure
@@ -2820,29 +2786,16 @@ extern "C" {
             }
 
             if (!already_registered) {
-                // Phase 65.1 CR-01: allocation must live INSIDE the dedup
-                // guard. `sv_make_override_context()` returns a heap-allocated
-                // `Box<OverrideContext>` whose ownership is transferred to
-                // `SemanticViewsParserInfo` below; the dtor of that
-                // shared_ptr-managed object frees it via
-                // `sv_drop_override_context`. On the `already_registered`
-                // skip path the ctor never runs, so any allocation hoisted
-                // above this guard would be permanently leaked — one
-                // `OverrideContext` per redundant LOAD, unbounded over a
-                // long-lived host process. This is the exact leak shape
-                // WR-09 was supposed to fix; the original Plan 12 patch
-                // moved the allocation guard around the `Register` call but
-                // left the allocation itself outside.
-                void *rust_state = sv_make_override_context();
-                if (!rust_state) {
-                    if (error_buf != nullptr && error_buf_len > 0) {
-                        snprintf(error_buf, error_buf_len,
-                            "sv_register_parser_hooks: sv_make_override_context "
-                            "returned null");
-                    }
-                    return false;
-                }
-
+                // Phase 65.1 CR-01 / WR-09: the `ParserExtension ext; ...;
+                // Register(...)` block — including the `SemanticViewsParserInfo`
+                // allocation — must stay INSIDE the dedup guard.
+                // `ParserExtension::Register` unconditionally appends to
+                // `DBConfig::parser_extensions` (no dedup API), so on the
+                // `already_registered` skip path we must not Register (or
+                // allocate) again — otherwise every redundant LOAD grows the
+                // list by one entry, an unbounded soft leak over a long-lived
+                // host process. AR-7: there is no longer a separate
+                // `sv_make_override_context()` allocation to guard here.
                 ParserExtension ext;
                 ext.parser_override = sv_parser_override;
                 // Phase 62 Plan 03: parse_function is the error-reporting layer.
@@ -2861,7 +2814,7 @@ extern "C" {
                 // the SemanticViewsParserInfo and immediately upcasts) then hand
                 // it to duckdb::shared_ptr's std-interop constructor.
                 std::shared_ptr<ParserExtensionInfo> info_std(
-                    new SemanticViewsParserInfo(rust_state));
+                    new SemanticViewsParserInfo());
                 ext.parser_info = duckdb::shared_ptr<ParserExtensionInfo>(info_std);
                 ParserExtension::Register(config, ext);
 

--- a/cpp/src/shim.hpp
+++ b/cpp/src/shim.hpp
@@ -27,12 +27,11 @@ extern "C" {
 // `DBConfig` and system catalog.
 //
 // Phase 65 Plan 06: signature slimmed to `(db_handle)` after H1
-// catalog_conn retirement. The C++ shim attaches an empty
-// `OverrideContext` (allocated via `sv_make_override_context()`) to
-// `SemanticViewsParserInfo::rust_state` purely for FFI shape
-// compatibility with `sv_parser_override_rust`'s `ctx_ptr` parameter —
-// no long-lived `duckdb_connection` is owned by the extension after
-// this plan.
+// catalog_conn retirement. AR-7: the C++ shim attaches an empty
+// `SemanticViewsParserInfo` marker to `ParserExtension::parser_info`
+// solely so the parser hooks can confirm ownership via `dynamic_cast`;
+// no per-DB Rust state and no long-lived `duckdb_connection` is owned by
+// the extension.
 //
 // Phase 65.1 Plan 10 (WR-06 D-12/D-13): trailing
 // `(char *error_buf, size_t error_buf_len)` pair surfaces both the

--- a/fuzz/fuzz_targets/fuzz_parser_override_ffi.rs
+++ b/fuzz/fuzz_targets/fuzz_parser_override_ffi.rs
@@ -5,9 +5,8 @@
 //!
 //! `sv_parser_override_rust` (the actual FFI symbol) is gated behind the
 //! `extension` feature so it can't be called directly from this target.
-//! `rewrite_to_native_sql` (Phase 62) takes an `&OverrideContext` (a
-//! catalog-aware handle) and is also `extension`-gated; the catalog access
-//! cannot be exercised meaningfully without a live DuckDB.
+//! `rewrite_to_native_sql` is also `extension`-gated and its catalog-aware
+//! emission cannot be exercised meaningfully without a live DuckDB.
 //!
 //! What we DO fuzz here is the syntax-level Rust validation pipeline,
 //! which is what executes inside `parser_override` BEFORE any catalog

--- a/src/parse/ffi.rs
+++ b/src/parse/ffi.rs
@@ -213,13 +213,16 @@ pub unsafe extern "C" fn sv_parser_override_rust(
 ///     (`SET allow_parser_override_extension='FALLBACK'`); `position_out=0`
 ///     so the caret lands on the `C` of `CREATE` / `D` of `DROP`.
 ///
-/// The extension build re-runs the FULL rewrite (`rewrite_to_native_sql`,
-/// including catalog-aware existence checks in `rewrite_drop` / `rewrite_alter`)
-/// so parse_function reproduces the exact error message `parser_override` saw —
-/// including "semantic view '…' does not exist" for DROP-of-missing — with
-/// caret rendering attached. Unit tests (no `extension` feature) fall back to
-/// syntax-only validation via `plan_rewrite`, since the catalog-aware emission
-/// path is not linked there.
+/// The extension build re-runs the full rewrite (`rewrite_to_native_sql`); unit
+/// tests (no `extension` feature) fall back to syntax-only validation via
+/// `plan_rewrite`. Either way the purpose is to recover the `ParseError` message
+/// + caret position for a *structurally invalid* DDL statement (e.g. a malformed
+/// CREATE body), reproducing exactly what `parser_override` saw. Catalog-level
+/// conditions — DROP-of-missing, rename-into-an-existing-name — are NOT
+/// rewrite-time errors: `rewrite_drop` / `rewrite_alter_*` emit execution-time
+/// SQL guards, so a well-formed-but-catalog-invalid statement rewrites
+/// successfully (`Ok(Some)`) and its error surfaces when the emitted SQL runs,
+/// not here (such a statement maps to rc=3 if `parser_override` is inactive).
 ///
 /// # Safety
 ///
@@ -272,11 +275,13 @@ pub unsafe extern "C" fn sv_parse_function_rust(
             return 2_u8; // genuinely not ours
         }
 
-        // Recognised prefix — re-run validation. The extension build uses
-        // rewrite_to_native_sql so catalog-level errors (DROP-of-missing,
-        // ALTER-renaming-to-existing-name, …) are reproduced here just as
-        // parser_override saw them; unit tests fall back to syntax-only
-        // validation (see the two cfg'd definitions below).
+        // Recognised prefix — re-run validation to recover the ParseError
+        // wording + caret for a structurally-invalid statement, exactly as
+        // parser_override saw it. Catalog-level conditions (DROP-of-missing,
+        // rename collision) are execution-time SQL guards, not rewrite-time
+        // errors, so they rewrite to Ok(Some) here and are not reproduced.
+        // Unit tests fall back to syntax-only validation (see the two cfg'd
+        // definitions below).
         let result = run_validation_for_parse_function(query);
 
         match result {
@@ -324,9 +329,11 @@ pub unsafe extern "C" fn sv_parse_function_rust(
 }
 
 /// Re-run validation for the parse_function path. Mirrors what
-/// `sv_parser_override_rust` did at parse time: the catalog-aware rewrite
-/// (`rewrite_to_native_sql`) so catalog-level errors are reproduced with the
-/// same wording parser_override produced.
+/// `sv_parser_override_rust` did at parse time (`rewrite_to_native_sql`), so a
+/// structurally-invalid DDL statement surfaces the same `ParseError` wording +
+/// position that parser_override produced. Catalog-level errors (DROP-of-missing,
+/// rename collision) are enforced by guards in the *emitted* SQL at execution
+/// time, so they are not reproduced here — such statements return `Ok(Some(_))`.
 ///
 /// Returning `Ok(Some(_))` means "validation succeeded" — at the
 /// parse_function call site this can only happen when parser_override

--- a/src/parse/ffi.rs
+++ b/src/parse/ffi.rs
@@ -1,19 +1,25 @@
 //! FFI entry points for the semantic-view `parser_override` path (AR-1).
 //!
 //! These are the C-ABI symbols the C++ shim (`cpp/src/shim.cpp`) links
-//! against: the `OverrideContext` lifecycle (`sv_make_override_context` /
-//! `sv_drop_override_context`), the parser-override hook
-//! (`sv_parser_override_rust`), the parse-function validation hook
-//! (`sv_parse_function_rust`), and the output-buffer reclaimer
-//! (`sv_free_buffer`). The `run_validation_for_parse_function` bridge and the
-//! `publish_owned_sql` helper live here too.
+//! against: the parser-override hook (`sv_parser_override_rust`), the
+//! parse-function validation hook (`sv_parse_function_rust`), and the
+//! output-buffer reclaimer (`sv_free_buffer`). The
+//! `run_validation_for_parse_function` bridge and the `publish_owned_sql`
+//! helper live here too.
+//!
+//! AR-7: the empty `OverrideContext` lifecycle
+//! (`sv_make_override_context` / `sv_drop_override_context` + the opaque
+//! `ctx_ptr` threaded through the two hooks) was retired. It became a pure
+//! no-op after Phase 65 Plan 06 moved the catalog pre-checks into the
+//! emitted SQL, so the struct, its allocator/deallocator, and the
+//! `SemanticViewsParserInfo::rust_state` round-trip carried no state.
 //!
 //! All of this is `unsafe` C-boundary plumbing, isolated from the pure parse
 //! logic in the sibling modules. The hooks delegate to `plan_rewrite`
 //! (syntax) and `rewrite_to_native_sql` (catalog-aware emission); buffer
-//! handling goes through `crate::ffi_util`. `OverrideContext` and
-//! `sv_free_buffer` are re-exported from the parent module so
-//! `crate::parse::*` paths (and cross-module tests) resolve unchanged.
+//! handling goes through `crate::ffi_util`. `sv_free_buffer` is re-exported
+//! from the parent module so `crate::parse::*` paths (and cross-module tests)
+//! resolve unchanged.
 
 #[cfg(feature = "extension")]
 use super::rewrite_to_native_sql;
@@ -23,46 +29,18 @@ use super::{detect_ddl_kind, detect_near_miss, plan_rewrite};
 use crate::errors::ParseError;
 
 // ---------------------------------------------------------------------------
-// OverrideContext — Phase 65 Plan 06: empty struct (no state).
-// ---------------------------------------------------------------------------
-//
-// Pre-Plan-06 this struct carried a `CatalogReader` wrapping a long-lived
-// `duckdb_connection` allocated in `init_extension` (H1 catalog_conn). That
-// connection was used by `parser_override` rewrite paths (rewrite_drop,
-// rewrite_alter_rename, rewrite_alter_comment, emit_native_create_sql) to
-// run pre-check `catalog.exists()` queries before emitting native SQL with
-// friendly error wording.
-//
-// Phase 65 Plan 06 retires H1 catalog_conn entirely. The pre-check queries
-// are replaced with pure-SQL guards (`SELECT CASE WHEN NOT EXISTS / EXISTS
-// THEN error(...) ELSE TRUE END; <DML>`) that run on the caller's
-// connection in the same transaction as the DML — snapshot-consistent and
-// transactional by construction.
-//
-// The struct is preserved as a zero-sized type only because the FFI
-// surface (`sv_make_override_context` / `sv_drop_override_context` /
-// `SemanticViewsParserInfo::rust_state`) still exists. We could fully
-// retire the FFI entry points and `SemanticViewsParserInfo::rust_state`
-// in a future cleanup; keeping them around as no-ops simplifies the
-// diff and lets the C++ shim keep its `dynamic_cast<SemanticViewsParserInfo *>`
-// null-guard pattern unchanged.
-//
-// No Drop impl is needed — there is nothing to free except the Box
-// allocation itself, which is reclaimed automatically when
-// `sv_drop_override_context` reconstructs the Box via `Box::from_raw`
-// and drops it.
-
-/// Empty marker struct retained for FFI shape compatibility. Carries no
-/// state after Phase 65 Plan 06's H1 catalog_conn retirement.
-///
-/// Owned by the C++ shim as `Box<OverrideContext>` (one per
-/// `SemanticViewsParserInfo`, i.e. one per extension-LOAD-per-DB).
-#[cfg(feature = "extension")]
-pub struct OverrideContext {}
-
-// ---------------------------------------------------------------------------
 // FFI entry points (extension feature-gated)
 // ---------------------------------------------------------------------------
+//
+// AR-7 (was Phase 65 Plan 06): the `OverrideContext` struct and its
+// `sv_make_override_context` / `sv_drop_override_context` allocator pair are
+// gone. Pre-Plan-06 the context carried a `CatalogReader` over a long-lived
+// `duckdb_connection` used for `catalog.exists()` pre-checks; Plan 06 replaced
+// those with pure-SQL guards (`SELECT CASE WHEN [NOT] EXISTS THEN error(...)
+// ELSE TRUE END; <DML>`) that run on the caller's connection in the same
+// transaction. The struct then held no state, so the hooks no longer take an
+// opaque `ctx_ptr` and the C++ `SemanticViewsParserInfo` no longer round-trips
+// a `rust_state` pointer.
 
 // The error writer, buffer leak/reclaim, and publish helpers all live in
 // `crate::ffi_util` (ST-4 consolidation) — this module used to carry its
@@ -109,64 +87,11 @@ unsafe fn publish_owned_sql(sql: String, sql_out_ptr: *mut *mut u8, sql_out_len:
     crate::ffi_util::publish_owned_string(sql, sql_out_ptr, sql_out_len);
 }
 
-/// FFI entry point: construct a heap-boxed (empty) `OverrideContext` and
-/// return its raw pointer to the C++ shim. The struct is empty after
-/// Phase 65 Plan 06; we retain the FFI surface so the C++ shim's
-/// `SemanticViewsParserInfo::rust_state` round-trip and
-/// `dynamic_cast<...>` null-guard pattern stay byte-identical with the
-/// pre-Plan-06 shape.
-///
-/// # Safety
-///
-/// - The returned pointer must be passed to `sv_drop_override_context`
-///   exactly once when the C++ shim's `SemanticViewsParserInfo` is
-///   destroyed. Never call `sv_drop_override_context` more than once on
-///   the same pointer.
-#[cfg(feature = "extension")]
-#[no_mangle]
-pub unsafe extern "C" fn sv_make_override_context() -> *mut std::ffi::c_void {
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let ctx = Box::new(OverrideContext {});
-        Box::into_raw(ctx) as *mut std::ffi::c_void
-    }));
-    result.unwrap_or(std::ptr::null_mut())
-}
-
-/// FFI entry point: re-box and drop the `OverrideContext` allocated by
-/// `sv_make_override_context`. The Rust-side `Box` allocation is freed.
-///
-/// # Safety
-///
-/// - `ctx_ptr` must be a value previously returned by
-///   `sv_make_override_context`, or null.
-/// - Must not be called more than once on the same pointer (use-after-free).
-///
-/// Phase 65 Plan 06: `OverrideContext` is now an empty struct — there is
-/// no longer a duckdb_connection to leak. The Box allocation itself is
-/// reclaimed by the `Box::from_raw` + drop below.
-#[cfg(feature = "extension")]
-#[no_mangle]
-pub unsafe extern "C" fn sv_drop_override_context(ctx_ptr: *mut std::ffi::c_void) {
-    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        if ctx_ptr.is_null() {
-            return;
-        }
-        // Re-box and drop. The struct is now empty after Plan 06 — no
-        // long-lived duckdb_connection to leak.
-        let _ = Box::from_raw(ctx_ptr as *mut OverrideContext);
-    }));
-}
-
 /// FFI entry point for parser_override. The sole DDL entry point for the
 /// extension as of v0.8.0 — the legacy parse_function/parse_stub path was
 /// retired. Rewrites recognized semantic-view DDL into native SQL suitable
 /// for re-parsing through DuckDB's own parser and execution on the caller's
 /// connection.
-///
-/// Phase 62: takes an opaque `ctx_ptr` (a `Box<OverrideContext>*` produced
-/// by `sv_make_override_context`) instead of the legacy `db_token` LRU
-/// lookup — the override context now lives directly inside
-/// `SemanticViewsParserInfo` (see `cpp/src/shim.cpp`).
 ///
 /// Returns:
 ///   0 = success: heap-owned native SQL pointer + length written to
@@ -177,13 +102,11 @@ pub unsafe extern "C" fn sv_drop_override_context(ctx_ptr: *mut std::ffi::c_void
 ///       `error_out`. (Currently unused under FALLBACK_OVERRIDE; kept for
 ///       Phase 62 Plan 03 once `parse_function` returns to caret rendering.)
 ///   2 = not ours: defer to default parser. Used both for genuinely
-///       non-semantic SQL, for null `ctx_ptr`, and for the early-return on
-///       null/empty input or invalid UTF-8.
+///       non-semantic SQL and for the early-return on null/empty input or
+///       invalid UTF-8.
 ///
 /// # Safety
 ///
-/// - `ctx_ptr` must be a non-null pointer previously returned by
-///   `sv_make_override_context`, or null. Null returns rc=2.
 /// - `query_ptr` must point to bytes of length `query_len` (validated as
 ///   UTF-8 here; invalid UTF-8 returns 2 rather than triggering UB).
 /// - `sql_out_ptr` must point to a writable `*mut u8` slot, or be null.
@@ -192,7 +115,6 @@ pub unsafe extern "C" fn sv_drop_override_context(ctx_ptr: *mut std::ffi::c_void
 #[cfg(feature = "extension")]
 #[no_mangle]
 pub unsafe extern "C" fn sv_parser_override_rust(
-    ctx_ptr: *const std::ffi::c_void,
     query_ptr: *const u8,
     query_len: usize,
     sql_out_ptr: *mut *mut u8,
@@ -201,9 +123,6 @@ pub unsafe extern "C" fn sv_parser_override_rust(
     error_out_len: usize,
 ) -> u8 {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        if ctx_ptr.is_null() {
-            return 2_u8; // no context — defer
-        }
         if query_ptr.is_null() || query_len == 0 {
             return 2_u8; // not ours
         }
@@ -215,9 +134,7 @@ pub unsafe extern "C" fn sv_parser_override_rust(
             return 2; // not ours — defer
         };
 
-        let ctx = &*(ctx_ptr as *const OverrideContext);
-
-        match rewrite_to_native_sql(ctx, query) {
+        match rewrite_to_native_sql(query) {
             Ok(Some(sql)) => {
                 publish_owned_sql(sql, sql_out_ptr, sql_out_len);
                 0 // success — native SQL handed to caller
@@ -296,13 +213,13 @@ pub unsafe extern "C" fn sv_parser_override_rust(
 ///     (`SET allow_parser_override_extension='FALLBACK'`); `position_out=0`
 ///     so the caret lands on the `C` of `CREATE` / `D` of `DROP`.
 ///
-/// `ctx_ptr` is the same `Box<OverrideContext>*` handed to
-/// `sv_parser_override_rust`. When non-null we re-run the FULL rewrite
-/// (including catalog-aware existence checks in `rewrite_drop` /
-/// `rewrite_alter`); when null we fall back to syntax-only validation.
-/// This is what lets parse_function reproduce the same error message
-/// `parser_override` saw — including "semantic view '…' does not exist"
-/// for DROP-of-missing — with caret rendering attached.
+/// The extension build re-runs the FULL rewrite (`rewrite_to_native_sql`,
+/// including catalog-aware existence checks in `rewrite_drop` / `rewrite_alter`)
+/// so parse_function reproduces the exact error message `parser_override` saw —
+/// including "semantic view '…' does not exist" for DROP-of-missing — with
+/// caret rendering attached. Unit tests (no `extension` feature) fall back to
+/// syntax-only validation via `plan_rewrite`, since the catalog-aware emission
+/// path is not linked there.
 ///
 /// # Safety
 ///
@@ -316,7 +233,6 @@ pub unsafe extern "C" fn sv_parser_override_rust(
 #[cfg(any(feature = "extension", test))]
 #[no_mangle]
 pub unsafe extern "C" fn sv_parse_function_rust(
-    ctx_ptr: *const std::ffi::c_void,
     query_ptr: *const u8,
     query_len: usize,
     error_out: *mut u8,
@@ -356,12 +272,12 @@ pub unsafe extern "C" fn sv_parse_function_rust(
             return 2_u8; // genuinely not ours
         }
 
-        // Recognised prefix — re-run validation. When ctx_ptr is non-null
-        // (production path) use rewrite_to_native_sql so catalog-level
-        // errors (DROP-of-missing, ALTER-renaming-to-existing-name, …) are
-        // reproduced here just as parser_override saw them. When ctx_ptr
-        // is null (unit tests) fall back to syntax-only validation.
-        let result = run_validation_for_parse_function(ctx_ptr, query);
+        // Recognised prefix — re-run validation. The extension build uses
+        // rewrite_to_native_sql so catalog-level errors (DROP-of-missing,
+        // ALTER-renaming-to-existing-name, …) are reproduced here just as
+        // parser_override saw them; unit tests fall back to syntax-only
+        // validation (see the two cfg'd definitions below).
+        let result = run_validation_for_parse_function(query);
 
         match result {
             Ok(Some(_rewritten)) => {
@@ -408,36 +324,23 @@ pub unsafe extern "C" fn sv_parse_function_rust(
 }
 
 /// Re-run validation for the parse_function path. Mirrors what
-/// `sv_parser_override_rust` did at parse time: catalog-aware rewrite when a
-/// context is available, syntax-only validation when not (unit tests + the
-/// future case where the C++ shim has lost its rust_state).
+/// `sv_parser_override_rust` did at parse time: the catalog-aware rewrite
+/// (`rewrite_to_native_sql`) so catalog-level errors are reproduced with the
+/// same wording parser_override produced.
 ///
 /// Returning `Ok(Some(_))` means "validation succeeded" — at the
 /// parse_function call site this can only happen when parser_override
 /// itself didn't run, so the caller maps it to rc=3 (actionable hint).
 #[cfg(feature = "extension")]
-unsafe fn run_validation_for_parse_function(
-    ctx_ptr: *const std::ffi::c_void,
-    query: &str,
-) -> Result<Option<String>, ParseError> {
-    if ctx_ptr.is_null() {
-        // Syntax-only fallback (ctx lost). Only the Ok(Some)/Ok(None)/Err shape
-        // matters here — the caller discards the string — so plan without
-        // rendering any SQL.
-        return plan_rewrite(query).map(|opt| opt.map(|_| String::new()));
-    }
-    let ctx = &*(ctx_ptr as *const OverrideContext);
-    rewrite_to_native_sql(ctx, query)
+fn run_validation_for_parse_function(query: &str) -> Result<Option<String>, ParseError> {
+    rewrite_to_native_sql(query)
 }
 
 /// Test-only sibling of `run_validation_for_parse_function` — pure syntax
 /// validation. Under `cargo test` the `extension` feature is OFF (default
-/// features = bundled), so `rewrite_to_native_sql` is unavailable; ctx_ptr
-/// is always null in tests anyway.
+/// features = bundled), so `rewrite_to_native_sql` is unavailable; only the
+/// `Ok(Some)/Ok(None)/Err` shape matters (the caller discards the string).
 #[cfg(all(not(feature = "extension"), test))]
-unsafe fn run_validation_for_parse_function(
-    _ctx_ptr: *const std::ffi::c_void,
-    query: &str,
-) -> Result<Option<String>, ParseError> {
+fn run_validation_for_parse_function(query: &str) -> Result<Option<String>, ParseError> {
     plan_rewrite(query).map(|opt| opt.map(|_| String::new()))
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -36,12 +36,12 @@ pub(crate) use detect::{
 };
 
 mod ffi;
+#[cfg(feature = "extension")]
+pub use ffi::sv_free_buffer;
 #[cfg(test)]
 pub(crate) use ffi::sv_parse_function_rust;
 #[cfg(all(feature = "extension", test))]
-pub(crate) use ffi::{sv_drop_override_context, sv_make_override_context, sv_parser_override_rust};
-#[cfg(feature = "extension")]
-pub use ffi::{sv_free_buffer, OverrideContext};
+pub(crate) use ffi::sv_parser_override_rust;
 
 mod native_sql;
 #[cfg(feature = "extension")]
@@ -780,32 +780,13 @@ mod tests {
     }
 
     // ===================================================================
-    // Phase 65 Plan 06: OverrideContext is now an empty struct — no
-    // long-lived duckdb_connection is carried, so no Drop impl is
-    // needed beyond the default Box reclamation. The pre-Plan-06
-    // `override_context_drop_does_not_disconnect` sentinel test became
-    // moot (there is no inner pointer to disconnect) and was removed.
-    // The FFI round-trip + null-drop tests remain to pin the FFI
-    // shape contract.
+    // AR-7: the empty `OverrideContext` + `sv_make_override_context` /
+    // `sv_drop_override_context` lifecycle was retired (dead after Phase 65
+    // Plan 06 moved catalog pre-checks into the emitted SQL). The FFI
+    // round-trip / null-drop tests that pinned that shape were removed with
+    // it; `sv_parser_override_rust` / `sv_parse_function_rust` no longer take
+    // an opaque context pointer.
     // ===================================================================
-
-    #[cfg(feature = "extension")]
-    #[test]
-    fn sv_make_and_drop_override_context_round_trip() {
-        // FFI ctor allocates an empty Box<OverrideContext> and returns
-        // its raw pointer. The dtor reconstructs the Box and drops it.
-        let ptr = unsafe { sv_make_override_context() };
-        assert!(!ptr.is_null(), "ctor must return non-null for a valid Box");
-        unsafe { sv_drop_override_context(ptr) };
-    }
-
-    #[cfg(feature = "extension")]
-    #[test]
-    fn sv_drop_override_context_handles_null() {
-        // Defensive: null-pointer drop must be a no-op (matches the
-        // C++ shim's `if (rust_state) { ... }` guard pattern).
-        unsafe { sv_drop_override_context(std::ptr::null_mut()) };
-    }
 
     // ===================================================================
     // Phase 62 Plan 03 — sv_parse_function_rust rc=0/1/2/3 contract.
@@ -824,7 +805,6 @@ mod tests {
         let mut position: u32 = u32::MAX;
         let rc = unsafe {
             sv_parse_function_rust(
-                std::ptr::null(),
                 query.as_ptr(),
                 query.len(),
                 error_buf.as_mut_ptr(),
@@ -853,7 +833,6 @@ mod tests {
         let mut position: u32 = u32::MAX;
         let rc = unsafe {
             sv_parse_function_rust(
-                std::ptr::null(),
                 bad.as_ptr(),
                 4, // exclude trailing nul, just 4 invalid bytes
                 error_buf.as_mut_ptr(),
@@ -902,16 +881,12 @@ mod tests {
         // now returns rc=2 (defer) rather than synthesising a SELECT error('...')
         // statement via the deleted sql_throwing helper. parse_function picks
         // up the error reporting via caret rendering.
-        let ctx_ptr = unsafe { sv_make_override_context() };
-        assert!(!ctx_ptr.is_null());
-
         let query = "CREATE SEMANTIC VIEW v AS TABLSE (t);";
         let mut sql_ptr: *mut u8 = std::ptr::null_mut();
         let mut sql_len: usize = 0;
         let mut error_buf = vec![0_u8; 1024];
         let rc = unsafe {
             sv_parser_override_rust(
-                ctx_ptr as *const std::ffi::c_void,
                 query.as_ptr(),
                 query.len(),
                 &mut sql_ptr as *mut *mut u8,
@@ -929,8 +904,6 @@ mod tests {
             "no rewritten SQL must be published on rc=2"
         );
         assert_eq!(sql_len, 0, "no SQL length on rc=2");
-
-        unsafe { sv_drop_override_context(ctx_ptr) };
     }
 
     // ===================================================================

--- a/src/parse/native_sql.rs
+++ b/src/parse/native_sql.rs
@@ -10,13 +10,13 @@
 //! The SQL-string escape pair and the guard-SELECT builders are compiled
 //! unconditionally (no `extension` gate) so `cargo test` can exercise the
 //! escaping and guard wording without linking the loadable-extension stubs;
-//! the emission/rewrite functions that consume an `OverrideContext` are
-//! `extension`-gated. `rewrite_to_native_sql` is re-exported from the parent
-//! module for the FFI entry points; the escape/guard helpers are re-exported
-//! under `#[cfg(test)]` for the parent module's unit tests.
+//! the emission/rewrite functions are `extension`-gated. `rewrite_to_native_sql`
+//! is re-exported from the parent module for the FFI entry points; the
+//! escape/guard helpers are re-exported under `#[cfg(test)]` for the parent
+//! module's unit tests.
 
 #[cfg(feature = "extension")]
-use super::{plan_rewrite, OverrideContext, RewriteAction};
+use super::{plan_rewrite, RewriteAction};
 #[cfg(feature = "extension")]
 use crate::catalog::writes::{
     definitions_table_guard_select, existence_guard_select, rename_collision_guard_select,
@@ -59,14 +59,12 @@ use crate::ident::normalize_view_name;
 //       → `Ok(None)`; the C++ shim returns DISPLAY_ORIGINAL_ERROR and DuckDB's
 //         default parser handles it.
 //
-// CREATE/DROP/ALTER need a `CatalogReader` for existence checks; CREATE also
-// runs catalog-side queries during enrichment (PK lookup, LIMIT 0 type
-// inference, fact typing). Phase 62 attaches the `OverrideContext` directly
-// to the C++ `SemanticViewsParserInfo` via an opaque `Box`, so the rewriters
-// take `&OverrideContext` here instead of looking up by token. Under
-// `cargo test` (no extension feature) these code paths are excluded entirely
-// (this entry point itself is feature-gated; its sole caller —
-// `sv_parser_override_rust` — is `extension`-only).
+// AR-7: this used to take `&OverrideContext`, but that struct was empty after
+// Phase 65 Plan 06 moved CREATE/DROP/ALTER existence checks into the emitted
+// SQL (pure-SQL race guards on the caller's connection) — so the parameter was
+// dead and has been removed. Under `cargo test` (no extension feature) this
+// path is excluded entirely (this entry point is feature-gated; its sole
+// caller — `sv_parser_override_rust` — is `extension`-only).
 //
 // INVARIANT (AR-5) — purity / idempotence. This function MUST be a pure
 // function of `query` (and committed catalog state): for a given input it
@@ -82,10 +80,7 @@ use crate::ident::normalize_view_name;
 // nondeterminism here breaks that contract and must instead cache the first
 // run's `(query -> result)` rather than re-deriving it.
 #[cfg(feature = "extension")]
-pub(crate) fn rewrite_to_native_sql(
-    _ctx: &OverrideContext,
-    query: &str,
-) -> Result<Option<String>, ParseError> {
+pub(crate) fn rewrite_to_native_sql(query: &str) -> Result<Option<String>, ParseError> {
     let Some(action) = plan_rewrite(query)? else {
         return Ok(None);
     };
@@ -278,7 +273,7 @@ fn emit_native_create_sql(
 /// caller's connection -- matching `emit_native_create_sql`'s non-YAML
 /// behaviour byte-for-byte.
 ///
-/// Phase 65 Plan 06: pure-SQL, no `OverrideContext` consumed. The YAML
+/// Phase 65 Plan 06: pure-SQL, no extension-owned catalog connection. The YAML
 /// read happens inside the `__sv_compute_create_from_yaml` helper TF's
 /// bind callback (per-call `Connection(*context.db)`), not on any
 /// long-lived extension-owned connection.

--- a/tests/parser_hook_idempotent.rs
+++ b/tests/parser_hook_idempotent.rs
@@ -254,6 +254,23 @@ fn parser_hook_register_is_idempotent() {
          re-Register the parser extension. guard_idx={guard_idx}, \
          info_idx={info_idx}"
     );
+    // The `Register` call itself is the actual leak vector (it unconditionally
+    // appends to `DBConfig::parser_extensions`), so pin its call site behind
+    // the guard too — anchor on the executable statement, not a comment.
+    let register_idx = register_body
+        .find("ParserExtension::Register(config, ext)")
+        .expect(
+            "Plan 12 Task 1 — sv_register_parser_hooks must call \
+             `ParserExtension::Register(config, ext)` on the registration path",
+        );
+    assert!(
+        register_idx > guard_idx,
+        "Plan 12 Task 1 — `ParserExtension::Register(config, ext)` must appear \
+         AFTER the `if (!already_registered)` guard; on the skip path a second \
+         Register would append a duplicate parser-extension entry, the unbounded \
+         WR-09 soft leak this guard exists to prevent. guard_idx={guard_idx}, \
+         register_idx={register_idx}"
+    );
 
     // -----------------------------------------------------------------------
     // Assertion 6: cite of Phase 65.1 D-21 / WR-09 above the dedup loop.

--- a/tests/parser_hook_idempotent.rs
+++ b/tests/parser_hook_idempotent.rs
@@ -223,20 +223,18 @@ fn parser_hook_register_is_idempotent() {
     );
 
     // -----------------------------------------------------------------------
-    // Assertion 5: dedup check guards the full allocation chain — both the
-    //              `sv_make_override_context()` heap allocation AND the
-    //              `SemanticViewsParserInfo` allocation must live inside the
-    //              `if (!already_registered)` block. Either one outside the
-    //              guard leaks unboundedly per redundant LOAD.
+    // Assertion 5: the dedup check guards the `SemanticViewsParserInfo`
+    //              allocation + Register call. Both must live inside the
+    //              `if (!already_registered)` block: `ParserExtension::Register`
+    //              unconditionally appends to `DBConfig::parser_extensions`, so
+    //              the skip path must not re-Register (an unbounded soft leak of
+    //              parser_extensions entries) or leak a fresh parser_info
+    //              shared_ptr.
     //
-    // Phase 65.1 CR-01: the original Plan 12 patch put the
-    // `SemanticViewsParserInfo` allocation behind the guard but left
-    // `sv_make_override_context()` ABOVE it — so every redundant LOAD still
-    // leaked a fresh `Box<OverrideContext>` (one allocation per re-LOAD,
-    // unbounded). This assertion now pins BOTH allocations behind the guard.
-    //
-    // We verify this structurally by checking that both call sites appear
-    // AFTER the `if (!already_registered)` guard within the function body.
+    // AR-7: this assertion previously also pinned a `sv_make_override_context()`
+    // allocation ABOVE-vs-BELOW the guard (Phase 65.1 CR-01). That allocation
+    // was retired — the `OverrideContext` was empty — so only the
+    // `SemanticViewsParserInfo` allocation remains to guard.
     // -----------------------------------------------------------------------
     let guard_idx = register_body.find("if (!already_registered)").expect(
         "Plan 12 Task 1 — sv_register_parser_hooks must contain \
@@ -252,34 +250,9 @@ fn parser_hook_register_is_idempotent() {
         info_idx > guard_idx,
         "Plan 12 Task 1 — `new SemanticViewsParserInfo(...)` allocation \
          must appear AFTER the `if (!already_registered)` guard so the \
-         skip path does not leak a fresh parser_info shared_ptr. \
-         guard_idx={guard_idx}, info_idx={info_idx}"
-    );
-    // Search for the actual call site, not a comment mention. The
-    // assignment-prefixed needle `void *rust_state = sv_make_override_context(`
-    // discriminates the executable statement from any documentation
-    // references to the function above the guard.
-    let make_ctx_idx = register_body
-        .find("void *rust_state = sv_make_override_context(")
-        .expect(
-            "Phase 65.1 CR-01 — sv_register_parser_hooks must still call \
-             `void *rust_state = sv_make_override_context()` on the \
-             registration path; if you removed or renamed that \
-             assignment the parser_override hook has no Rust-side state \
-             to dispatch through. (We anchor on the assignment-prefixed \
-             form to discriminate from any comment references to the \
-             same function name.)",
-        );
-    assert!(
-        make_ctx_idx > guard_idx,
-        "Phase 65.1 CR-01 — `sv_make_override_context()` allocation must \
-         appear AFTER the `if (!already_registered)` guard. On the skip \
-         path no SemanticViewsParserInfo ctor runs to take ownership of \
-         the returned `Box<OverrideContext>`, so any allocation hoisted \
-         above the guard leaks one OverrideContext per redundant LOAD — \
-         unbounded across a long-lived host process. This is the precise \
-         leak shape WR-09 / CR-01 (65.1) was meant to fix. \
-         guard_idx={guard_idx}, make_ctx_idx={make_ctx_idx}"
+         skip path does not leak a fresh parser_info shared_ptr or \
+         re-Register the parser extension. guard_idx={guard_idx}, \
+         info_idx={info_idx}"
     );
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Third and final PR from the R3 §4 "small FF/AR hardening batch" — two architecture cleanups.

## AR-7 — retire the empty `OverrideContext` abstraction

Pre-Phase-65-Plan-06 the `OverrideContext` carried a `CatalogReader` over a long-lived `duckdb_connection`, used by the `parser_override` rewriters for `catalog.exists()` pre-checks. Plan 06 replaced those with pure-SQL race guards (`SELECT CASE WHEN [NOT] EXISTS THEN error(...) ELSE TRUE END; <DML>`) that run on the caller's connection in its transaction — leaving the struct stateless. It survived only "for FFI shape compatibility". This removes the whole dead lifecycle:

- **Rust** (`src/parse/ffi.rs`, `native_sql.rs`, `mod.rs`): deleted the `OverrideContext` struct and the `sv_make_override_context` / `sv_drop_override_context` allocator pair; dropped the opaque `ctx_ptr` parameter from `sv_parser_override_rust` and `sv_parse_function_rust`; dropped the unused `&OverrideContext` parameter from `rewrite_to_native_sql`; simplified `run_validation_for_parse_function` (extension build → `rewrite_to_native_sql`, test build → `plan_rewrite`, same as before, just without the always-non-null ctx branch).
- **C++** (`cpp/src/shim.cpp`, `shim.hpp`): removed `SemanticViewsParserInfo::rust_state` and the `sv_drop_override_context` dtor call; `SemanticViewsParserInfo` is now an empty marker kept purely for the `dynamic_cast` ownership check in the two hooks; removed the `sv_make_override_context()` allocation from registration. The WR-09 dedup guard still wraps the `Register` + `parser_info` allocation (the soft-leak fix is unchanged).
- The structural idempotence test (`tests/parser_hook_idempotent.rs`) was re-anchored off the removed allocation onto the still-valid invariant (the `SemanticViewsParserInfo` allocation + `Register` stay inside the `if (!already_registered)` guard).

Net: ~350 lines of dead cross-language plumbing removed. No behavior change — every path that reached the (empty) context now reaches nothing.

## AR-9 — hard-fail the Windows amalgamation patch-miss

`build.rs::patch_duckdb_cpp_for_windows` runs only on Windows builds and patches the version-pinned DuckDB amalgamation. Patch 2 (`#undef` the Win32 `interface` macro) and patch 3 (neutralize fmt's removed `stdext::checked_array_iterator`) are **required** for the MSVC build to compile. They previously soft-skipped with `cargo:warning` when their marker wasn't found, so a DuckDB bump that reshaped the amalgamation would silently drop the patch and surface much later as opaque `C2xxxx` errors far from the cause. Both now `panic!` at the patch site with an actionable message naming the marker to update. Patch 1 stays an expected no-op — its marker is legitimately absent on DuckDB ≥ 1.5.0.

## Verification

- `just build` ✓
- `cargo test` ✓ (incl. the re-anchored `parser_hook_register_is_idempotent`)
- `cargo fmt --check` ✓ / `cargo clippy -- -D warnings` ✓
- `just test-sql` — 66/66 ✓
- `just test-ducklake-ci` — 6/6 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqhLSyyvEeLBwUufXhdSiz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqhLSyyvEeLBwUufXhdSiz)_