### PR TITLE
R3 AR-3: self-describing read-path FFI wire format

### DIFF
--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -1000,6 +1000,52 @@ static std::string sv_read_string(const char *buf, size_t buf_len, size_t &offse
     return s;
 }
 
+// Self-describing wire-format schema tags (AR-3). Kept in sync with
+// `WIRE_TAG_VARCHAR` / `WIRE_TAG_BOOL` in `src/ddl/read_ffi.rs` — the Rust
+// serializers emit these, the parsers below assert them.
+static constexpr uint8_t SV_WIRE_VARCHAR = 1;
+static constexpr uint8_t SV_WIRE_BOOL = 2;
+
+// Read + validate the self-describing schema header (AR-3): `u32 col_count`
+// followed by one `u8` type tag per column. `expected_tags` is the column
+// layout the bind callback declared; a mismatch means the Rust dispatcher and
+// this C++ bind disagree on the result shape — fail loudly at the header
+// rather than misparse cell bytes downstream.
+//
+// An empty result set is serialized with `col_count == 0` and no tags (there
+// are no rows, hence no cells to misalign); the schema check is skipped in
+// that case and only the `row_count == 0` that follows is read by the caller.
+static void sv_read_wire_schema(const char *buf, size_t buf_len, size_t &offset,
+                                const std::vector<uint8_t> &expected_tags,
+                                const char *fn_name) {
+    uint32_t col_count = sv_read_u32_le(buf, buf_len, offset);
+    if (col_count == 0) {
+        return;  // empty result set — no schema to validate
+    }
+    if (col_count != expected_tags.size()) {
+        throw BinderException(
+            std::string(fn_name) + ": FFI wire-format column count mismatch (payload declares " +
+            std::to_string(col_count) + " columns, bind expects " +
+            std::to_string(expected_tags.size()) + ")");
+    }
+    if (offset + col_count > buf_len) {
+        throw BinderException(
+            std::string(fn_name) + ": FFI buffer truncated (expected " +
+            std::to_string(col_count) + " schema tags at offset " +
+            std::to_string(offset) + " of " + std::to_string(buf_len) + ")");
+    }
+    for (uint32_t c = 0; c < col_count; ++c) {
+        uint8_t tag = static_cast<uint8_t>(buf[offset + c]);
+        if (tag != expected_tags[c]) {
+            throw BinderException(
+                std::string(fn_name) + ": FFI wire-format column-type mismatch at column " +
+                std::to_string(c) + " (payload tag " + std::to_string(tag) +
+                ", bind expects " + std::to_string(expected_tags[c]) + ")");
+        }
+    }
+    offset += col_count;
+}
+
 static unique_ptr<FunctionData> sv_list_semantic_views_bind(
     ClientContext &context,
     TableFunctionBindInput & /*input*/,
@@ -1069,8 +1115,13 @@ static unique_ptr<FunctionData> sv_list_semantic_views_bind(
         return std::move(bd);
     }
 
-    // Parse the flat binary buffer into ListSemanticViewsRow entries.
+    // Parse the flat binary buffer into ListSemanticViewsRow entries. The
+    // self-describing schema header (AR-3) is validated first: this TF
+    // declares 6 VARCHAR columns (see return_types above).
     size_t offset = 0;
+    sv_read_wire_schema(
+        payload.ptr, payload.len, offset,
+        std::vector<uint8_t>(6, SV_WIRE_VARCHAR), "list_semantic_views");
     uint32_t row_count = sv_read_u32_le(payload.ptr, payload.len, offset);
     bd->rows.reserve(row_count);
     for (uint32_t r = 0; r < row_count; ++r) {
@@ -1184,6 +1235,10 @@ static void sv_parse_varchar_payload(const char *buf, size_t buf_len,
         return;  // rc=0 with null buffer == zero rows
     }
     size_t offset = 0;
+    // Validate the self-describing schema header (AR-3): all VARCHAR columns.
+    sv_read_wire_schema(buf, buf_len, offset,
+                        std::vector<uint8_t>(bd.expected_cols, SV_WIRE_VARCHAR),
+                        fn_name);
     uint32_t row_count = sv_read_u32_le(buf, buf_len, offset);
     bd.rows.reserve(row_count);
     for (uint32_t r = 0; r < row_count; ++r) {
@@ -1256,6 +1311,11 @@ static void sv_parse_varchar_bool_payload(const char *buf, size_t buf_len,
         return;
     }
     size_t offset = 0;
+    // Validate the self-describing schema header (AR-3): N VARCHAR columns
+    // followed by a single trailing BOOLEAN column.
+    std::vector<uint8_t> expected_tags(bd.expected_varchar_cols, SV_WIRE_VARCHAR);
+    expected_tags.push_back(SV_WIRE_BOOL);
+    sv_read_wire_schema(buf, buf_len, offset, expected_tags, fn_name);
     uint32_t row_count = sv_read_u32_le(buf, buf_len, offset);
     bd.rows.reserve(row_count);
     for (uint32_t r = 0; r < row_count; ++r) {

--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -972,10 +972,11 @@ struct ListSemanticViewsLocalState : public LocalTableFunctionState {
 // Helper: read a little-endian u32 from buf[offset..offset+4] and advance.
 // Throws BinderException on out-of-bounds — defensive against an FFI buffer
 // truncated by a panic or allocation failure on the Rust side.
-static uint32_t sv_read_u32_le(const char *buf, size_t buf_len, size_t &offset) {
+static uint32_t sv_read_u32_le(const char *buf, size_t buf_len, size_t &offset,
+                               const char *fn_name) {
     if (offset + 4 > buf_len) {
         throw BinderException(
-            "list_semantic_views: FFI buffer truncated (expected u32 at offset " +
+            std::string(fn_name) + ": FFI buffer truncated (expected u32 at offset " +
             std::to_string(offset) + " of " + std::to_string(buf_len) + ")");
     }
     auto p = reinterpret_cast<const unsigned char *>(buf + offset);
@@ -987,11 +988,12 @@ static uint32_t sv_read_u32_le(const char *buf, size_t buf_len, size_t &offset) 
     return v;
 }
 
-static std::string sv_read_string(const char *buf, size_t buf_len, size_t &offset) {
-    uint32_t len = sv_read_u32_le(buf, buf_len, offset);
+static std::string sv_read_string(const char *buf, size_t buf_len, size_t &offset,
+                                  const char *fn_name) {
+    uint32_t len = sv_read_u32_le(buf, buf_len, offset, fn_name);
     if (offset + len > buf_len) {
         throw BinderException(
-            "list_semantic_views: FFI buffer truncated (expected " +
+            std::string(fn_name) + ": FFI buffer truncated (expected " +
             std::to_string(len) + " string bytes at offset " +
             std::to_string(offset) + " of " + std::to_string(buf_len) + ")");
     }
@@ -1014,13 +1016,15 @@ static constexpr uint8_t SV_WIRE_BOOL = 2;
 //
 // An empty result set is serialized with `col_count == 0` and no tags (there
 // are no rows, hence no cells to misalign); the schema check is skipped in
-// that case and only the `row_count == 0` that follows is read by the caller.
-static void sv_read_wire_schema(const char *buf, size_t buf_len, size_t &offset,
-                                const std::vector<uint8_t> &expected_tags,
-                                const char *fn_name) {
-    uint32_t col_count = sv_read_u32_le(buf, buf_len, offset);
+// that case. Returns the `col_count` read from the header so the caller can
+// enforce the empty-encoding invariant (`col_count == 0` ⟺ `row_count == 0`)
+// against the `row_count` that follows.
+static uint32_t sv_read_wire_schema(const char *buf, size_t buf_len, size_t &offset,
+                                    const std::vector<uint8_t> &expected_tags,
+                                    const char *fn_name) {
+    uint32_t col_count = sv_read_u32_le(buf, buf_len, offset, fn_name);
     if (col_count == 0) {
-        return;  // empty result set — no schema to validate
+        return 0;  // empty result set — no schema to validate
     }
     if (col_count != expected_tags.size()) {
         throw BinderException(
@@ -1044,6 +1048,7 @@ static void sv_read_wire_schema(const char *buf, size_t buf_len, size_t &offset,
         }
     }
     offset += col_count;
+    return col_count;
 }
 
 static unique_ptr<FunctionData> sv_list_semantic_views_bind(
@@ -1119,19 +1124,26 @@ static unique_ptr<FunctionData> sv_list_semantic_views_bind(
     // self-describing schema header (AR-3) is validated first: this TF
     // declares 6 VARCHAR columns (see return_types above).
     size_t offset = 0;
-    sv_read_wire_schema(
+    const char *fn_name = "list_semantic_views";
+    uint32_t schema_cols = sv_read_wire_schema(
         payload.ptr, payload.len, offset,
-        std::vector<uint8_t>(6, SV_WIRE_VARCHAR), "list_semantic_views");
-    uint32_t row_count = sv_read_u32_le(payload.ptr, payload.len, offset);
+        std::vector<uint8_t>(6, SV_WIRE_VARCHAR), fn_name);
+    uint32_t row_count = sv_read_u32_le(payload.ptr, payload.len, offset, fn_name);
+    if (schema_cols == 0 && row_count != 0) {
+        throw BinderException(
+            std::string(fn_name) +
+            ": FFI wire-format empty-schema header (col_count == 0) with row_count == " +
+            std::to_string(row_count) + " > 0");
+    }
     bd->rows.reserve(row_count);
     for (uint32_t r = 0; r < row_count; ++r) {
         ListSemanticViewsRow row;
-        row.created_on    = sv_read_string(payload.ptr, payload.len, offset);
-        row.name          = sv_read_string(payload.ptr, payload.len, offset);
-        row.kind          = sv_read_string(payload.ptr, payload.len, offset);
-        row.database_name = sv_read_string(payload.ptr, payload.len, offset);
-        row.schema_name   = sv_read_string(payload.ptr, payload.len, offset);
-        row.comment       = sv_read_string(payload.ptr, payload.len, offset);
+        row.created_on    = sv_read_string(payload.ptr, payload.len, offset, fn_name);
+        row.name          = sv_read_string(payload.ptr, payload.len, offset, fn_name);
+        row.kind          = sv_read_string(payload.ptr, payload.len, offset, fn_name);
+        row.database_name = sv_read_string(payload.ptr, payload.len, offset, fn_name);
+        row.schema_name   = sv_read_string(payload.ptr, payload.len, offset, fn_name);
+        row.comment       = sv_read_string(payload.ptr, payload.len, offset, fn_name);
         bd->rows.push_back(std::move(row));
     }
 
@@ -1236,16 +1248,23 @@ static void sv_parse_varchar_payload(const char *buf, size_t buf_len,
     }
     size_t offset = 0;
     // Validate the self-describing schema header (AR-3): all VARCHAR columns.
-    sv_read_wire_schema(buf, buf_len, offset,
-                        std::vector<uint8_t>(bd.expected_cols, SV_WIRE_VARCHAR),
-                        fn_name);
-    uint32_t row_count = sv_read_u32_le(buf, buf_len, offset);
+    uint32_t schema_cols =
+        sv_read_wire_schema(buf, buf_len, offset,
+                            std::vector<uint8_t>(bd.expected_cols, SV_WIRE_VARCHAR),
+                            fn_name);
+    uint32_t row_count = sv_read_u32_le(buf, buf_len, offset, fn_name);
+    if (schema_cols == 0 && row_count != 0) {
+        throw BinderException(
+            std::string(fn_name) +
+            ": FFI wire-format empty-schema header (col_count == 0) with row_count == " +
+            std::to_string(row_count) + " > 0");
+    }
     bd.rows.reserve(row_count);
     for (uint32_t r = 0; r < row_count; ++r) {
         std::vector<std::string> row;
         row.reserve(bd.expected_cols);
         for (size_t c = 0; c < bd.expected_cols; ++c) {
-            row.push_back(sv_read_string(buf, buf_len, offset));
+            row.push_back(sv_read_string(buf, buf_len, offset, fn_name));
         }
         bd.rows.push_back(std::move(row));
     }
@@ -1315,14 +1334,20 @@ static void sv_parse_varchar_bool_payload(const char *buf, size_t buf_len,
     // followed by a single trailing BOOLEAN column.
     std::vector<uint8_t> expected_tags(bd.expected_varchar_cols, SV_WIRE_VARCHAR);
     expected_tags.push_back(SV_WIRE_BOOL);
-    sv_read_wire_schema(buf, buf_len, offset, expected_tags, fn_name);
-    uint32_t row_count = sv_read_u32_le(buf, buf_len, offset);
+    uint32_t schema_cols = sv_read_wire_schema(buf, buf_len, offset, expected_tags, fn_name);
+    uint32_t row_count = sv_read_u32_le(buf, buf_len, offset, fn_name);
+    if (schema_cols == 0 && row_count != 0) {
+        throw BinderException(
+            std::string(fn_name) +
+            ": FFI wire-format empty-schema header (col_count == 0) with row_count == " +
+            std::to_string(row_count) + " > 0");
+    }
     bd.rows.reserve(row_count);
     for (uint32_t r = 0; r < row_count; ++r) {
         std::vector<std::string> strs;
         strs.reserve(bd.expected_varchar_cols);
         for (size_t c = 0; c < bd.expected_varchar_cols; ++c) {
-            strs.push_back(sv_read_string(buf, buf_len, offset));
+            strs.push_back(sv_read_string(buf, buf_len, offset, fn_name));
         }
         if (offset + 1 > buf_len) {
             throw BinderException(
@@ -2550,15 +2575,15 @@ static unique_ptr<FunctionData> sv_semantic_view_bind(
 
     // Parse the schema + execution_sql wire format.
     size_t offset = 0;
-    uint32_t n_cols = sv_read_u32_le(payload.ptr, payload.len, offset);
+    uint32_t n_cols = sv_read_u32_le(payload.ptr, payload.len, offset, "semantic_view");
     bd->columns.reserve(n_cols);
     for (uint32_t i = 0; i < n_cols; ++i) {
         SemanticViewColumnInfo info;
-        info.name = sv_read_string(payload.ptr, payload.len, offset);
-        info.type_id = sv_read_u32_le(payload.ptr, payload.len, offset);
+        info.name = sv_read_string(payload.ptr, payload.len, offset, "semantic_view");
+        info.type_id = sv_read_u32_le(payload.ptr, payload.len, offset, "semantic_view");
         bd->columns.push_back(std::move(info));
     }
-    bd->execution_sql = sv_read_string(payload.ptr, payload.len, offset);
+    bd->execution_sql = sv_read_string(payload.ptr, payload.len, offset, "semantic_view");
     if (offset != payload.len) {
         throw BinderException(
             "semantic_view: FFI buffer has trailing bytes (consumed " +

--- a/src/ddl/read_ffi.rs
+++ b/src/ddl/read_ffi.rs
@@ -10,25 +10,41 @@
 //! # Wire format (length-prefixed binary, little-endian)
 //!
 //! ```text
+//! u32 col_count                 ─┐ self-describing schema header (AR-3)
+//! col_count × u8 type_tag        │ 1 = VARCHAR, 2 = BOOLEAN
+//!                               ─┘
 //! u32 row_count
 //! for each row:
-//!   for each column:
-//!     u32 byte_len
-//!     byte_len bytes (UTF-8 payload — VARCHAR cells)
+//!   for each column (in type_tag order):
+//!     VARCHAR: u32 byte_len + byte_len bytes (UTF-8 payload)
+//!     BOOLEAN: u8 (1 = TRUE, 0 = FALSE)
 //! ```
 //!
-//! Column layout (count + order + types) is implicit — agreed out-of-band
-//! between the Rust dispatcher and the matching C++ bind. The C++ side
-//! parses with `sv_read_u32_le` + `sv_read_string` helpers (already in
-//! `cpp/src/shim.cpp` from the Wave 0 spike) and emits rows into the
-//! DataChunk.
+//! ## Self-describing schema header (AR-3)
 //!
-//! # Variant: VARCHAR with a trailing BOOLEAN column
+//! The payload opens with a schema header — the column count followed by one
+//! type tag per column. This makes the column layout *self-describing* rather
+//! than agreed out-of-band: the C++ bind reads the header and asserts it
+//! against the column set it declared (count, and per-column VARCHAR/BOOLEAN),
+//! turning a former convention-guarded coupling (the reintroduction of
+//! TECH-DEBT #12's two-place schema agreement) into a machine-checked one. A
+//! dispatcher that emits a different column shape than its C++ bind expects
+//! now fails loudly at the header with a clear message, instead of desyncing
+//! silently or misparsing cell bytes. The C++ side parses with `sv_read_u32_le`
+//! + `sv_read_string` (+ `sv_read_wire_schema` for the header) in
+//! `cpp/src/shim.cpp`, then emits rows into the DataChunk.
 //!
-//! `show_semantic_dimensions_for_metric` returns 3 VARCHAR + 1 BOOLEAN.
-//! The wire-format encodes the BOOLEAN as a single trailing `u8` per row
-//! (1 = TRUE, 0 = FALSE) after all the VARCHAR cells. C++ side parses with
-//! `sv_read_u8` after the string reads.
+//! The header is emitted for every non-empty result. An empty result set
+//! (`row_count == 0`) writes `col_count == 0` and no tags: there are no cells
+//! to misalign, so the C++ side skips the schema assertion in that case.
+//!
+//! ## Variant: VARCHAR with a trailing BOOLEAN column
+//!
+//! `show_semantic_dimensions_for_metric` returns 3 VARCHAR + 1 BOOLEAN. Its
+//! schema header carries tags `[VARCHAR, VARCHAR, VARCHAR, BOOLEAN]`; each
+//! row emits the VARCHAR cells first, then a single trailing `u8` for the
+//! BOOLEAN (1 = TRUE, 0 = FALSE). C++ side parses with `sv_read_u8` after the
+//! string reads.
 //!
 //! # Borrow contract (critical)
 //!
@@ -188,20 +204,46 @@ fn wire_len(n: usize, what: &str) -> Result<u32, String> {
     u32::try_from(n).map_err(|_| format!("{what} ({n} bytes) exceeds the wire-format u32 limit"))
 }
 
+/// Column type tag in the self-describing schema header (AR-3). Kept in sync
+/// with the `SV_WIRE_VARCHAR` / `SV_WIRE_BOOL` constants in `cpp/src/shim.cpp`
+/// — the C++ bind asserts the received tags against the column set it declared.
+const WIRE_TAG_VARCHAR: u8 = 1;
+/// See [`WIRE_TAG_VARCHAR`].
+const WIRE_TAG_BOOL: u8 = 2;
+
+/// Write the self-describing schema header (AR-3): `u32 col_count` followed by
+/// one `u8` type tag per column. Emitting the header for every non-empty
+/// payload lets the C++ bind assert the column layout it declared matches what
+/// the dispatcher actually produced, rather than trusting an out-of-band
+/// agreement.
+fn write_wire_schema(buf: &mut Vec<u8>, tags: &[u8]) -> Result<(), String> {
+    let col_count = wire_len(tags.len(), "column count")?;
+    buf.extend_from_slice(&col_count.to_le_bytes());
+    buf.extend_from_slice(tags);
+    Ok(())
+}
+
 /// Serialize a vector of VARCHAR rows into the wire format described above.
 ///
 /// `rows` is a `Vec<Vec<String>>` where every inner Vec has the same length
 /// (number of columns). The function does NOT validate that — callers are
-/// expected to construct rectangular row sets.
+/// expected to construct rectangular row sets. The column count for the
+/// self-describing header (AR-3) is taken from the first row; an empty row set
+/// emits a zero-column header (the C++ side skips its schema assertion then).
 ///
 /// Returns `Err` if the row count or any cell length overflows the wire
 /// format's `u32` fields (see [`wire_len`]).
 pub fn serialize_varchar_rows(rows: &[Vec<String>]) -> Result<Vec<u8>, String> {
-    let cap = 4 + rows
-        .iter()
-        .map(|r| r.iter().map(|s| 4 + s.len()).sum::<usize>())
-        .sum::<usize>();
+    let n_cols = rows.first().map_or(0, Vec::len);
+    let cap = 4
+        + n_cols
+        + 4
+        + rows
+            .iter()
+            .map(|r| r.iter().map(|s| 4 + s.len()).sum::<usize>())
+            .sum::<usize>();
     let mut buf = Vec::with_capacity(cap);
+    write_wire_schema(&mut buf, &vec![WIRE_TAG_VARCHAR; n_cols])?;
     let row_count = wire_len(rows.len(), "row count")?;
     buf.extend_from_slice(&row_count.to_le_bytes());
     for row in rows {
@@ -218,14 +260,30 @@ pub fn serialize_varchar_rows(rows: &[Vec<String>]) -> Result<Vec<u8>, String> {
 /// emitted first (same shape as `serialize_varchar_rows`) followed by a
 /// single trailing `u8` (1 = TRUE, 0 = FALSE).
 ///
+/// The self-describing header (AR-3) carries the VARCHAR tags followed by a
+/// trailing BOOLEAN tag; the VARCHAR column count is taken from the first
+/// row's string vector. An empty row set emits a zero-column header.
+///
 /// Returns `Err` on the same overflow conditions as
 /// [`serialize_varchar_rows`].
 pub fn serialize_varchar_bool_rows(rows: &[(Vec<String>, bool)]) -> Result<Vec<u8>, String> {
-    let cap = 4 + rows
-        .iter()
-        .map(|(strs, _)| strs.iter().map(|s| 4 + s.len()).sum::<usize>() + 1)
-        .sum::<usize>();
+    let n_varchar = rows.first().map_or(0, |(strs, _)| strs.len());
+    let cap = 4
+        + (n_varchar + 1)
+        + 4
+        + rows
+            .iter()
+            .map(|(strs, _)| strs.iter().map(|s| 4 + s.len()).sum::<usize>() + 1)
+            .sum::<usize>();
     let mut buf = Vec::with_capacity(cap);
+    if rows.is_empty() {
+        // No rows → zero-column header (C++ skips the schema assertion).
+        write_wire_schema(&mut buf, &[])?;
+    } else {
+        let mut tags = vec![WIRE_TAG_VARCHAR; n_varchar];
+        tags.push(WIRE_TAG_BOOL);
+        write_wire_schema(&mut buf, &tags)?;
+    }
     let row_count = wire_len(rows.len(), "row count")?;
     buf.extend_from_slice(&row_count.to_le_bytes());
     for (strs, b) in rows {
@@ -349,15 +407,25 @@ mod tests {
 
     #[test]
     fn serialize_empty_row_set() {
+        // Empty result → zero-column schema header, then row_count = 0.
         let buf = serialize_varchar_rows(&[]).unwrap();
-        assert_eq!(buf, vec![0, 0, 0, 0]);
+        assert_eq!(
+            buf,
+            vec![
+                0, 0, 0, 0, // col_count = 0 (no tags follow)
+                0, 0, 0, 0, // row_count = 0
+            ]
+        );
     }
 
     #[test]
     fn serialize_single_row() {
         let rows = vec![vec!["a".to_string(), "bc".to_string()]];
         let buf = serialize_varchar_rows(&rows).unwrap();
+        #[rustfmt::skip]
         let expected: Vec<u8> = vec![
+            2, 0, 0, 0, // col_count = 2
+            WIRE_TAG_VARCHAR, WIRE_TAG_VARCHAR, // tags: [VARCHAR, VARCHAR]
             1, 0, 0, 0, // row_count = 1
             1, 0, 0, 0,    // len("a") = 1
             b'a', // "a"
@@ -374,11 +442,21 @@ mod tests {
             (vec!["y".to_string()], false),
         ];
         let buf = serialize_varchar_bool_rows(&rows).unwrap();
+        #[rustfmt::skip]
         let expected: Vec<u8> = vec![
+            2, 0, 0, 0, // col_count = 2 (1 VARCHAR + trailing BOOL)
+            WIRE_TAG_VARCHAR, WIRE_TAG_BOOL, // tags: [VARCHAR, BOOL]
             2, 0, 0, 0, // row_count = 2
             1, 0, 0, 0, b'x', 1, // ("x", true)
             1, 0, 0, 0, b'y', 0, // ("y", false)
         ];
         assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn serialize_bool_empty_row_set() {
+        // Empty bool-variant result → zero-column header, then row_count = 0.
+        let buf = serialize_varchar_bool_rows(&[]).unwrap();
+        assert_eq!(buf, vec![0, 0, 0, 0, 0, 0, 0, 0]);
     }
 }

--- a/src/ddl/read_ffi.rs
+++ b/src/ddl/read_ffi.rs
@@ -225,16 +225,23 @@ fn write_wire_schema(buf: &mut Vec<u8>, tags: &[u8]) -> Result<(), String> {
 
 /// Serialize a vector of VARCHAR rows into the wire format described above.
 ///
-/// `rows` is a `Vec<Vec<String>>` where every inner Vec has the same length
-/// (number of columns). The function does NOT validate that — callers are
-/// expected to construct rectangular row sets. The column count for the
-/// self-describing header (AR-3) is taken from the first row; an empty row set
-/// emits a zero-column header (the C++ side skips its schema assertion then).
+/// `rows` is a `Vec<Vec<String>>` where every inner Vec must have the same
+/// length (number of columns). The column count for the self-describing header
+/// (AR-3) is taken from the first row; an empty row set emits a zero-column
+/// header (the C++ side skips its schema assertion then). A ragged row set is
+/// rejected: the header would otherwise advertise the first row's column count
+/// while the payload bytes carry a different one, desyncing the C++ parser.
 ///
-/// Returns `Err` if the row count or any cell length overflows the wire
-/// format's `u32` fields (see [`wire_len`]).
+/// Returns `Err` if the rows are non-rectangular, or if the row count or any
+/// cell length overflows the wire format's `u32` fields (see [`wire_len`]).
 pub fn serialize_varchar_rows(rows: &[Vec<String>]) -> Result<Vec<u8>, String> {
     let n_cols = rows.first().map_or(0, Vec::len);
+    if let Some(bad) = rows.iter().position(|r| r.len() != n_cols) {
+        return Err(format!(
+            "non-rectangular row set: row {bad} has {} columns, expected {n_cols}",
+            rows[bad].len()
+        ));
+    }
     let cap = 4
         + n_cols
         + 4
@@ -262,12 +269,21 @@ pub fn serialize_varchar_rows(rows: &[Vec<String>]) -> Result<Vec<u8>, String> {
 ///
 /// The self-describing header (AR-3) carries the VARCHAR tags followed by a
 /// trailing BOOLEAN tag; the VARCHAR column count is taken from the first
-/// row's string vector. An empty row set emits a zero-column header.
+/// row's string vector. An empty row set emits a zero-column header. A ragged
+/// row set (rows whose VARCHAR-cell counts differ) is rejected for the same
+/// reason as [`serialize_varchar_rows`] — the header would disagree with the
+/// payload bytes.
 ///
-/// Returns `Err` on the same overflow conditions as
+/// Returns `Err` on non-rectangular rows or the same overflow conditions as
 /// [`serialize_varchar_rows`].
 pub fn serialize_varchar_bool_rows(rows: &[(Vec<String>, bool)]) -> Result<Vec<u8>, String> {
     let n_varchar = rows.first().map_or(0, |(strs, _)| strs.len());
+    if let Some(bad) = rows.iter().position(|(strs, _)| strs.len() != n_varchar) {
+        return Err(format!(
+            "non-rectangular row set: row {bad} has {} VARCHAR columns, expected {n_varchar}",
+            rows[bad].0.len()
+        ));
+    }
     let cap = 4
         + (n_varchar + 1)
         + 4
@@ -458,5 +474,29 @@ mod tests {
         // Empty bool-variant result → zero-column header, then row_count = 0.
         let buf = serialize_varchar_bool_rows(&[]).unwrap();
         assert_eq!(buf, vec![0, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn serialize_varchar_rows_rejects_ragged() {
+        // Second row has a different column count than the first — the schema
+        // header (derived from row 0) would disagree with the payload bytes.
+        let rows = vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["c".to_string()],
+        ];
+        let err = serialize_varchar_rows(&rows).unwrap_err();
+        assert!(err.contains("non-rectangular"), "unexpected error: {err}");
+        assert!(err.contains("row 1"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn serialize_varchar_bool_rows_rejects_ragged() {
+        let rows = vec![
+            (vec!["a".to_string(), "b".to_string()], true),
+            (vec!["c".to_string()], false),
+        ];
+        let err = serialize_varchar_bool_rows(&rows).unwrap_err();
+        assert!(err.contains("non-rectangular"), "unexpected error: {err}");
+        assert!(err.contains("row 1"), "unexpected error: {err}");
     }
 }


### PR DESCRIPTION
## Summary

Phase R3 item **AR-3** from the 2026-07-02 code review (`_notes/code-review-2026-07-02.md` §3.7 / §4 R3.5).

The read-path table functions serialize result rows from the Rust dispatcher to the C++ bind over a length-prefixed binary format. Its column layout — count, order, and types — was **implicit**, agreed out-of-band between each Rust dispatcher and its matching C++ bind (`src/ddl/read_ffi.rs:20-24`). That is the same two-place schema coupling `TECH-DEBT #12` documented for the retired pipeline, reintroduced by the Phase 65 read-path migration without a machine check: a dispatcher that emitted a different column shape than its bind declared would desync silently or misparse cell bytes.

This makes the format **self-describing**. Each non-empty payload now opens with a schema header — `u32 col_count` followed by one `u8` type tag per column (`1 = VARCHAR`, `2 = BOOLEAN`). The C++ bind reads the header and asserts it against the column set it declared (count and per-column type), failing loudly with a clear `BinderException` on any mismatch instead of guessing — converting a convention-guarded invariant into a machine-checked one, in the same spirit as the connection-lifecycle newtype guards.

The `semantic_view()` query payload was already self-describing (it carries `n_cols` + per-column `type_id`); this closes the gap for the VARCHAR / VARCHAR+BOOL read emitters that back the 12 `list_*` / `show_*` / `describe_` / `explain_` table functions.

## Wire format

```text
u32 col_count                 ─┐ self-describing schema header (AR-3)
col_count × u8 type_tag        │ 1 = VARCHAR, 2 = BOOLEAN
                              ─┘
u32 row_count
for each row, per column (in tag order):
  VARCHAR: u32 byte_len + byte_len bytes (UTF-8)
  BOOLEAN: u8 (1 = TRUE, 0 = FALSE)
```

An empty result set writes `col_count == 0` and no tags; with no rows there are no cells to misalign, so the C++ side skips the schema assertion in that case and reads only the `row_count == 0` that follows.

## Changes

- **`src/ddl/read_ffi.rs`** — emit the schema header in `serialize_varchar_rows` and `serialize_varchar_bool_rows` (`WIRE_TAG_VARCHAR` / `WIRE_TAG_BOOL`); module doc rewritten; byte-layout unit tests updated for the header, plus an empty-bool-variant case.
- **`cpp/src/shim.cpp`** — `sv_read_wire_schema` helper + `SV_WIRE_VARCHAR` / `SV_WIRE_BOOL` constants; header validated in the `list_semantic_views` bind and in both shared `varchar` / `varchar+bool` payload parsers.

The dispatcher call sites are untouched — the column count is derived from the row data, so only the two serializers and the three C++ readers change.

## Testing

- `cargo test` (bundled features) — green
- `read_ffi` byte-layout unit tests under `--features extension` — 4 passed
- Full `just test-sql` suite (67 files) — 0 failed; exercises the serialize → C++ parse round-trip end-to-end for every read TF

Held for review — not auto-merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DqhLSyyvEeLBwUufXhdSiz)_