### PR TITLE
Extension FFI clippy hygiene + CI gate

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -41,6 +41,14 @@ jobs:
       - name: Clippy (pedantic lints, deny warnings)
         run: cargo clippy -- -D warnings
 
+      # Also lint the `extension`-gated FFI layer, which the default-feature
+      # clippy above never compiles. SV_SKIP_CPP_BUILD makes build.rs skip the
+      # ~25 MB DuckDB amalgamation + C++ shim compile: clippy only type-checks
+      # (never links the cdylib), so the C++ half is irrelevant here and the
+      # step needs no amalgamation download.
+      - name: Clippy (extension feature, deny warnings)
+        run: SV_SKIP_CPP_BUILD=1 cargo clippy --no-default-features --features extension -- -D warnings
+
       - name: cargo-deny (licenses + advisories)
         uses: EmbarkStudios/cargo-deny-action@v2
 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -238,6 +238,16 @@ The `Coverage check (80% minimum)` job in `CodeQuality.yml` runs `cargo llvm-cov
 
 Net: treat the 80% figure as a floor on the bundled core's line coverage, not as end-to-end coverage of the shipped extension.
 
+### Linting the extension-gated FFI layer
+
+`cargo clippy` (and the `Clippy (pedantic lints, deny warnings)` CI step) compiles the **default** feature set, so it never lints the `#[cfg(feature = "extension")]` FFI modules. A second CI step, `Clippy (extension feature, deny warnings)`, closes that gap:
+
+```bash
+SV_SKIP_CPP_BUILD=1 cargo clippy --no-default-features --features extension -- -D warnings
+```
+
+`SV_SKIP_CPP_BUILD` makes `build.rs` skip the ~25 MB DuckDB amalgamation + C++ shim compile. Clippy only type-checks (it never links the final `cdylib`), so the C++ half is irrelevant and the check needs no amalgamation download — it runs in seconds. Use the same command locally before touching any FFI (`src/query/{table_function,explain}.rs`, `src/ddl/*_ffi.rs`, `src/parse/ffi.rs`) code. Do **not** set `SV_SKIP_CPP_BUILD` for a real `just build` — the extension won't link without the C++ shim.
+
 ### DuckLake/Iceberg Tests
 
 The DuckLake integration test requires one-time setup:

--- a/build.rs
+++ b/build.rs
@@ -190,6 +190,21 @@ fn main() {
         return;
     }
 
+    // SV_SKIP_CPP_BUILD lets `cargo clippy`/`cargo check --features extension`
+    // type-check the extension-gated Rust WITHOUT compiling the ~25 MB DuckDB
+    // amalgamation + C++ shim (a ~10-min cc build). Analysis-only cargo modes
+    // never link the final cdylib, so the missing DuckDB symbols and link
+    // directives don't matter — this is purely to make linting the FFI layer
+    // fast (locally and in CI) and does NOT produce a loadable extension.
+    // A real `cargo build --features extension` must leave this unset.
+    if std::env::var("SV_SKIP_CPP_BUILD").is_ok() {
+        println!(
+            "cargo:warning=SV_SKIP_CPP_BUILD set: skipping DuckDB amalgamation + C++ shim compile \
+             (analysis-only; the resulting artifact will NOT link/load as an extension)"
+        );
+        return;
+    }
+
     // Compile the DuckDB amalgamation source + C++ shim.
     // duckdb.cpp provides all DuckDB C++ symbol definitions (constructors, RTTI,
     // vtables) so the shim can use ParserExtension, TableFunction, etc. without

--- a/build.rs
+++ b/build.rs
@@ -182,6 +182,12 @@ fn main() {
     if std::path::Path::new("cpp/include/duckdb.cpp").exists() {
         println!("cargo:rerun-if-changed=cpp/include/duckdb.cpp");
     }
+    // Toggling SV_SKIP_CPP_BUILD flips whether the C++ shim/amalgamation is
+    // compiled below, so it must invalidate the build-script cache. Without
+    // this, a `cargo build --features extension` right after a
+    // `SV_SKIP_CPP_BUILD=1 cargo clippy` could reuse the skipped output and
+    // link against a never-built shim.
+    println!("cargo:rerun-if-env-changed=SV_SKIP_CPP_BUILD");
 
     // Only configure C++ compilation and symbol visibility when building the loadable
     // extension binary. CARGO_FEATURE_EXTENSION is set by Cargo when `--features extension`

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -245,6 +245,7 @@ mod reader {
         /// (the BORROW contract documented at module scope of
         /// `src/ddl/read_ffi.rs`). The `'a` lifetime parameter prevents safe
         /// code from moving the reader past that scope.
+        #[must_use]
         pub fn new(borrowed: &'a BorrowedConnection, catalog_table_present: bool) -> Self {
             Self {
                 conn: borrowed.as_raw(),
@@ -253,6 +254,7 @@ mod reader {
             }
         }
 
+        #[must_use]
         pub fn raw(&self) -> ffi::duckdb_connection {
             self.conn
         }
@@ -314,7 +316,7 @@ mod reader {
     impl PreparedStmt {
         unsafe fn prepare(conn: ffi::duckdb_connection, sql: &CStr) -> Result<Self, String> {
             let mut ptr: ffi::duckdb_prepared_statement = std::ptr::null_mut();
-            let rc = ffi::duckdb_prepare(conn, sql.as_ptr(), &mut ptr);
+            let rc = ffi::duckdb_prepare(conn, sql.as_ptr(), &raw mut ptr);
             if rc != ffi::DuckDBSuccess {
                 let err = ffi::duckdb_prepare_error(ptr);
                 let msg = if err.is_null() {
@@ -322,7 +324,7 @@ mod reader {
                 } else {
                     CStr::from_ptr(err).to_string_lossy().into_owned()
                 };
-                ffi::duckdb_destroy_prepare(&mut ptr);
+                ffi::duckdb_destroy_prepare(&raw mut ptr);
                 return Err(msg);
             }
             Ok(Self { ptr })
@@ -335,7 +337,7 @@ mod reader {
 
     impl Drop for PreparedStmt {
         fn drop(&mut self) {
-            unsafe { ffi::duckdb_destroy_prepare(&mut self.ptr) };
+            unsafe { ffi::duckdb_destroy_prepare(&raw mut self.ptr) };
         }
     }
 

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -437,7 +437,9 @@ mod reader {
         }
 
         let row_count = ffi::duckdb_row_count(result.raw_mut());
-        let mut out = Vec::with_capacity(row_count as usize);
+        // Capacity hint only; `unwrap_or(0)` keeps it correct (never truncating)
+        // on 32-bit targets where idx_t (u64) may exceed usize.
+        let mut out = Vec::with_capacity(usize::try_from(row_count).unwrap_or(0));
         for r in 0..row_count {
             let name = read_column_string(result.raw_mut(), 0, r).unwrap_or_default();
             let def = read_column_string(result.raw_mut(), 1, r).unwrap_or_default();
@@ -463,7 +465,9 @@ mod reader {
         }
 
         let row_count = ffi::duckdb_row_count(result.raw_mut());
-        let mut out = Vec::with_capacity(row_count as usize);
+        // Capacity hint only; `unwrap_or(0)` keeps it correct (never truncating)
+        // on 32-bit targets where idx_t (u64) may exceed usize.
+        let mut out = Vec::with_capacity(usize::try_from(row_count).unwrap_or(0));
         for r in 0..row_count {
             let name = read_column_string(result.raw_mut(), 0, r).unwrap_or_default();
             out.push(name);

--- a/src/ddl/alter_helpers_ffi.rs
+++ b/src/ddl/alter_helpers_ffi.rs
@@ -110,17 +110,13 @@ pub unsafe extern "C" fn sv_compute_create_from_yaml_rust(
         }
 
         let content_bytes = std::slice::from_raw_parts(content_ptr, content_len);
-        let content = if let Ok(s) = std::str::from_utf8(content_bytes) {
-            s
-        } else {
+        let Ok(content) = std::str::from_utf8(content_bytes) else {
             write_error_buf(error_buf, error_buf_len, "YAML content is not valid UTF-8");
             return 1_u8;
         };
 
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let name = if let Ok(s) = std::str::from_utf8(name_bytes) {
-            s
-        } else {
+        let Ok(name) = std::str::from_utf8(name_bytes) else {
             write_error_buf(error_buf, error_buf_len, "view name is not valid UTF-8");
             return 1_u8;
         };

--- a/src/ddl/alter_helpers_ffi.rs
+++ b/src/ddl/alter_helpers_ffi.rs
@@ -2,19 +2,19 @@
 //!
 //! Phase 65 Plan 04 introduces the first such helper, `__sv_compute_create_from_yaml`,
 //! whose C++ bind callback (in `cpp/src/shim.cpp`) opens a per-call
-//! `Connection(*context.db)` to read the YAML file via DuckDB's `read_text(?)`
+//! `Connection(*context.db)` to read the YAML file via `DuckDB`'s `read_text(?)`
 //! function, then calls into Rust here to parse the YAML, run validation +
 //! cardinality inference, and serialize the resulting JSON. The bind returns
-//! the JSON in a single VARCHAR row; the outer parser_override INSERT (in
+//! the JSON in a single VARCHAR row; the outer `parser_override` INSERT (in
 //! `src/parse.rs::rewrite_yaml_file_create`) wraps that row with
 //! `json_merge_patch` + `json_object` to add the metadata fields
 //! (`created_on`, `database_name`, `schema_name`) on the caller's connection.
 //!
 //! Read-elimination architecture (Phase 65 D-11): the YAML read no longer
-//! goes through the OverrideContext's catalog connection. The per-call
+//! goes through the `OverrideContext`'s catalog connection. The per-call
 //! Connection opened inside the bind closes at end-of-bind scope, so no
 //! long-lived extension-owned `duckdb_connection` outlives the user's
-//! `close()`. This is the load-bearing primitive for retiring H1 catalog_conn
+//! `close()`. This is the load-bearing primitive for retiring H1 `catalog_conn`
 //! in Plan 06.
 //!
 //! FFI safety conventions (match `src/parse.rs::sv_parser_override_rust`):
@@ -44,7 +44,7 @@ use std::panic::AssertUnwindSafe;
 /// opened from `ClientContext::db`, so this function only sees the
 /// already-loaded bytes — no file I/O on the Rust side.
 ///
-/// Returns the metadata-less JSON definition. The outer parser_override
+/// Returns the metadata-less JSON definition. The outer `parser_override`
 /// INSERT wraps the JSON with `json_merge_patch(new_def, json_object(...))`
 /// to populate `created_on` / `database_name` / `schema_name` on the
 /// caller's connection (preserving D-21 transactional contract).
@@ -110,33 +110,30 @@ pub unsafe extern "C" fn sv_compute_create_from_yaml_rust(
         }
 
         let content_bytes = std::slice::from_raw_parts(content_ptr, content_len);
-        let content = match std::str::from_utf8(content_bytes) {
-            Ok(s) => s,
-            Err(_) => {
-                write_error_buf(error_buf, error_buf_len, "YAML content is not valid UTF-8");
-                return 1_u8;
-            }
+        let content = if let Ok(s) = std::str::from_utf8(content_bytes) {
+            s
+        } else {
+            write_error_buf(error_buf, error_buf_len, "YAML content is not valid UTF-8");
+            return 1_u8;
         };
 
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let name = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s,
-            Err(_) => {
-                write_error_buf(error_buf, error_buf_len, "view name is not valid UTF-8");
-                return 1_u8;
-            }
+        let name = if let Ok(s) = std::str::from_utf8(name_bytes) {
+            s
+        } else {
+            write_error_buf(error_buf, error_buf_len, "view name is not valid UTF-8");
+            return 1_u8;
         };
 
         let comment_opt: Option<String> = if comment_len == 0 || comment_ptr.is_null() {
             None
         } else {
             let comment_bytes = std::slice::from_raw_parts(comment_ptr, comment_len);
-            match std::str::from_utf8(comment_bytes) {
-                Ok(s) => Some(s.to_owned()),
-                Err(_) => {
-                    write_error_buf(error_buf, error_buf_len, "COMMENT value is not valid UTF-8");
-                    return 1_u8;
-                }
+            if let Ok(s) = std::str::from_utf8(comment_bytes) {
+                Some(s.to_owned())
+            } else {
+                write_error_buf(error_buf, error_buf_len, "COMMENT value is not valid UTF-8");
+                return 1_u8;
             }
         };
 
@@ -173,16 +170,15 @@ pub unsafe extern "C" fn sv_compute_create_from_yaml_rust(
             }
         }
     }));
-    match result {
-        Ok(rc) => rc,
-        Err(_) => {
-            write_error_buf(
-                error_buf,
-                error_buf_len,
-                "internal error: panic inside sv_compute_create_from_yaml_rust",
-            );
-            3
-        }
+    if let Ok(rc) = result {
+        rc
+    } else {
+        write_error_buf(
+            error_buf,
+            error_buf_len,
+            "internal error: panic inside sv_compute_create_from_yaml_rust",
+        );
+        3
     }
 }
 

--- a/src/ddl/define.rs
+++ b/src/ddl/define.rs
@@ -1,7 +1,7 @@
-//! CREATE-time enrichment shared by the parser_override CREATE path.
+//! CREATE-time enrichment shared by the `parser_override` CREATE path.
 //!
 //! Pre-v0.8.0 this module also hosted `DefineFromJsonVTab` — a table function
-//! that the legacy parse_function fallback rewrote DDL into. v0.8.0's full
+//! that the legacy `parse_function` fallback rewrote DDL into. v0.8.0's full
 //! unification deleted that path; `parser_override` now emits native INSERT
 //! against `semantic_layer._definitions` directly. Only the enrichment helper
 //! remains — called by `crate::parse::rewrite_create` and
@@ -42,10 +42,10 @@
 /// populated here — the rewritten INSERT in `emit_native_create_sql`
 /// wraps the serialized JSON in a `json_merge_patch(..., json_object(
 /// 'created_on', strftime(now(), '%Y-%m-%dT%H:%M:%SZ'), 'database_name',
-/// current_database(), 'schema_name', current_schema()))` so DuckDB
+/// current_database(), 'schema_name', current_schema()))` so `DuckDB`
 /// resolves the values on the caller's connection at INSERT-time. This
 /// makes CREATE SEMANTIC VIEW participate in the caller's transaction
-/// without parser_override needing a long-lived catalog connection
+/// without `parser_override` needing a long-lived catalog connection
 /// (D-21 + read-elimination architecture).
 ///
 /// Column type inference (`column_type_names`, `column_types_inferred`,
@@ -54,7 +54,7 @@
 /// in the persisted JSON.
 ///
 /// Called by both `parse::rewrite_create` (inline AS-body) and
-/// `parse::rewrite_yaml_file_create` (FROM YAML FILE) under parser_override.
+/// `parse::rewrite_yaml_file_create` (FROM YAML FILE) under `parser_override`.
 pub fn enrich_definition_for_create(
     _name: &str,
     mut def: crate::model::SemanticViewDefinition,

--- a/src/ddl/describe.rs
+++ b/src/ddl/describe.rs
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn sv_describe_semantic_view_bind_rust(
         let def = match SemanticViewDefinition::from_json(&name, &json) {
             Ok(d) => d,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.clone());
+                write_err(error_buf, error_buf_len, &e);
                 return 1_u8;
             }
         };

--- a/src/ddl/describe.rs
+++ b/src/ddl/describe.rs
@@ -40,12 +40,11 @@ pub unsafe extern "C" fn sv_describe_semantic_view_bind_rust(
             return 1_u8;
         }
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let raw_name = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s,
-            Err(_) => {
-                write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
-                return 1_u8;
-            }
+        let raw_name = if let Ok(s) = std::str::from_utf8(name_bytes) {
+            s
+        } else {
+            write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
+            return 1_u8;
         };
         // FF-4: normalize so quoted-identifier inputs resolve like `semantic_view()`.
         let name = match crate::ident::normalize_view_name(raw_name) {
@@ -87,7 +86,7 @@ pub unsafe extern "C" fn sv_describe_semantic_view_bind_rust(
         let def = match SemanticViewDefinition::from_json(&name, &json) {
             Ok(d) => d,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.to_string());
+                write_err(error_buf, error_buf_len, &e.clone());
                 return 1_u8;
             }
         };
@@ -131,17 +130,16 @@ pub unsafe extern "C" fn sv_describe_semantic_view_bind_rust(
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));
-    match result {
-        Ok(rc) => rc,
-        Err(_) => {
-            use crate::ddl::read_ffi::write_err;
-            write_err(
-                error_buf,
-                error_buf_len,
-                "internal error: panic inside sv_describe_semantic_view_bind_rust",
-            );
-            2
-        }
+    if let Ok(rc) = result {
+        rc
+    } else {
+        use crate::ddl::read_ffi::write_err;
+        write_err(
+            error_buf,
+            error_buf_len,
+            "internal error: panic inside sv_describe_semantic_view_bind_rust",
+        );
+        2
     }
 }
 
@@ -415,10 +413,10 @@ fn collect_dimension_rows(
     }
 }
 
-/// Collect METRIC and DERIVED_METRIC property rows from the definition.
+/// Collect METRIC and `DERIVED_METRIC` property rows from the definition.
 ///
-/// Metrics with `source_table: Some(...)` emit as METRIC (TABLE, EXPRESSION, DATA_TYPE).
-/// Metrics with `source_table: None` emit as DERIVED_METRIC (EXPRESSION, DATA_TYPE only).
+/// Metrics with `source_table: Some(...)` emit as METRIC (TABLE, EXPRESSION, `DATA_TYPE`).
+/// Metrics with `source_table: None` emit as `DERIVED_METRIC` (EXPRESSION, `DATA_TYPE` only).
 fn collect_metric_rows(
     def: &SemanticViewDefinition,
     base_table: &str,

--- a/src/ddl/describe.rs
+++ b/src/ddl/describe.rs
@@ -15,6 +15,10 @@ use crate::model::{AccessModifier, SemanticViewDefinition};
 /// `conn` is a borrowed handle; `name_ptr` must point to `name_len` UTF-8 bytes.
 #[cfg(feature = "extension")]
 #[no_mangle]
+// Single linear FFI dispatcher (catch_unwind guard, arg decode, catalog lookup,
+// row collection, wire serialization) kept as one path so the panic boundary
+// and borrow contract stay in one place.
+#[allow(clippy::too_many_lines)]
 pub unsafe extern "C" fn sv_describe_semantic_view_bind_rust(
     conn: libduckdb_sys::duckdb_connection,
     name_ptr: *const u8,
@@ -40,9 +44,7 @@ pub unsafe extern "C" fn sv_describe_semantic_view_bind_rust(
             return 1_u8;
         }
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let raw_name = if let Ok(s) = std::str::from_utf8(name_bytes) {
-            s
-        } else {
+        let Ok(raw_name) = std::str::from_utf8(name_bytes) else {
             write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
             return 1_u8;
         };
@@ -417,6 +419,10 @@ fn collect_dimension_rows(
 ///
 /// Metrics with `source_table: Some(...)` emit as METRIC (TABLE, EXPRESSION, `DATA_TYPE`).
 /// Metrics with `source_table: None` emit as `DERIVED_METRIC` (EXPRESSION, `DATA_TYPE` only).
+// One row-builder per metric shape (regular, window, semi-additive, derived);
+// each branch emits a distinct fixed set of property rows, so the length is
+// inherent to the DESCRIBE row schema rather than tangled logic.
+#[allow(clippy::too_many_lines)]
 fn collect_metric_rows(
     def: &SemanticViewDefinition,
     base_table: &str,

--- a/src/ddl/get_ddl.rs
+++ b/src/ddl/get_ddl.rs
@@ -1,6 +1,6 @@
-//! GET_DDL scalar function: wraps [`crate::render_ddl::render_create_ddl`] as a
+//! `GET_DDL` scalar function: wraps [`crate::render_ddl::render_create_ddl`] as a
 //! C++ Catalog API scalar so that `SELECT GET_DDL('SEMANTIC_VIEW', 'name')`
-//! works inside DuckDB.
+//! works inside `DuckDB`.
 //!
 //! The render logic itself lives in [`crate::render_ddl`] (always compiled,
 //! unit-tested under `cargo test`). This module adds the extension-only Rust
@@ -9,7 +9,7 @@
 //! # Phase 65 Plan 05 Task 4 (Wave 3) — Batch 3 final cleanup
 //!
 //! The legacy `GetDdlScalar` `VScalar` impl block was retired in the same
-//! commit that deleted the H2 query_conn allocation; all live invocations
+//! commit that deleted the H2 `query_conn` allocation; all live invocations
 //! of `SELECT GET_DDL(...)` now route through [`sv_get_ddl_exec_rust`] below.
 
 use crate::catalog::CatalogReader;
@@ -61,19 +61,17 @@ pub unsafe extern "C" fn sv_get_ddl_exec_rust(
         }
         let type_bytes = std::slice::from_raw_parts(type_ptr, type_len);
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let obj_type = match std::str::from_utf8(type_bytes) {
-            Ok(s) => s,
-            Err(_) => {
-                write_err(error_buf, error_buf_len, "object_type is not valid UTF-8");
-                return 1_u8;
-            }
+        let obj_type = if let Ok(s) = std::str::from_utf8(type_bytes) {
+            s
+        } else {
+            write_err(error_buf, error_buf_len, "object_type is not valid UTF-8");
+            return 1_u8;
         };
-        let name = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s,
-            Err(_) => {
-                write_err(error_buf, error_buf_len, "name is not valid UTF-8");
-                return 1_u8;
-            }
+        let name = if let Ok(s) = std::str::from_utf8(name_bytes) {
+            s
+        } else {
+            write_err(error_buf, error_buf_len, "name is not valid UTF-8");
+            return 1_u8;
         };
 
         if !obj_type.eq_ignore_ascii_case("SEMANTIC_VIEW") {
@@ -129,16 +127,15 @@ pub unsafe extern "C" fn sv_get_ddl_exec_rust(
         publish_owned_buffer(ddl.into_bytes(), out_ptr, out_len);
         0_u8
     }));
-    match result {
-        Ok(rc) => rc,
-        Err(_) => {
-            use crate::ddl::read_ffi::write_err;
-            write_err(
-                error_buf,
-                error_buf_len,
-                "internal error: panic inside sv_get_ddl_exec_rust",
-            );
-            2
-        }
+    if let Ok(rc) = result {
+        rc
+    } else {
+        use crate::ddl::read_ffi::write_err;
+        write_err(
+            error_buf,
+            error_buf_len,
+            "internal error: panic inside sv_get_ddl_exec_rust",
+        );
+        2
     }
 }

--- a/src/ddl/get_ddl.rs
+++ b/src/ddl/get_ddl.rs
@@ -61,15 +61,11 @@ pub unsafe extern "C" fn sv_get_ddl_exec_rust(
         }
         let type_bytes = std::slice::from_raw_parts(type_ptr, type_len);
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let obj_type = if let Ok(s) = std::str::from_utf8(type_bytes) {
-            s
-        } else {
+        let Ok(obj_type) = std::str::from_utf8(type_bytes) else {
             write_err(error_buf, error_buf_len, "object_type is not valid UTF-8");
             return 1_u8;
         };
-        let name = if let Ok(s) = std::str::from_utf8(name_bytes) {
-            s
-        } else {
+        let Ok(name) = std::str::from_utf8(name_bytes) else {
             write_err(error_buf, error_buf_len, "name is not valid UTF-8");
             return 1_u8;
         };

--- a/src/ddl/list.rs
+++ b/src/ddl/list.rs
@@ -45,26 +45,27 @@ use crate::model::SemanticViewDefinition;
 /// The 6 columns match the v0.9.0 Rust `VTab` shape exactly:
 /// (`created_on`, name, kind, `database_name`, `schema_name`, comment).
 ///
-/// # Bridge lifecycle (critical)
+/// # Safety
 ///
-/// The `conn` parameter is a BORROWED handle — the underlying C++
-/// `Connection` is owned by a stack local in the C++ bind callback.
-/// This function MUST NOT:
-///   * call `duckdb_disconnect(conn)` (would `delete` a stack object — UB),
-///   * stash the handle in long-lived storage (would dangle after bind),
-///   * call functions that take ownership of the handle (none in the
-///     `CatalogReader` path — `CatalogReader::new` only stores the raw
-///     pointer, and the prepared-statement / query helpers in
-///     `src/catalog.rs` operate on the handle without consuming it).
+/// The `conn` parameter is a BORROWED handle (bridge lifecycle, critical) — the
+/// underlying C++ `Connection` is owned by a stack local in the C++ bind
+/// callback. This function MUST NOT:
+///
+/// * call `duckdb_disconnect(conn)` (would `delete` a stack object — UB),
+/// * stash the handle in long-lived storage (would dangle after bind),
+/// * call functions that take ownership of the handle (none in the
+///   `CatalogReader` path — `CatalogReader::new` only stores the raw pointer,
+///   and the prepared-statement / query helpers in `src/catalog.rs` operate on
+///   the handle without consuming it).
 ///
 /// # Return codes
 ///
 /// * `0` — success; `(out_ptr, out_len)` populated. Caller MUST release
-///         via `sv_free_buffer(ptr, len)`.
+///   via `sv_free_buffer(ptr, len)`.
 /// * `1` — catalog read error (e.g. the `semantic_layer._definitions`
-///         table is missing); `error_buf` populated.
+///   table is missing); `error_buf` populated.
 /// * `2` — internal error (panic across FFI, serialization failure);
-///         `error_buf` populated.
+///   `error_buf` populated.
 ///
 /// # Catalog-table-present probing
 ///

--- a/src/ddl/list.rs
+++ b/src/ddl/list.rs
@@ -36,14 +36,14 @@ use crate::model::SemanticViewDefinition;
 /// `CatalogReader`, performs the catalog read, and serializes the rows
 /// into a flat binary buffer with the wire format:
 ///
-///   u32 row_count (little-endian)
+///   u32 `row_count` (little-endian)
 ///   for each row:
 ///     for each of 6 columns:
-///       u32 byte_len (little-endian)
-///       byte_len bytes (UTF-8, NOT NUL-terminated)
+///       u32 `byte_len` (little-endian)
+///       `byte_len` bytes (UTF-8, NOT NUL-terminated)
 ///
-/// The 6 columns match the v0.9.0 Rust VTab shape exactly:
-/// (created_on, name, kind, database_name, schema_name, comment).
+/// The 6 columns match the v0.9.0 Rust `VTab` shape exactly:
+/// (`created_on`, name, kind, `database_name`, `schema_name`, comment).
 ///
 /// # Bridge lifecycle (critical)
 ///
@@ -53,7 +53,7 @@ use crate::model::SemanticViewDefinition;
 ///   * call `duckdb_disconnect(conn)` (would `delete` a stack object — UB),
 ///   * stash the handle in long-lived storage (would dangle after bind),
 ///   * call functions that take ownership of the handle (none in the
-///     CatalogReader path — `CatalogReader::new` only stores the raw
+///     `CatalogReader` path — `CatalogReader::new` only stores the raw
 ///     pointer, and the prepared-statement / query helpers in
 ///     `src/catalog.rs` operate on the handle without consuming it).
 ///
@@ -168,16 +168,15 @@ pub unsafe extern "C" fn sv_list_semantic_views_bind_rust(
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));
-    match result {
-        Ok(rc) => rc,
-        Err(_) => {
-            write_err(
-                error_buf,
-                error_buf_len,
-                "internal error: panic inside sv_list_semantic_views_bind_rust",
-            );
-            2
-        }
+    if let Ok(rc) = result {
+        rc
+    } else {
+        write_err(
+            error_buf,
+            error_buf_len,
+            "internal error: panic inside sv_list_semantic_views_bind_rust",
+        );
+        2
     }
 }
 
@@ -201,11 +200,11 @@ pub unsafe extern "C" fn sv_list_semantic_views_bind_rust(
 /// function — 5-column subset of `list_semantic_views()` (no `comment`).
 ///
 /// Wire format (length-prefixed binary, LE):
-///   u32 row_count
+///   u32 `row_count`
 ///   for each row:
-///     for each of 5 cols: u32 byte_len | bytes (UTF-8)
+///     for each of 5 cols: u32 `byte_len` | bytes (UTF-8)
 ///
-/// Columns: (created_on, name, kind, database_name, schema_name).
+/// Columns: (`created_on`, name, kind, `database_name`, `schema_name`).
 ///
 /// # Safety
 ///
@@ -281,16 +280,15 @@ pub unsafe extern "C" fn sv_list_terse_semantic_views_bind_rust(
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));
-    match result {
-        Ok(rc) => rc,
-        Err(_) => {
-            use crate::ddl::read_ffi::write_err;
-            write_err(
-                error_buf,
-                error_buf_len,
-                "internal error: panic inside sv_list_terse_semantic_views_bind_rust",
-            );
-            2
-        }
+    if let Ok(rc) = result {
+        rc
+    } else {
+        use crate::ddl::read_ffi::write_err;
+        write_err(
+            error_buf,
+            error_buf_len,
+            "internal error: panic inside sv_list_terse_semantic_views_bind_rust",
+        );
+        2
     }
 }

--- a/src/ddl/read_ffi.rs
+++ b/src/ddl/read_ffi.rs
@@ -32,7 +32,7 @@
 //! now fails loudly at the header with a clear message, instead of desyncing
 //! silently or misparsing cell bytes. The C++ side parses with `sv_read_u32_le`
 //! + `sv_read_string` (+ `sv_read_wire_schema` for the header) in
-//! `cpp/src/shim.cpp`, then emits rows into the DataChunk.
+//! `cpp/src/shim.cpp`, then emits rows into the `DataChunk`.
 //!
 //! The header is emitted for every non-empty result. An empty result set
 //! (`row_count == 0`) writes `col_count == 0` and no tags: there are no cells
@@ -162,11 +162,11 @@ pub unsafe fn probe_catalog_table_present(borrowed: &BorrowedConnection) -> Resu
     )
     .map_err(|_| "catalog probe SQL contains an interior null byte".to_string())?;
     let mut result: ffi::duckdb_result = std::mem::zeroed();
-    let rc = ffi::duckdb_query(conn, sql.as_ptr(), &mut result);
+    let rc = ffi::duckdb_query(conn, sql.as_ptr(), &raw mut result);
     let out = if rc == ffi::DuckDBSuccess {
-        Ok(ffi::duckdb_row_count(&mut result) > 0)
+        Ok(ffi::duckdb_row_count(&raw mut result) > 0)
     } else {
-        let err_ptr = ffi::duckdb_result_error(&mut result);
+        let err_ptr = ffi::duckdb_result_error(&raw mut result);
         let msg = if err_ptr.is_null() {
             "catalog presence probe failed".to_string()
         } else {
@@ -174,7 +174,7 @@ pub unsafe fn probe_catalog_table_present(borrowed: &BorrowedConnection) -> Resu
         };
         Err(msg)
     };
-    ffi::duckdb_destroy_result(&mut result);
+    ffi::duckdb_destroy_result(&raw mut result);
     out
 }
 
@@ -384,16 +384,15 @@ where
             }
         }
     }));
-    match result {
-        Ok(rc) => rc,
-        Err(_) => {
-            write_err(
-                error_buf,
-                error_buf_len,
-                &format!("internal error: panic inside {panic_label}"),
-            );
-            2
-        }
+    if let Ok(rc) = result {
+        rc
+    } else {
+        write_err(
+            error_buf,
+            error_buf_len,
+            &format!("internal error: panic inside {panic_label}"),
+        );
+        2
     }
 }
 

--- a/src/ddl/read_ffi.rs
+++ b/src/ddl/read_ffi.rs
@@ -30,9 +30,9 @@
 //! TECH-DEBT #12's two-place schema agreement) into a machine-checked one. A
 //! dispatcher that emits a different column shape than its C++ bind expects
 //! now fails loudly at the header with a clear message, instead of desyncing
-//! silently or misparsing cell bytes. The C++ side parses with `sv_read_u32_le`
-//! + `sv_read_string` (+ `sv_read_wire_schema` for the header) in
-//! `cpp/src/shim.cpp`, then emits rows into the `DataChunk`.
+//! silently or misparsing cell bytes. The C++ side parses the payload with
+//! `sv_read_u32_le` / `sv_read_string` (plus `sv_read_wire_schema` for the
+//! header) in `cpp/src/shim.cpp`, then emits rows into the `DataChunk`.
 //!
 //! The header is emitted for every non-empty result. An empty result set
 //! (`row_count == 0`) writes `col_count == 0` and no tags: there are no cells

--- a/src/ddl/read_yaml.rs
+++ b/src/ddl/read_yaml.rs
@@ -10,7 +10,7 @@
 //! # Phase 65 Plan 05 Task 4 (Wave 3) — Batch 3 final cleanup
 //!
 //! The legacy `ReadYamlFromSemanticViewScalar` `VScalar` impl block was
-//! retired in the same commit that deleted the H2 query_conn allocation; all
+//! retired in the same commit that deleted the H2 `query_conn` allocation; all
 //! live invocations of `SELECT READ_YAML_FROM_SEMANTIC_VIEW(...)` now route
 //! through [`sv_read_yaml_from_semantic_view_exec_rust`] below.
 
@@ -69,12 +69,11 @@ pub unsafe extern "C" fn sv_read_yaml_from_semantic_view_exec_rust(
             return 1_u8;
         }
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let raw_name = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s,
-            Err(_) => {
-                write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
-                return 1_u8;
-            }
+        let raw_name = if let Ok(s) = std::str::from_utf8(name_bytes) {
+            s
+        } else {
+            write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
+            return 1_u8;
         };
         let bare_name = resolve_bare_name(raw_name);
 
@@ -113,24 +112,23 @@ pub unsafe extern "C" fn sv_read_yaml_from_semantic_view_exec_rust(
         let yaml = match render_yaml_export(&def) {
             Ok(s) => s,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.to_string());
+                write_err(error_buf, error_buf_len, &e.clone());
                 return 1_u8;
             }
         };
         publish_owned_buffer(yaml.into_bytes(), out_ptr, out_len);
         0_u8
     }));
-    match result {
-        Ok(rc) => rc,
-        Err(_) => {
-            use crate::ddl::read_ffi::write_err;
-            write_err(
-                error_buf,
-                error_buf_len,
-                "internal error: panic inside sv_read_yaml_from_semantic_view_exec_rust",
-            );
-            2
-        }
+    if let Ok(rc) = result {
+        rc
+    } else {
+        use crate::ddl::read_ffi::write_err;
+        write_err(
+            error_buf,
+            error_buf_len,
+            "internal error: panic inside sv_read_yaml_from_semantic_view_exec_rust",
+        );
+        2
     }
 }
 

--- a/src/ddl/read_yaml.rs
+++ b/src/ddl/read_yaml.rs
@@ -69,9 +69,7 @@ pub unsafe extern "C" fn sv_read_yaml_from_semantic_view_exec_rust(
             return 1_u8;
         }
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let raw_name = if let Ok(s) = std::str::from_utf8(name_bytes) {
-            s
-        } else {
+        let Ok(raw_name) = std::str::from_utf8(name_bytes) else {
             write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
             return 1_u8;
         };

--- a/src/ddl/read_yaml.rs
+++ b/src/ddl/read_yaml.rs
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn sv_read_yaml_from_semantic_view_exec_rust(
         let yaml = match render_yaml_export(&def) {
             Ok(s) => s,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.clone());
+                write_err(error_buf, error_buf_len, &e);
                 return 1_u8;
             }
         };

--- a/src/ddl/show_columns.rs
+++ b/src/ddl/show_columns.rs
@@ -43,9 +43,7 @@ pub unsafe extern "C" fn sv_show_columns_in_semantic_view_bind_rust(
             return 1_u8;
         }
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let raw_name = if let Ok(s) = std::str::from_utf8(name_bytes) {
-            s
-        } else {
+        let Ok(raw_name) = std::str::from_utf8(name_bytes) else {
             write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
             return 1_u8;
         };

--- a/src/ddl/show_columns.rs
+++ b/src/ddl/show_columns.rs
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn sv_show_columns_in_semantic_view_bind_rust(
         let def = match SemanticViewDefinition::from_json(&view_name, &json) {
             Ok(d) => d,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.clone());
+                write_err(error_buf, error_buf_len, &e);
                 return 1_u8;
             }
         };

--- a/src/ddl/show_columns.rs
+++ b/src/ddl/show_columns.rs
@@ -43,12 +43,11 @@ pub unsafe extern "C" fn sv_show_columns_in_semantic_view_bind_rust(
             return 1_u8;
         }
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let raw_name = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s,
-            Err(_) => {
-                write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
-                return 1_u8;
-            }
+        let raw_name = if let Ok(s) = std::str::from_utf8(name_bytes) {
+            s
+        } else {
+            write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
+            return 1_u8;
         };
         // FF-4: normalize so quoted-identifier inputs resolve like `semantic_view()`.
         let view_name = match crate::ident::normalize_view_name(raw_name) {
@@ -90,7 +89,7 @@ pub unsafe extern "C" fn sv_show_columns_in_semantic_view_bind_rust(
         let def = match SemanticViewDefinition::from_json(&view_name, &json) {
             Ok(d) => d,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.to_string());
+                write_err(error_buf, error_buf_len, &e.clone());
                 return 1_u8;
             }
         };
@@ -118,17 +117,16 @@ pub unsafe extern "C" fn sv_show_columns_in_semantic_view_bind_rust(
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));
-    match result {
-        Ok(rc) => rc,
-        Err(_) => {
-            use crate::ddl::read_ffi::write_err;
-            write_err(
-                error_buf,
-                error_buf_len,
-                "internal error: panic inside sv_show_columns_in_semantic_view_bind_rust",
-            );
-            2
-        }
+    if let Ok(rc) = result {
+        rc
+    } else {
+        use crate::ddl::read_ffi::write_err;
+        write_err(
+            error_buf,
+            error_buf_len,
+            "internal error: panic inside sv_show_columns_in_semantic_view_bind_rust",
+        );
+        2
     }
 }
 
@@ -152,7 +150,7 @@ struct ShowColumnRow {
 
 /// Collect column rows from a semantic view definition.
 /// Includes all dimensions, public facts, and public metrics.
-/// Derived metrics (no source_table) get kind "DERIVED_METRIC".
+/// Derived metrics (no `source_table`) get kind "`DERIVED_METRIC`".
 fn collect_column_rows(def: &SemanticViewDefinition, view_name: &str) -> Vec<ShowColumnRow> {
     let database_name = def.database_name.clone().unwrap_or_default();
     let schema_name = def.schema_name.clone().unwrap_or_default();

--- a/src/ddl/show_dims_for_metric.rs
+++ b/src/ddl/show_dims_for_metric.rs
@@ -65,6 +65,10 @@ pub unsafe extern "C" fn sv_show_semantic_dimensions_for_metric_bind_rust(
 ///
 /// `view_name_ptr` / `metric_name_ptr` must each be null or point to the
 /// matching number of readable bytes.
+// Linear resolve-and-filter path (decode names, look up view, find metric,
+// walk reachable dimensions, serialize); kept together so each not-found case
+// returns its own tailored diagnostic.
+#[allow(clippy::too_many_lines)]
 unsafe fn show_dims_for_metric(
     borrowed: &BorrowedConnection,
     view_name_ptr: *const u8,
@@ -81,9 +85,7 @@ unsafe fn show_dims_for_metric(
 
     let present = probe_catalog_table_present(borrowed)?;
     let reader = CatalogReader::new(borrowed, present);
-    let json = if let Some(j) = reader.lookup(&view_name)? {
-        j
-    } else {
+    let Some(json) = reader.lookup(&view_name)? else {
         let available = reader.list_names().unwrap_or_default();
         let not_found = crate::catalog::view_not_found_msg(&view_name);
         return Err(match suggest_closest(&view_name, &available) {
@@ -94,13 +96,11 @@ unsafe fn show_dims_for_metric(
     let def = SemanticViewDefinition::from_json(&view_name, &json)?;
 
     let metric_lower = metric_name.to_ascii_lowercase();
-    let met = if let Some(m) = def
+    let Some(met) = def
         .metrics
         .iter()
         .find(|m| m.name.to_ascii_lowercase() == metric_lower)
-    {
-        m
-    } else {
+    else {
         let available: Vec<String> = def.metrics.iter().map(|m| m.name.clone()).collect();
         return Err(match suggest_closest(&metric_name, &available) {
             Some(suggestion) => format!(

--- a/src/ddl/show_dims_for_metric.rs
+++ b/src/ddl/show_dims_for_metric.rs
@@ -81,36 +81,34 @@ unsafe fn show_dims_for_metric(
 
     let present = probe_catalog_table_present(borrowed)?;
     let reader = CatalogReader::new(borrowed, present);
-    let json = match reader.lookup(&view_name)? {
-        Some(j) => j,
-        None => {
-            let available = reader.list_names().unwrap_or_default();
-            let not_found = crate::catalog::view_not_found_msg(&view_name);
-            return Err(match suggest_closest(&view_name, &available) {
-                Some(suggestion) => format!("{not_found}. Did you mean '{suggestion}'?"),
-                None => not_found,
-            });
-        }
+    let json = if let Some(j) = reader.lookup(&view_name)? {
+        j
+    } else {
+        let available = reader.list_names().unwrap_or_default();
+        let not_found = crate::catalog::view_not_found_msg(&view_name);
+        return Err(match suggest_closest(&view_name, &available) {
+            Some(suggestion) => format!("{not_found}. Did you mean '{suggestion}'?"),
+            None => not_found,
+        });
     };
     let def = SemanticViewDefinition::from_json(&view_name, &json)?;
 
     let metric_lower = metric_name.to_ascii_lowercase();
-    let met = match def
+    let met = if let Some(m) = def
         .metrics
         .iter()
         .find(|m| m.name.to_ascii_lowercase() == metric_lower)
     {
-        Some(m) => m,
-        None => {
-            let available: Vec<String> = def.metrics.iter().map(|m| m.name.clone()).collect();
-            return Err(match suggest_closest(&metric_name, &available) {
-                Some(suggestion) => format!(
-                    "metric '{metric_name}' not found in semantic view '{view_name}'. \
-                     Did you mean '{suggestion}'?"
-                ),
-                None => format!("metric '{metric_name}' not found in semantic view '{view_name}'"),
-            });
-        }
+        m
+    } else {
+        let available: Vec<String> = def.metrics.iter().map(|m| m.name.clone()).collect();
+        return Err(match suggest_closest(&metric_name, &available) {
+            Some(suggestion) => format!(
+                "metric '{metric_name}' not found in semantic view '{view_name}'. \
+                 Did you mean '{suggestion}'?"
+            ),
+            None => format!("metric '{metric_name}' not found in semantic view '{view_name}'"),
+        });
     };
 
     let required_dim_names: HashSet<String> = if let Some(ref ws) = met.window_spec {

--- a/src/ddl/show_entities.rs
+++ b/src/ddl/show_entities.rs
@@ -177,9 +177,8 @@ fn show_entities_one(
         .map_err(|e| format!("Invalid view name '{view_name}': {e}"))?;
     let present = unsafe { probe_catalog_table_present(borrowed) }?;
     let reader = CatalogReader::new(borrowed, present);
-    let json = match reader.lookup(&view_name)? {
-        Some(j) => j,
-        None => return Err(crate::catalog::view_not_found_msg(&view_name)),
+    let Some(json) = reader.lookup(&view_name)? else {
+        return Err(crate::catalog::view_not_found_msg(&view_name));
     };
     // FF-9: named single-view SHOW propagates a parse error — the user asked
     // for this specific view, so a corrupt definition must surface loudly

--- a/src/ddl/show_materializations.rs
+++ b/src/ddl/show_materializations.rs
@@ -131,9 +131,8 @@ pub unsafe extern "C" fn sv_show_semantic_materializations_bind_rust(
                 .map_err(|e| format!("Invalid view name '{view_name}': {e}"))?;
             let present = unsafe { probe_catalog_table_present(borrowed) }?;
             let reader = CatalogReader::new(borrowed, present);
-            let json = match reader.lookup(&view_name)? {
-                Some(j) => j,
-                None => return Err(crate::catalog::view_not_found_msg(&view_name)),
+            let Some(json) = reader.lookup(&view_name)? else {
+                return Err(crate::catalog::view_not_found_msg(&view_name));
             };
             // FF-9: named single-view SHOW propagates a parse error rather than
             // silently returning zero rows for a corrupt definition.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,15 +307,15 @@ pub mod test_helpers {
 #[cfg(feature = "extension")]
 pub mod ddl;
 
-/// Extension entry point — called by DuckDB when the extension is loaded.
+/// Extension entry point — called by `DuckDB` when the extension is loaded.
 ///
-/// Uses C_STRUCT ABI (semantic_views_init_c_api) for the DuckDB handshake.
+/// Uses `C_STRUCT` ABI (`semantic_views_init_c_api`) for the `DuckDB` handshake.
 /// After Rust-side initialization (catalog, DDL functions, query functions),
-/// calls a C++ helper (sv_register_parser_hooks) to register parser extension
-/// hooks that require C++ types (ParserExtension, DBConfig).
+/// calls a C++ helper (`sv_register_parser_hooks`) to register parser extension
+/// hooks that require C++ types (`ParserExtension`, `DBConfig`).
 ///
-/// This is "Option A" from Phase 15: keep C_STRUCT entry, call C++ helper.
-/// Option B (CPP entry via DUCKDB_CPP_EXTENSION_ENTRY) was tried first but
+/// This is "Option A" from Phase 15: keep `C_STRUCT` entry, call C++ helper.
+/// Option B (CPP entry via `DUCKDB_CPP_EXTENSION_ENTRY`) was tried first but
 /// failed due to unresolved C++ symbols from -fvisibility=hidden in the host.
 #[cfg(feature = "extension")]
 mod extension {
@@ -491,8 +491,7 @@ mod extension {
             .query_row("SELECT current_setting('access_mode')", [], |row| {
                 row.get::<_, String>(0)
             })
-            .map(|s| s.eq_ignore_ascii_case("read_only"))
-            .unwrap_or(false);
+            .is_ok_and(|s| s.eq_ignore_ascii_case("read_only"));
 
         // Initialize the persistent catalog (schema + table + companion-file migration).
         init_catalog(con, &db_path, is_read_only)?;
@@ -551,7 +550,7 @@ mod extension {
     /// # Safety
     ///
     /// Called by the extern "C" entrypoint below. `info` and `access` must be
-    /// valid pointers provided by DuckDB.
+    /// valid pointers provided by `DuckDB`.
     unsafe fn semantic_views_init_c_api_internal(
         info: ffi::duckdb_extension_info,
         access: *const ffi::duckdb_extension_access,
@@ -575,12 +574,12 @@ mod extension {
         Ok(true)
     }
 
-    /// FFI entrypoint called by DuckDB when the extension is loaded (C_STRUCT ABI).
+    /// FFI entrypoint called by `DuckDB` when the extension is loaded (`C_STRUCT` ABI).
     ///
     /// # Safety
     ///
-    /// This is an extern "C" function called across the FFI boundary by DuckDB.
-    /// `info` and `access` are guaranteed valid by DuckDB for the call duration.
+    /// This is an extern "C" function called across the FFI boundary by `DuckDB`.
+    /// `info` and `access` are guaranteed valid by `DuckDB` for the call duration.
     #[no_mangle]
     pub unsafe extern "C" fn semantic_views_init_c_api(
         info: ffi::duckdb_extension_info,

--- a/src/parse/ffi.rs
+++ b/src/parse/ffi.rs
@@ -92,10 +92,10 @@ unsafe fn publish_owned_sql(sql: String, sql_out_ptr: *mut *mut u8, sql_out_len:
     crate::ffi_util::publish_owned_string(sql, sql_out_ptr, sql_out_len);
 }
 
-/// FFI entry point for parser_override. The sole DDL entry point for the
-/// extension as of v0.8.0 — the legacy parse_function/parse_stub path was
+/// FFI entry point for `parser_override`. The sole DDL entry point for the
+/// extension as of v0.8.0 — the legacy `parse_function/parse_stub` path was
 /// retired. Rewrites recognized semantic-view DDL into native SQL suitable
-/// for re-parsing through DuckDB's own parser and execution on the caller's
+/// for re-parsing through `DuckDB`'s own parser and execution on the caller's
 /// connection.
 ///
 /// Returns:
@@ -104,7 +104,7 @@ unsafe fn publish_owned_sql(sql: String, sql_out_ptr: *mut *mut u8, sql_out_len:
 ///       release via `sv_free_buffer`. The buffer is **not** NUL-terminated;
 ///       read exactly `*sql_out_len` bytes.
 ///   1 = validation error / near-miss suggestion: error message written to
-///       `error_out`. (Currently unused under FALLBACK_OVERRIDE; kept for
+///       `error_out`. (Currently unused under `FALLBACK_OVERRIDE`; kept for
 ///       Phase 62 Plan 03 once `parse_function` returns to caret rendering.)
 ///   2 = not ours: defer to default parser. Used both for genuinely
 ///       non-semantic SQL and for the early-return on null/empty input or
@@ -195,10 +195,10 @@ pub unsafe extern "C" fn sv_parser_override_rust(
 
 /// FFI entry point for `parse_function` — Phase 62's error-reporting layer.
 ///
-/// Called by DuckDB's `Parser::ParseQuery` after the default parser fails on
+/// Called by `DuckDB`'s `Parser::ParseQuery` after the default parser fails on
 /// an unrecognised prefix (e.g. `CREATE SEMANTIC VIEW …` or `CRETAE …`).
 /// Re-runs validation against the user's input and returns the validation
-/// error message + a byte-offset position so DuckDB's
+/// error message + a byte-offset position so `DuckDB`'s
 /// `ParserException::SyntaxError` can render `LINE 1: … ^` (caret) at the
 /// offending token.
 ///
@@ -333,15 +333,15 @@ pub unsafe extern "C" fn sv_parse_function_rust(
     result.unwrap_or(2) // on panic: not ours
 }
 
-/// Re-run validation for the parse_function path. Mirrors what
+/// Re-run validation for the `parse_function` path. Mirrors what
 /// `sv_parser_override_rust` did at parse time (`rewrite_to_native_sql`), so a
 /// structurally-invalid DDL statement surfaces the same `ParseError` wording +
-/// position that parser_override produced. Catalog-level errors (DROP-of-missing,
+/// position that `parser_override` produced. Catalog-level errors (DROP-of-missing,
 /// rename collision) are enforced by guards in the *emitted* SQL at execution
 /// time, so they are not reproduced here — such statements return `Ok(Some(_))`.
 ///
 /// Returning `Ok(Some(_))` means "validation succeeded" — at the
-/// parse_function call site this can only happen when parser_override
+/// `parse_function` call site this can only happen when `parser_override`
 /// itself didn't run, so the caller maps it to rc=3 (actionable hint).
 #[cfg(feature = "extension")]
 fn run_validation_for_parse_function(query: &str) -> Result<Option<String>, ParseError> {

--- a/src/parse/ffi.rs
+++ b/src/parse/ffi.rs
@@ -220,9 +220,10 @@ pub unsafe extern "C" fn sv_parser_override_rust(
 ///
 /// The extension build re-runs the full rewrite (`rewrite_to_native_sql`); unit
 /// tests (no `extension` feature) fall back to syntax-only validation via
-/// `plan_rewrite`. Either way the purpose is to recover the `ParseError` message
-/// + caret position for a *structurally invalid* DDL statement (e.g. a malformed
-/// CREATE body), reproducing exactly what `parser_override` saw. Catalog-level
+/// `plan_rewrite`. Either way the purpose is to recover the `ParseError`
+/// message and caret position for a *structurally invalid* DDL statement (e.g. a
+/// malformed CREATE body), reproducing exactly what `parser_override` saw.
+/// Catalog-level
 /// conditions — DROP-of-missing, rename-into-an-existing-name — are NOT
 /// rewrite-time errors: `rewrite_drop` / `rewrite_alter_*` emit execution-time
 /// SQL guards, so a well-formed-but-catalog-invalid statement rewrites

--- a/src/parse/native_sql.rs
+++ b/src/parse/native_sql.rs
@@ -162,7 +162,7 @@ pub(crate) fn rewrite_to_native_sql(query: &str) -> Result<Option<String>, Parse
 /// 1. Run `enrich_definition_for_create` (validation + graph + serialize
 ///    to JSON; no catalog connection needed).
 /// 2. Emit `INSERT [OR REPLACE / OR IGNORE] INTO semantic_layer._definitions
-///    ... RETURNING name AS view_name` so DuckDB executes the write on the
+///    ... RETURNING name AS view_name` so `DuckDB` executes the write on the
 ///    caller's connection inside the caller's transaction. The plain CREATE
 ///    form (no OR REPLACE, no IF NOT EXISTS) wraps the INSERT in a
 ///    CASE+error subquery that emits "already exists" wording — replaces

--- a/src/parse/native_sql.rs
+++ b/src/parse/native_sql.rs
@@ -410,6 +410,11 @@ pub(crate) fn escape_sql_arg(s: &str) -> String {
 }
 
 #[cfg(feature = "extension")]
+// Infallible today, but kept `Result`-returning for symmetry with the fallible
+// `rewrite_*` siblings (e.g. `rewrite_alter_comment`) dispatched through the
+// same `?`-chained match in `rewrite_to_native_sql`; diverging one signature
+// would fragment that dispatch.
+#[allow(clippy::unnecessary_wraps)]
 fn rewrite_drop(name_escaped: &str, if_exists: bool) -> Result<Option<String>, ParseError> {
     if if_exists {
         // IF EXISTS: pure DELETE on the caller's connection — affects 0
@@ -460,6 +465,9 @@ fn rewrite_drop(name_escaped: &str, if_exists: bool) -> Result<Option<String>, P
 }
 
 #[cfg(feature = "extension")]
+// Infallible today; kept `Result`-returning for symmetry with the fallible
+// `rewrite_*` siblings dispatched through the same match (see `rewrite_drop`).
+#[allow(clippy::unnecessary_wraps)]
 fn rewrite_alter_rename(
     old_escaped: &str,
     new_escaped: &str,

--- a/src/query/error.rs
+++ b/src/query/error.rs
@@ -15,7 +15,7 @@ pub enum QueryError {
     EmptyRequest { view_name: String },
     /// The expansion engine returned an error.
     ExpandFailed { source: ExpandError },
-    /// The expanded SQL failed to execute against DuckDB.
+    /// The expanded SQL failed to execute against `DuckDB`.
     SqlExecution {
         expanded_sql: String,
         duckdb_error: String,

--- a/src/query/explain.rs
+++ b/src/query/explain.rs
@@ -200,7 +200,7 @@ pub unsafe extern "C" fn sv_explain_semantic_view_bind_rust(
         let def = match SemanticViewDefinition::from_json(&view_name, &json_str) {
             Ok(d) => d,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.clone());
+                write_err(error_buf, error_buf_len, &e);
                 return 1_u8;
             }
         };
@@ -208,21 +208,21 @@ pub unsafe extern "C" fn sv_explain_semantic_view_bind_rust(
         let dimensions = match expand_wildcards(&dimensions, &def, &WildcardItemType::Dimension) {
             Ok(v) => v,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.clone());
+                write_err(error_buf, error_buf_len, &e);
                 return 1_u8;
             }
         };
         let metrics = match expand_wildcards(&metrics, &def, &WildcardItemType::Metric) {
             Ok(v) => v,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.clone());
+                write_err(error_buf, error_buf_len, &e);
                 return 1_u8;
             }
         };
         let facts = match expand_wildcards(&facts, &def, &WildcardItemType::Fact) {
             Ok(v) => v,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.clone());
+                write_err(error_buf, error_buf_len, &e);
                 return 1_u8;
             }
         };

--- a/src/query/explain.rs
+++ b/src/query/explain.rs
@@ -56,7 +56,10 @@ use super::wire::parse_varchar_list;
 /// documented above. `name_ptr` must point to `name_len` UTF-8 bytes.
 #[cfg(feature = "extension")]
 #[no_mangle]
-#[allow(clippy::too_many_arguments)]
+// Single linear FFI dispatcher (catch_unwind guard, arg decode, expand, EXPLAIN
+// capture, wire serialization); kept as one straight path so the panic boundary
+// and borrow contract stay in one place.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub unsafe extern "C" fn sv_explain_semantic_view_bind_rust(
     conn: libduckdb_sys::duckdb_connection,
     name_ptr: *const u8,

--- a/src/query/explain.rs
+++ b/src/query/explain.rs
@@ -94,12 +94,11 @@ pub unsafe extern "C" fn sv_explain_semantic_view_bind_rust(
             return 1_u8;
         }
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let view_name_raw = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s.to_string(),
-            Err(_) => {
-                write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
-                return 1_u8;
-            }
+        let view_name_raw = if let Ok(s) = std::str::from_utf8(name_bytes) {
+            s.to_string()
+        } else {
+            write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
+            return 1_u8;
         };
         let view_name = match crate::ident::normalize_view_name(&view_name_raw) {
             Ok(s) => s,
@@ -198,7 +197,7 @@ pub unsafe extern "C" fn sv_explain_semantic_view_bind_rust(
         let def = match SemanticViewDefinition::from_json(&view_name, &json_str) {
             Ok(d) => d,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.to_string());
+                write_err(error_buf, error_buf_len, &e.clone());
                 return 1_u8;
             }
         };
@@ -206,21 +205,21 @@ pub unsafe extern "C" fn sv_explain_semantic_view_bind_rust(
         let dimensions = match expand_wildcards(&dimensions, &def, &WildcardItemType::Dimension) {
             Ok(v) => v,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.to_string());
+                write_err(error_buf, error_buf_len, &e.clone());
                 return 1_u8;
             }
         };
         let metrics = match expand_wildcards(&metrics, &def, &WildcardItemType::Metric) {
             Ok(v) => v,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.to_string());
+                write_err(error_buf, error_buf_len, &e.clone());
                 return 1_u8;
             }
         };
         let facts = match expand_wildcards(&facts, &def, &WildcardItemType::Fact) {
             Ok(v) => v,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.to_string());
+                write_err(error_buf, error_buf_len, &e.clone());
                 return 1_u8;
             }
         };
@@ -300,17 +299,16 @@ pub unsafe extern "C" fn sv_explain_semantic_view_bind_rust(
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));
-    match result {
-        Ok(rc) => rc,
-        Err(_) => {
-            use crate::ddl::read_ffi::write_err;
-            write_err(
-                error_buf,
-                error_buf_len,
-                "internal error: panic inside sv_explain_semantic_view_bind_rust",
-            );
-            2
-        }
+    if let Ok(rc) = result {
+        rc
+    } else {
+        use crate::ddl::read_ffi::write_err;
+        write_err(
+            error_buf,
+            error_buf_len,
+            "internal error: panic inside sv_explain_semantic_view_bind_rust",
+        );
+        2
     }
 }
 

--- a/src/query/table_function.rs
+++ b/src/query/table_function.rs
@@ -56,7 +56,11 @@ use super::wire::{build_execution_sql, parse_varchar_list, serialize_register_pa
 /// described above; `name_ptr` must point to `name_len` UTF-8 bytes.
 #[cfg(feature = "extension")]
 #[no_mangle]
-#[allow(clippy::too_many_arguments)]
+// Single linear FFI dispatcher: catch_unwind guard, arg decoding, catalog
+// lookup, expansion, schema inference, and wire serialization in one straight
+// path with no shared state — splitting it would scatter the panic boundary and
+// the borrow contract across helpers for no readability gain.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub unsafe extern "C" fn sv_semantic_view_bind_rust(
     conn: ffi::duckdb_connection,
     name_ptr: *const u8,
@@ -396,7 +400,8 @@ pub(crate) unsafe fn try_infer_schema(
 ) -> Result<(Vec<String>, Vec<ffi::duckdb_type>), String> {
     let mut result = execute_sql_raw(borrowed.as_raw(), sql)?;
 
-    let col_count = ffi::duckdb_column_count(&raw mut result) as usize;
+    // idx_t (u64) column count; `unwrap_or(0)` avoids a 32-bit truncation cast.
+    let col_count = usize::try_from(ffi::duckdb_column_count(&raw mut result)).unwrap_or(0);
     let mut names = Vec::with_capacity(col_count);
     let mut types = Vec::with_capacity(col_count);
 

--- a/src/query/table_function.rs
+++ b/src/query/table_function.rs
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn sv_semantic_view_bind_rust(
         let def = match SemanticViewDefinition::from_json(&view_name, &json_str) {
             Ok(d) => d,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.clone());
+                write_err(error_buf, error_buf_len, &e);
                 return 1_u8;
             }
         };

--- a/src/query/table_function.rs
+++ b/src/query/table_function.rs
@@ -91,12 +91,11 @@ pub unsafe extern "C" fn sv_semantic_view_bind_rust(
             return 1_u8;
         }
         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let view_name_raw = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s.to_string(),
-            Err(_) => {
-                write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
-                return 1_u8;
-            }
+        let view_name_raw = if let Ok(s) = std::str::from_utf8(name_bytes) {
+            s.to_string()
+        } else {
+            write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
+            return 1_u8;
         };
         let view_name = match crate::ident::normalize_view_name(&view_name_raw) {
             Ok(s) => s,
@@ -192,7 +191,7 @@ pub unsafe extern "C" fn sv_semantic_view_bind_rust(
         let def = match SemanticViewDefinition::from_json(&view_name, &json_str) {
             Ok(d) => d,
             Err(e) => {
-                write_err(error_buf, error_buf_len, &e.to_string());
+                write_err(error_buf, error_buf_len, &e.clone());
                 return 1_u8;
             }
         };
@@ -279,8 +278,7 @@ pub unsafe extern "C" fn sv_semantic_view_bind_rust(
             // expressions behind a VARCHAR placeholder at query time.
             match try_infer_schema(&borrowed, &limit0_sql) {
                 Ok((names, types)) => {
-                    let type_ids: Vec<u32> =
-                        types.iter().map(|t| normalize_type_id(*t as u32)).collect();
+                    let type_ids: Vec<u32> = types.iter().map(|t| normalize_type_id(*t)).collect();
                     (names, type_ids)
                 }
                 Err(msg) => {
@@ -312,17 +310,16 @@ pub unsafe extern "C" fn sv_semantic_view_bind_rust(
         publish_owned_buffer(buf, out_ptr, out_len);
         0_u8
     }));
-    match result {
-        Ok(rc) => rc,
-        Err(_) => {
-            use crate::ddl::read_ffi::write_err;
-            write_err(
-                error_buf,
-                error_buf_len,
-                "internal error: panic inside sv_semantic_view_bind_rust",
-            );
-            2
-        }
+    if let Ok(rc) = result {
+        rc
+    } else {
+        use crate::ddl::read_ffi::write_err;
+        write_err(
+            error_buf,
+            error_buf_len,
+            "internal error: panic inside sv_semantic_view_bind_rust",
+        );
+        2
     }
 }
 
@@ -330,7 +327,7 @@ pub unsafe extern "C" fn sv_semantic_view_bind_rust(
 // FFI helpers
 // ---------------------------------------------------------------------------
 
-/// Execute a SQL string via the DuckDB C API and return the result.
+/// Execute a SQL string via the `DuckDB` C API and return the result.
 ///
 /// The caller is responsible for calling `duckdb_destroy_result` on the returned
 /// result when done.
@@ -344,15 +341,15 @@ pub(crate) unsafe fn execute_sql_raw(
 ) -> Result<ffi::duckdb_result, String> {
     let sql_cstr = CString::new(sql).map_err(|e| e.to_string())?;
     let mut result: ffi::duckdb_result = std::mem::zeroed();
-    let rc = ffi::duckdb_query(conn, sql_cstr.as_ptr(), &mut result);
+    let rc = ffi::duckdb_query(conn, sql_cstr.as_ptr(), &raw mut result);
     if rc != ffi::DuckDBSuccess {
-        let err_ptr = ffi::duckdb_result_error(&mut result);
+        let err_ptr = ffi::duckdb_result_error(&raw mut result);
         let err_msg = if err_ptr.is_null() {
             "unknown error".to_string()
         } else {
             CStr::from_ptr(err_ptr).to_string_lossy().into_owned()
         };
-        ffi::duckdb_destroy_result(&mut result);
+        ffi::duckdb_destroy_result(&raw mut result);
         return Err(err_msg);
     }
     Ok(result)
@@ -360,7 +357,7 @@ pub(crate) unsafe fn execute_sql_raw(
 
 /// Normalize HUGEINT/UHUGEINT type IDs to BIGINT/UBIGINT.
 ///
-/// DuckDB's query planner infers `sum()` as HUGEINT at LIMIT-0 time, but the
+/// `DuckDB`'s query planner infers `sum()` as HUGEINT at LIMIT-0 time, but the
 /// runtime optimizer may substitute `sum_no_overflow` → BIGINT (8 bytes/value).
 /// Normalizing stored type IDs prevents stale HUGEINT values from propagating
 /// into output declarations.
@@ -399,12 +396,12 @@ pub(crate) unsafe fn try_infer_schema(
 ) -> Result<(Vec<String>, Vec<ffi::duckdb_type>), String> {
     let mut result = execute_sql_raw(borrowed.as_raw(), sql)?;
 
-    let col_count = ffi::duckdb_column_count(&mut result) as usize;
+    let col_count = ffi::duckdb_column_count(&raw mut result) as usize;
     let mut names = Vec::with_capacity(col_count);
     let mut types = Vec::with_capacity(col_count);
 
     for i in 0..col_count {
-        let name_ptr = ffi::duckdb_column_name(&mut result, i as ffi::idx_t);
+        let name_ptr = ffi::duckdb_column_name(&raw mut result, i as ffi::idx_t);
         let name = if name_ptr.is_null() {
             format!("column{i}")
         } else {
@@ -412,11 +409,11 @@ pub(crate) unsafe fn try_infer_schema(
         };
         names.push(name);
 
-        let ty = ffi::duckdb_column_type(&mut result, i as ffi::idx_t);
+        let ty = ffi::duckdb_column_type(&raw mut result, i as ffi::idx_t);
         types.push(ty);
     }
 
-    ffi::duckdb_destroy_result(&mut result);
+    ffi::duckdb_destroy_result(&raw mut result);
     Ok((names, types))
 }
 


### PR DESCRIPTION
## Why

CI runs clippy on the **default** feature set only (`cargo clippy -- -D warnings`), so the entire `#[cfg(feature = "extension")]` FFI layer — the `#[no_mangle] extern "C"` bind/exec dispatchers in `src/query/{table_function,explain}.rs`, `src/ddl/*_ffi.rs`, `src/parse/ffi.rs`, etc. — has never been clippy-checked. Surfacing it (via a full extension build) turned up **143 pedantic lints**. None were pre-existing regressions from recent work; they'd simply accumulated in an unlinted layer.

This PR clears all 143 and closes the gap so they can't silently re-accumulate.

## What

Four commits:

1. **`build.rs`: `SV_SKIP_CPP_BUILD` enabler.** `cargo clippy`/`check --features extension` otherwise triggers the ~25 MB DuckDB amalgamation + C++ shim compile (a ~10-min `cc` build), which is why this layer was never linted. Analysis-only cargo modes never link the final `cdylib`, so the env var makes `build.rs` return early — linting the FFI Rust becomes seconds, locally and in CI. A real `cargo build --features extension` must leave it unset.

2. **Machine-applicable fixes (~100).** `cargo clippy --fix --features extension`: doc backticks, `single_match_else` → `if let`, `implicit_clone`, `borrow_as_ptr` → `&raw const`, and other auto-applicable suggestions.

3. **The 32 non-autofixable lints, by hand.**
   - 11 `manual_let_else`: `let X = if let Ok(s)=… {s} else {…}` → `let Ok(X)=… else {…}`
   - 5 `too_many_lines`: rationale'd `#[allow]` on the linear FFI dispatchers / DESCRIBE row-builder — splitting would scatter the `catch_unwind` panic boundary and the borrow contract across helpers for no readability gain (matches the existing `body_parser` precedent)
   - 3 `cast_possible_truncation`: `idx_t` (u64) → `usize` capacity hints via `usize::try_from(..).unwrap_or(0)`
   - 2 `unnecessary_wraps`: rationale'd `#[allow]` to keep `rewrite_drop`/`rewrite_alter_rename` `Result`-symmetric with the genuinely-fallible `rewrite_*` siblings dispatched through the same `?`-chained match
   - 1 `missing_safety_doc`: retitle the list bind's borrow-contract section `# Safety`
   - 10 doc-list formatting: continuation indentation, and rewording doc lines that began with `+` (markdown parsed them as bullets)

4. **CI gate + docs.** New `Clippy (extension feature, deny warnings)` step in `CodeQuality.yml` (`SV_SKIP_CPP_BUILD=1 cargo clippy --no-default-features --features extension -- -D warnings`), and a MAINTAINER.md note documenting the local command and the coverage/lint split.

No behavior change — all fixes are lint hygiene in extension-gated code.

## Verification

- `SV_SKIP_CPP_BUILD=1 cargo clippy --no-default-features --features extension -- -D warnings` → **clean** (was 143)
- `cargo clippy -- -D warnings` (default) → clean
- `cargo test` → 12/12 binaries green
- `make debug` → real `.duckdb_extension` compiled + linked with all fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015wpHq92ExWRZFk6t3C7zEx)_