### PR TITLE
Code-review 2026-07-11 R4: finish run_dispatcher migration (ddl/ read dispatchers)

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -52,6 +52,22 @@ jobs:
       - name: cargo-deny (licenses + advisories)
         uses: EmbarkStudios/cargo-deny-action@v2
 
+      # `cargo llvm-cov` builds an instrumented copy of the WHOLE crate —
+      # including the bundled DuckDB linked by the default-feature `duckdb`
+      # dependency — plus every integration test binary into
+      # target/llvm-cov-target/. That tree runs right at the edge of the
+      # runner's ~14 GB free disk and has failed with "No space left on
+      # device". Reclaim the large preinstalled toolchains this job never uses
+      # (~25 GB) so the instrumented build has headroom. Inline shell (not a
+      # third-party action) to keep the supply-chain surface unchanged.
+      - name: Free disk space for the instrumented coverage build
+        run: |
+          echo "Before:" && df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+                      /usr/local/lib/android /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force || true
+          echo "After:" && df -h /
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 

--- a/src/ddl/describe.rs
+++ b/src/ddl/describe.rs
@@ -15,10 +15,6 @@ use crate::model::{AccessModifier, SemanticViewDefinition};
 /// `conn` is a borrowed handle; `name_ptr` must point to `name_len` UTF-8 bytes.
 #[cfg(feature = "extension")]
 #[no_mangle]
-// Single linear FFI dispatcher (catch_unwind guard, arg decode, catalog lookup,
-// row collection, wire serialization) kept as one path so the panic boundary
-// and borrow contract stay in one place.
-#[allow(clippy::too_many_lines)]
 pub unsafe extern "C" fn sv_describe_semantic_view_bind_rust(
     conn: libduckdb_sys::duckdb_connection,
     name_ptr: *const u8,
@@ -28,121 +24,75 @@ pub unsafe extern "C" fn sv_describe_semantic_view_bind_rust(
     error_buf: *mut u8,
     error_buf_len: usize,
 ) -> u8 {
-    use crate::ddl::read_ffi::{
-        probe_catalog_table_present, publish_owned_buffer, serialize_varchar_rows, write_err,
-        BorrowedConnection,
-    };
-    use std::panic::AssertUnwindSafe;
-    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-        let borrowed = BorrowedConnection::new(conn);
-        if borrowed.is_null() {
-            write_err(error_buf, error_buf_len, "duckdb_connection is null");
-            return 1_u8;
-        }
-        if name_ptr.is_null() {
-            write_err(error_buf, error_buf_len, "view name pointer is null");
-            return 1_u8;
-        }
-        let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let Ok(raw_name) = std::str::from_utf8(name_bytes) else {
-            write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
-            return 1_u8;
-        };
-        // FF-4: normalize so quoted-identifier inputs resolve like `semantic_view()`.
-        let name = match crate::ident::normalize_view_name(raw_name) {
-            Ok(s) => s,
-            Err(e) => {
-                write_err(
-                    error_buf,
-                    error_buf_len,
-                    &format!("Invalid view name '{raw_name}': {e}"),
-                );
-                return 1_u8;
-            }
-        };
-        // FF-9: surface a probe-query failure as an error distinct from "no
-        // views" instead of silently folding it into absence.
-        let present = match probe_catalog_table_present(&borrowed) {
-            Ok(p) => p,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let reader = CatalogReader::new(&borrowed, present);
-        let json = match reader.lookup(&name) {
-            Ok(Some(j)) => j,
-            Ok(None) => {
-                write_err(
-                    error_buf,
-                    error_buf_len,
-                    &crate::catalog::view_not_found_msg(&name),
-                );
-                return 1_u8;
-            }
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let def = match SemanticViewDefinition::from_json(&name, &json) {
-            Ok(d) => d,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let alias_map = def.alias_to_table_map();
-        let base_table = def.base_table().to_string();
+    crate::ddl::read_ffi::run_dispatcher(
+        conn,
+        out_ptr,
+        out_len,
+        error_buf,
+        error_buf_len,
+        "sv_describe_semantic_view_bind_rust",
+        |borrowed| unsafe { describe_view_rows(borrowed, name_ptr, name_len) },
+    )
+}
 
-        let mut internal: Vec<DescribeRow> = Vec::new();
-        if let Some(ref comment) = def.comment {
-            internal.push(DescribeRow {
-                object_kind: String::new(),
-                object_name: String::new(),
-                parent_entity: String::new(),
-                property: "COMMENT".to_string(),
-                property_value: comment.clone(),
-            });
-        }
-        collect_table_rows(&def, &mut internal);
-        collect_relationship_rows(&def, &alias_map, &mut internal);
-        collect_fact_rows(&def, &base_table, &alias_map, &mut internal);
-        collect_dimension_rows(&def, &base_table, &alias_map, &mut internal);
-        collect_metric_rows(&def, &base_table, &alias_map, &mut internal);
-        collect_materialization_rows(&def, &mut internal);
+/// Body for [`sv_describe_semantic_view_bind_rust`]: resolve the view and
+/// serialize its DESCRIBE property rows over the shared varchar wire format.
+///
+/// # Safety
+///
+/// `name_ptr` must be null or point to `name_len` readable bytes.
+#[cfg(feature = "extension")]
+unsafe fn describe_view_rows(
+    borrowed: &crate::ddl::read_ffi::BorrowedConnection,
+    name_ptr: *const u8,
+    name_len: usize,
+) -> Result<Vec<u8>, String> {
+    use crate::ddl::read_ffi::{probe_catalog_table_present, read_str_arg, serialize_varchar_rows};
 
-        let mut rows: Vec<Vec<String>> = Vec::with_capacity(internal.len());
-        for r in internal {
-            rows.push(vec![
+    let raw_name = read_str_arg(name_ptr, name_len, "view name")?;
+    // FF-4: normalize so quoted-identifier inputs resolve like `semantic_view()`.
+    let name = crate::ident::normalize_view_name(&raw_name)
+        .map_err(|e| format!("Invalid view name '{raw_name}': {e}"))?;
+    // FF-9: a probe-query failure is distinct from "no views" (propagated).
+    let present = probe_catalog_table_present(borrowed)?;
+    let reader = CatalogReader::new(borrowed, present);
+    let json = reader
+        .lookup(&name)?
+        .ok_or_else(|| crate::catalog::view_not_found_msg(&name))?;
+    let def = SemanticViewDefinition::from_json(&name, &json)?;
+    let alias_map = def.alias_to_table_map();
+    let base_table = def.base_table().to_string();
+
+    let mut internal: Vec<DescribeRow> = Vec::new();
+    if let Some(ref comment) = def.comment {
+        internal.push(DescribeRow {
+            object_kind: String::new(),
+            object_name: String::new(),
+            parent_entity: String::new(),
+            property: "COMMENT".to_string(),
+            property_value: comment.clone(),
+        });
+    }
+    collect_table_rows(&def, &mut internal);
+    collect_relationship_rows(&def, &alias_map, &mut internal);
+    collect_fact_rows(&def, &base_table, &alias_map, &mut internal);
+    collect_dimension_rows(&def, &base_table, &alias_map, &mut internal);
+    collect_metric_rows(&def, &base_table, &alias_map, &mut internal);
+    collect_materialization_rows(&def, &mut internal);
+
+    let rows: Vec<Vec<String>> = internal
+        .into_iter()
+        .map(|r| {
+            vec![
                 r.object_kind,
                 r.object_name,
                 r.parent_entity,
                 r.property,
                 r.property_value,
-            ]);
-        }
-        let buf = match serialize_varchar_rows(&rows) {
-            Ok(b) => b,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        publish_owned_buffer(buf, out_ptr, out_len);
-        0_u8
-    }));
-    if let Ok(rc) = result {
-        rc
-    } else {
-        use crate::ddl::read_ffi::write_err;
-        write_err(
-            error_buf,
-            error_buf_len,
-            "internal error: panic inside sv_describe_semantic_view_bind_rust",
-        );
-        2
-    }
+            ]
+        })
+        .collect();
+    serialize_varchar_rows(&rows)
 }
 
 /// A single property row in the DESCRIBE output.

--- a/src/ddl/get_ddl.rs
+++ b/src/ddl/get_ddl.rs
@@ -45,104 +45,59 @@ pub unsafe extern "C" fn sv_get_ddl_exec_rust(
     error_buf: *mut u8,
     error_buf_len: usize,
 ) -> u8 {
-    use crate::ddl::read_ffi::{
-        probe_catalog_table_present, publish_owned_buffer, write_err, BorrowedConnection,
-    };
-    use std::panic::AssertUnwindSafe;
-    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-        let borrowed = BorrowedConnection::new(conn);
-        if borrowed.is_null() {
-            write_err(error_buf, error_buf_len, "duckdb_connection is null");
-            return 1_u8;
-        }
-        if type_ptr.is_null() || name_ptr.is_null() {
-            write_err(error_buf, error_buf_len, "argument pointer is null");
-            return 1_u8;
-        }
-        let type_bytes = std::slice::from_raw_parts(type_ptr, type_len);
-        let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let Ok(obj_type) = std::str::from_utf8(type_bytes) else {
-            write_err(error_buf, error_buf_len, "object_type is not valid UTF-8");
-            return 1_u8;
-        };
-        let Ok(name) = std::str::from_utf8(name_bytes) else {
-            write_err(error_buf, error_buf_len, "name is not valid UTF-8");
-            return 1_u8;
-        };
+    crate::ddl::read_ffi::run_dispatcher(
+        conn,
+        out_ptr,
+        out_len,
+        error_buf,
+        error_buf_len,
+        "sv_get_ddl_exec_rust",
+        |borrowed| unsafe { get_ddl(borrowed, type_ptr, type_len, name_ptr, name_len) },
+    )
+}
 
-        if !obj_type.eq_ignore_ascii_case("SEMANTIC_VIEW") {
-            write_err(
-                error_buf,
-                error_buf_len,
-                &format!(
-                    "GET_DDL: unsupported object type '{obj_type}'. Only 'SEMANTIC_VIEW' is supported."
-                ),
-            );
-            return 1_u8;
-        }
+/// Body for [`sv_get_ddl_exec_rust`]: validate the object type, resolve the
+/// view, and render its `CREATE OR REPLACE SEMANTIC VIEW` DDL.
+///
+/// # Safety
+///
+/// `type_ptr` / `name_ptr` must each be null or point to the matching number
+/// of readable bytes.
+#[cfg(feature = "extension")]
+unsafe fn get_ddl(
+    borrowed: &crate::ddl::read_ffi::BorrowedConnection,
+    type_ptr: *const u8,
+    type_len: usize,
+    name_ptr: *const u8,
+    name_len: usize,
+) -> Result<Vec<u8>, String> {
+    use crate::ddl::read_ffi::{probe_catalog_table_present, read_str_arg};
 
-        // C-2 (code-review 2026-07-11): normalize the requested name like
-        // every other single-view read path (FF-4/PA-8 sweep) — fold
-        // unquoted case, strip qualification, unwrap quoting. Lenient
-        // contract mirrors read_yaml's `resolve_bare_name`: a name that does
-        // not parse as an identifier is looked up verbatim and fails with
-        // the canonical "does not exist" message.
-        let name = crate::ident::normalize_view_name(name).unwrap_or_else(|_| name.to_string());
+    let obj_type = read_str_arg(type_ptr, type_len, "object_type")?;
+    let raw_name = read_str_arg(name_ptr, name_len, "view name")?;
 
-        // FF-9: surface a probe-query failure as an error distinct from "no
-        // views" instead of silently folding it into absence.
-        let present = match probe_catalog_table_present(&borrowed) {
-            Ok(p) => p,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let reader = CatalogReader::new(&borrowed, present);
-        let json = match reader.lookup(&name) {
-            Ok(Some(j)) => j,
-            Ok(None) => {
-                write_err(
-                    error_buf,
-                    error_buf_len,
-                    &crate::catalog::view_not_found_msg(&name),
-                );
-                return 1_u8;
-            }
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        // C-2: `from_json` for the canonical "invalid definition for
-        // semantic view '<name>'" context on corrupt rows (raw serde
-        // messages were the get_ddl/read_yaml exception).
-        let def = match SemanticViewDefinition::from_json(&name, &json) {
-            Ok(d) => d,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let ddl = match render_create_ddl(&name, &def) {
-            Ok(s) => s,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &format!("GET_DDL error: {e}"));
-                return 1_u8;
-            }
-        };
-        publish_owned_buffer(ddl.into_bytes(), out_ptr, out_len);
-        0_u8
-    }));
-    if let Ok(rc) = result {
-        rc
-    } else {
-        use crate::ddl::read_ffi::write_err;
-        write_err(
-            error_buf,
-            error_buf_len,
-            "internal error: panic inside sv_get_ddl_exec_rust",
-        );
-        2
+    if !obj_type.eq_ignore_ascii_case("SEMANTIC_VIEW") {
+        return Err(format!(
+            "GET_DDL: unsupported object type '{obj_type}'. Only 'SEMANTIC_VIEW' is supported."
+        ));
     }
+
+    // C-2 (code-review 2026-07-11): normalize the requested name like every
+    // other single-view read path (FF-4/PA-8 sweep). Lenient contract mirrors
+    // read_yaml's `resolve_bare_name`: a name that does not parse as an
+    // identifier is looked up verbatim and fails with the canonical message.
+    let name = crate::ident::normalize_view_name(&raw_name).unwrap_or(raw_name);
+
+    // FF-9: a probe-query failure is distinct from "no views" (propagated).
+    let present = probe_catalog_table_present(borrowed)?;
+    let reader = CatalogReader::new(borrowed, present);
+    let json = reader
+        .lookup(&name)?
+        .ok_or_else(|| crate::catalog::view_not_found_msg(&name))?;
+    // C-2: `from_json` for the canonical "invalid definition for semantic
+    // view '<name>'" context on corrupt rows.
+    let def = SemanticViewDefinition::from_json(&name, &json)?;
+    render_create_ddl(&name, &def)
+        .map(String::into_bytes)
+        .map_err(|e| format!("GET_DDL error: {e}"))
 }

--- a/src/ddl/list.rs
+++ b/src/ddl/list.rs
@@ -83,99 +83,73 @@ pub unsafe extern "C" fn sv_list_semantic_views_bind_rust(
     error_buf: *mut u8,
     error_buf_len: usize,
 ) -> u8 {
-    use crate::ddl::read_ffi::{
-        probe_catalog_table_present, publish_owned_buffer, serialize_varchar_rows, write_err,
-        BorrowedConnection,
-    };
-    use std::panic::AssertUnwindSafe;
-    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-        // Wrap the raw FFI handle in a BorrowedConnection at the boundary
-        // (D-10 / WR-05). Everything below this point goes through &borrowed
-        // or borrowed.as_raw(); the raw `conn` parameter is shadowed and
-        // never used again.
-        let borrowed = BorrowedConnection::new(conn);
-        if borrowed.is_null() {
-            write_err(error_buf, error_buf_len, "duckdb_connection is null");
-            return 1_u8;
+    crate::ddl::read_ffi::run_dispatcher(
+        conn,
+        out_ptr,
+        out_len,
+        error_buf,
+        error_buf_len,
+        "sv_list_semantic_views_bind_rust",
+        |borrowed| unsafe {
+            list_view_rows(borrowed, /* include_comment = */ true)
+        },
+    )
+}
+
+/// Shared body for both `list_semantic_views()` (6 columns) and
+/// `list_terse_semantic_views()` (5 columns — no trailing `comment`): probe
+/// the catalog, read every definition, and serialize the rows over the shared
+/// varchar wire format, name-sorted for byte-stable output.
+///
+/// FF-9: a genuine probe-query failure surfaces as an error rather than being
+/// folded into "no views" (an attached read-only DB without a bootstrapped
+/// catalog still returns 0 rows via `probe_catalog_table_present == false`).
+///
+/// # Safety
+///
+/// `borrowed` must wrap a live `duckdb_connection` (guaranteed by
+/// `run_dispatcher`, which constructs and null-checks it before calling).
+#[cfg(feature = "extension")]
+unsafe fn list_view_rows(
+    borrowed: &crate::ddl::read_ffi::BorrowedConnection,
+    include_comment: bool,
+) -> Result<Vec<u8>, String> {
+    use crate::ddl::read_ffi::{probe_catalog_table_present, serialize_varchar_rows};
+
+    let table_present = probe_catalog_table_present(borrowed)?;
+    let reader = CatalogReader::new(borrowed, table_present);
+    let entries = reader.list_all()?;
+
+    let mut rows: Vec<Vec<String>> = Vec::with_capacity(entries.len());
+    for (name, json) in &entries {
+        let def = SemanticViewDefinition::from_json(name, json).ok();
+        let (created_on, database_name, schema_name, comment) = match &def {
+            Some(d) => (
+                d.created_on.clone().unwrap_or_default(),
+                d.database_name.clone().unwrap_or_default(),
+                d.schema_name.clone().unwrap_or_default(),
+                d.comment.clone().unwrap_or_default(),
+            ),
+            None => (String::new(), String::new(), String::new(), String::new()),
+        };
+        let mut row = vec![
+            created_on,
+            name.clone(),
+            "SEMANTIC_VIEW".to_string(),
+            database_name,
+            schema_name,
+        ];
+        if include_comment {
+            row.push(comment);
         }
-
-        // Probe whether semantic_layer._definitions exists on the caller's
-        // connection. Cheap (single query); matches Phase 63's RO-load
-        // short-circuit semantics so an attached read-only DB without a
-        // bootstrapped catalog returns Ok(false) (0 rows) instead of an error.
-        // FF-9: a genuine probe-query failure now surfaces as an error rather
-        // than being silently folded into "no views".
-        let table_present = match probe_catalog_table_present(&borrowed) {
-            Ok(p) => p,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-
-        // CatalogReader::new only stores the raw pointer extracted via
-        // borrowed.as_raw() — no transfer of ownership.
-        let reader = CatalogReader::new(&borrowed, table_present);
-        let entries = match reader.list_all() {
-            Ok(e) => e,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-
-        // Reconstruct the 6-column rows exactly like the Rust VTab did
-        // (ListBindData::rows) — sort by name so output ordering is
-        // byte-identical to the v0.9.0 behavior.
-        let mut rows: Vec<Vec<String>> = Vec::with_capacity(entries.len());
-        for (name, json) in &entries {
-            let def = SemanticViewDefinition::from_json(name, json).ok();
-            let (created_on, database_name, schema_name, comment) = match &def {
-                Some(d) => (
-                    d.created_on.clone().unwrap_or_default(),
-                    d.database_name.clone().unwrap_or_default(),
-                    d.schema_name.clone().unwrap_or_default(),
-                    d.comment.clone().unwrap_or_default(),
-                ),
-                None => (String::new(), String::new(), String::new(), String::new()),
-            };
-            rows.push(vec![
-                created_on,
-                name.clone(),
-                "SEMANTIC_VIEW".to_string(),
-                database_name,
-                schema_name,
-                comment,
-            ]);
-        }
-        rows.sort_by(|a, b| a[1].cmp(&b[1]));
-
-        // FF-6: the shared serializer returns an error (rather than clamping a
-        // length to u32::MAX and desyncing the header from the payload) if a
-        // cell or the row count overflows the wire format's u32 fields. The
-        // previous inline copy used bare `as u32` casts. `publish_owned_buffer`
-        // hands the heap-owned buffer to C++ under the both-or-drop contract;
-        // the caller releases it via sv_free_buffer with the exact (ptr, len).
-        let buf = match serialize_varchar_rows(&rows) {
-            Ok(b) => b,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        publish_owned_buffer(buf, out_ptr, out_len);
-        0_u8
-    }));
-    if let Ok(rc) = result {
-        rc
-    } else {
-        write_err(
-            error_buf,
-            error_buf_len,
-            "internal error: panic inside sv_list_semantic_views_bind_rust",
-        );
-        2
+        rows.push(row);
     }
+    rows.sort_by(|a, b| a[1].cmp(&b[1]));
+
+    // FF-6: the shared serializer errors (rather than clamping a length to
+    // u32::MAX and desyncing the header from the payload) if a cell or the
+    // row count overflows the wire format's u32 fields.
+    serialize_varchar_rows(&rows)
 }
 
 // Phase 65.1 Plan 03a (IN-06 / D-26): the module-local duplicates of
@@ -215,76 +189,15 @@ pub unsafe extern "C" fn sv_list_terse_semantic_views_bind_rust(
     error_buf: *mut u8,
     error_buf_len: usize,
 ) -> u8 {
-    use crate::ddl::read_ffi::{
-        probe_catalog_table_present, publish_owned_buffer, serialize_varchar_rows, write_err,
-        BorrowedConnection,
-    };
-    use std::panic::AssertUnwindSafe;
-    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-        let borrowed = BorrowedConnection::new(conn);
-        if borrowed.is_null() {
-            write_err(error_buf, error_buf_len, "duckdb_connection is null");
-            return 1_u8;
-        }
-
-        // FF-9: a genuine probe-query failure now surfaces as an error rather
-        // than being silently folded into "no views".
-        let table_present = match probe_catalog_table_present(&borrowed) {
-            Ok(p) => p,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let reader = CatalogReader::new(&borrowed, table_present);
-        let entries = match reader.list_all() {
-            Ok(e) => e,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-
-        let mut rows: Vec<Vec<String>> = Vec::with_capacity(entries.len());
-        for (name, json) in &entries {
-            let def = SemanticViewDefinition::from_json(name, json).ok();
-            let (created_on, database_name, schema_name) = match &def {
-                Some(d) => (
-                    d.created_on.clone().unwrap_or_default(),
-                    d.database_name.clone().unwrap_or_default(),
-                    d.schema_name.clone().unwrap_or_default(),
-                ),
-                None => (String::new(), String::new(), String::new()),
-            };
-            rows.push(vec![
-                created_on,
-                name.clone(),
-                "SEMANTIC_VIEW".to_string(),
-                database_name,
-                schema_name,
-            ]);
-        }
-        rows.sort_by(|a, b| a[1].cmp(&b[1]));
-
-        let buf = match serialize_varchar_rows(&rows) {
-            Ok(b) => b,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        publish_owned_buffer(buf, out_ptr, out_len);
-        0_u8
-    }));
-    if let Ok(rc) = result {
-        rc
-    } else {
-        use crate::ddl::read_ffi::write_err;
-        write_err(
-            error_buf,
-            error_buf_len,
-            "internal error: panic inside sv_list_terse_semantic_views_bind_rust",
-        );
-        2
-    }
+    crate::ddl::read_ffi::run_dispatcher(
+        conn,
+        out_ptr,
+        out_len,
+        error_buf,
+        error_buf_len,
+        "sv_list_terse_semantic_views_bind_rust",
+        |borrowed| unsafe {
+            list_view_rows(borrowed, /* include_comment = */ false)
+        },
+    )
 }

--- a/src/ddl/read_yaml.rs
+++ b/src/ddl/read_yaml.rs
@@ -54,83 +54,44 @@ pub unsafe extern "C" fn sv_read_yaml_from_semantic_view_exec_rust(
     error_buf: *mut u8,
     error_buf_len: usize,
 ) -> u8 {
-    use crate::ddl::read_ffi::{
-        probe_catalog_table_present, publish_owned_buffer, write_err, BorrowedConnection,
-    };
-    use std::panic::AssertUnwindSafe;
-    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-        let borrowed = BorrowedConnection::new(conn);
-        if borrowed.is_null() {
-            write_err(error_buf, error_buf_len, "duckdb_connection is null");
-            return 1_u8;
-        }
-        if name_ptr.is_null() {
-            write_err(error_buf, error_buf_len, "view name pointer is null");
-            return 1_u8;
-        }
-        let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let Ok(raw_name) = std::str::from_utf8(name_bytes) else {
-            write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
-            return 1_u8;
-        };
-        let bare_name = resolve_bare_name(raw_name);
+    crate::ddl::read_ffi::run_dispatcher(
+        conn,
+        out_ptr,
+        out_len,
+        error_buf,
+        error_buf_len,
+        "sv_read_yaml_from_semantic_view_exec_rust",
+        |borrowed| unsafe { read_yaml_export(borrowed, name_ptr, name_len) },
+    )
+}
 
-        // FF-9: surface a probe-query failure as an error distinct from "no
-        // views" instead of silently folding it into absence.
-        let present = match probe_catalog_table_present(&borrowed) {
-            Ok(p) => p,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let reader = CatalogReader::new(&borrowed, present);
-        let json = match reader.lookup(&bare_name) {
-            Ok(Some(j)) => j,
-            Ok(None) => {
-                write_err(
-                    error_buf,
-                    error_buf_len,
-                    &crate::catalog::view_not_found_msg(&bare_name),
-                );
-                return 1_u8;
-            }
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        // C-2 (code-review 2026-07-11): `from_json` for the canonical
-        // "invalid definition for semantic view '<name>'" context on corrupt
-        // rows, matching every TF dispatcher.
-        let def = match SemanticViewDefinition::from_json(&bare_name, &json) {
-            Ok(d) => d,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let yaml = match render_yaml_export(&def) {
-            Ok(s) => s,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        publish_owned_buffer(yaml.into_bytes(), out_ptr, out_len);
-        0_u8
-    }));
-    if let Ok(rc) = result {
-        rc
-    } else {
-        use crate::ddl::read_ffi::write_err;
-        write_err(
-            error_buf,
-            error_buf_len,
-            "internal error: panic inside sv_read_yaml_from_semantic_view_exec_rust",
-        );
-        2
-    }
+/// Body for [`sv_read_yaml_from_semantic_view_exec_rust`]: resolve the view
+/// and render its YAML export.
+///
+/// # Safety
+///
+/// `name_ptr` must be null or point to `name_len` readable bytes.
+#[cfg(feature = "extension")]
+unsafe fn read_yaml_export(
+    borrowed: &crate::ddl::read_ffi::BorrowedConnection,
+    name_ptr: *const u8,
+    name_len: usize,
+) -> Result<Vec<u8>, String> {
+    use crate::ddl::read_ffi::{probe_catalog_table_present, read_str_arg};
+
+    let raw_name = read_str_arg(name_ptr, name_len, "view name")?;
+    let bare_name = resolve_bare_name(&raw_name);
+
+    // FF-9: a probe-query failure is distinct from "no views" (propagated).
+    let present = probe_catalog_table_present(borrowed)?;
+    let reader = CatalogReader::new(borrowed, present);
+    let json = reader
+        .lookup(&bare_name)?
+        .ok_or_else(|| crate::catalog::view_not_found_msg(&bare_name))?;
+    // C-2 (code-review 2026-07-11): `from_json` for the canonical
+    // "invalid definition for semantic view '<name>'" context on corrupt rows.
+    let def = SemanticViewDefinition::from_json(&bare_name, &json)?;
+    render_yaml_export(&def).map(String::into_bytes)
 }
 
 #[cfg(test)]

--- a/src/ddl/show_columns.rs
+++ b/src/ddl/show_columns.rs
@@ -27,77 +27,47 @@ pub unsafe extern "C" fn sv_show_columns_in_semantic_view_bind_rust(
     error_buf: *mut u8,
     error_buf_len: usize,
 ) -> u8 {
-    use crate::ddl::read_ffi::{
-        probe_catalog_table_present, publish_owned_buffer, serialize_varchar_rows, write_err,
-        BorrowedConnection,
-    };
-    use std::panic::AssertUnwindSafe;
-    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-        let borrowed = BorrowedConnection::new(conn);
-        if borrowed.is_null() {
-            write_err(error_buf, error_buf_len, "duckdb_connection is null");
-            return 1_u8;
-        }
-        if name_ptr.is_null() {
-            write_err(error_buf, error_buf_len, "view name pointer is null");
-            return 1_u8;
-        }
-        let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let Ok(raw_name) = std::str::from_utf8(name_bytes) else {
-            write_err(error_buf, error_buf_len, "view name is not valid UTF-8");
-            return 1_u8;
-        };
-        // FF-4: normalize so quoted-identifier inputs resolve like `semantic_view()`.
-        let view_name = match crate::ident::normalize_view_name(raw_name) {
-            Ok(s) => s,
-            Err(e) => {
-                write_err(
-                    error_buf,
-                    error_buf_len,
-                    &format!("Invalid view name '{raw_name}': {e}"),
-                );
-                return 1_u8;
-            }
-        };
-        // FF-9: surface a probe-query failure as an error distinct from "no
-        // views" instead of silently folding it into absence.
-        let present = match probe_catalog_table_present(&borrowed) {
-            Ok(p) => p,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let reader = CatalogReader::new(&borrowed, present);
-        let json = match reader.lookup(&view_name) {
-            Ok(Some(j)) => j,
-            Ok(None) => {
-                // C-4 (code-review 2026-07-11): canonical wording via
-                // view_not_found_msg — SHOW COLUMNS was the one read path
-                // with divergent "not found" phrasing.
-                write_err(
-                    error_buf,
-                    error_buf_len,
-                    &crate::catalog::view_not_found_msg(&view_name),
-                );
-                return 1_u8;
-            }
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let def = match SemanticViewDefinition::from_json(&view_name, &json) {
-            Ok(d) => d,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        let internal_rows = collect_column_rows(&def, &view_name);
-        let mut rows: Vec<Vec<String>> = Vec::with_capacity(internal_rows.len());
-        for r in internal_rows {
-            rows.push(vec![
+    crate::ddl::read_ffi::run_dispatcher(
+        conn,
+        out_ptr,
+        out_len,
+        error_buf,
+        error_buf_len,
+        "sv_show_columns_in_semantic_view_bind_rust",
+        |borrowed| unsafe { show_columns_rows(borrowed, name_ptr, name_len) },
+    )
+}
+
+/// Body for [`sv_show_columns_in_semantic_view_bind_rust`]: resolve the view
+/// and serialize its column rows over the shared varchar wire format.
+///
+/// # Safety
+///
+/// `name_ptr` must be null or point to `name_len` readable bytes.
+#[cfg(feature = "extension")]
+unsafe fn show_columns_rows(
+    borrowed: &crate::ddl::read_ffi::BorrowedConnection,
+    name_ptr: *const u8,
+    name_len: usize,
+) -> Result<Vec<u8>, String> {
+    use crate::ddl::read_ffi::{probe_catalog_table_present, read_str_arg, serialize_varchar_rows};
+
+    let raw_name = read_str_arg(name_ptr, name_len, "view name")?;
+    // FF-4: normalize so quoted-identifier inputs resolve like `semantic_view()`.
+    let view_name = crate::ident::normalize_view_name(&raw_name)
+        .map_err(|e| format!("Invalid view name '{raw_name}': {e}"))?;
+    // FF-9: a probe-query failure is distinct from "no views" (propagated).
+    let present = probe_catalog_table_present(borrowed)?;
+    let reader = CatalogReader::new(borrowed, present);
+    // C-4 (code-review 2026-07-11): canonical wording via view_not_found_msg.
+    let json = reader
+        .lookup(&view_name)?
+        .ok_or_else(|| crate::catalog::view_not_found_msg(&view_name))?;
+    let def = SemanticViewDefinition::from_json(&view_name, &json)?;
+    let rows: Vec<Vec<String>> = collect_column_rows(&def, &view_name)
+        .into_iter()
+        .map(|r| {
+            vec![
                 r.database_name,
                 r.schema_name,
                 r.semantic_view_name,
@@ -106,29 +76,10 @@ pub unsafe extern "C" fn sv_show_columns_in_semantic_view_bind_rust(
                 r.kind,
                 r.expression,
                 r.comment,
-            ]);
-        }
-        let buf = match serialize_varchar_rows(&rows) {
-            Ok(b) => b,
-            Err(e) => {
-                write_err(error_buf, error_buf_len, &e);
-                return 1_u8;
-            }
-        };
-        publish_owned_buffer(buf, out_ptr, out_len);
-        0_u8
-    }));
-    if let Ok(rc) = result {
-        rc
-    } else {
-        use crate::ddl::read_ffi::write_err;
-        write_err(
-            error_buf,
-            error_buf_len,
-            "internal error: panic inside sv_show_columns_in_semantic_view_bind_rust",
-        );
-        2
-    }
+            ]
+        })
+        .collect();
+    serialize_varchar_rows(&rows)
 }
 
 /// A single row in the SHOW COLUMNS IN SEMANTIC VIEW output.


### PR DESCRIPTION
Fourth PR of the 2026-07-11 remediation series (follows #71, #72, #73). Completes the deferred half-migration from the review's C-3 / R-6: the ST-2 `run_dispatcher` scaffold existed and was proven in 3 modules, but 6 of the `src/ddl/` read-side FFI dispatchers still hand-rolled the same boilerplate ladder. **No behavioural change.**

## What changed

Each migrated dispatcher was ~30–40 lines of the identical `catch_unwind(AssertUnwindSafe(|| { null-check; …; match { Ok => publish; Err => write_err+return 1 } }))` frame plus a panic arm returning rc 2. They now decode their arguments via `read_str_arg` and return `Result<Vec<u8>, String>` from a small body function; the panic boundary, borrow contract, and the `0`/`1`/`2` return-code contract are single-sourced in `run_dispatcher`.

| Dispatcher | File |
|---|---|
| `describe_semantic_view` | `src/ddl/describe.rs` |
| `show_columns_in_semantic_view` | `src/ddl/show_columns.rs` |
| `get_ddl` | `src/ddl/get_ddl.rs` |
| `read_yaml_from_semantic_view` | `src/ddl/read_yaml.rs` |
| `list_semantic_views` | `src/ddl/list.rs` |
| `list_terse_semantic_views` | `src/ddl/list.rs` |

The two `list` bodies (6-column vs 5-column, differing only in a trailing `comment`) are unified into one shared `list_view_rows(borrowed, include_comment)` — the terse variant simply appends no comment column.

**Net −270 lines** across 5 files, and every error path in these dispatchers now shares one rc contract instead of six hand-maintained copies.

## Scope note

The two query-path binds — `semantic_view` and `explain_semantic_view` in `src/query/` — also end in a single `publish_owned_buffer` and are structurally migratable, but they involve wildcard expansion and LIMIT-0 type inference and live in a different subsystem. Migrating them is left for a focused follow-up rather than bundled with the `ddl/` read-path sweep, to keep this PR to one cohesive boundary. After that, all 17 read-side dispatchers will be on the scaffold.

## Verification

- `cargo test`: 1,094 lib tests, green
- Extension rebuilt; **sqllogictest 69/69** — exercises DESCRIBE / SHOW COLUMNS / GET_DDL / READ_YAML / `list_semantic_views` end-to-end through the migrated dispatchers
- DuckLake CI: pass
- `cargo fmt --check`; `cargo clippy -- -D warnings` and `SV_SKIP_CPP_BUILD=1 cargo clippy --no-default-features --features extension -- -D warnings`: both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mHHdC6wSnG51pwXKZGsWX

---
_Generated by [Claude Code](https://claude.ai/code/session_013mHHdC6wSnG51pwXKZGsWX)_