### PR TITLE
Code-review 2026-07-11 R10: idiomatic hardening cleanups (R-7/R-8/R-9 + R-13/R-15/R-16/C-11)

### DIFF
--- a/src/expand/fan_trap.rs
+++ b/src/expand/fan_trap.rs
@@ -4,7 +4,7 @@ use crate::model::{Cardinality, Metric, SemanticViewDefinition};
 
 use super::facts::collect_derived_metric_source_tables;
 use super::semi_additive::is_active_semi_additive;
-use super::types::ExpandError;
+use super::types::{ExpandError, FanTrapError, MetricFanTrapError};
 
 /// Cardinality map: `(from_lower, to_lower)` -> (worst-case cardinality,
 /// name of a relationship carrying that cardinality).
@@ -32,7 +32,7 @@ type CardMap = HashMap<(String, String), (Cardinality, String)>;
 /// For an edge `(from_alias, to_alias)` with cardinality:
 /// - `ManyToOne`: from->to is safe (many go to one), to->from is fan-out
 /// - `OneToOne`: both directions are safe
-#[allow(clippy::result_large_err, clippy::too_many_lines)]
+#[allow(clippy::too_many_lines)]
 pub(super) fn check_fan_traps(
     view_name: &str,
     def: &SemanticViewDefinition,
@@ -116,15 +116,17 @@ pub(super) fn check_fan_traps(
                     .or_else(|| fanning_edge_on_path(&down_path, &card_map));
                 if let Some(rel_name) = fanning {
                     return Err(ExpandError::FanTrap {
-                        view_name: view_name.to_string(),
-                        metric_name: met.name.clone(),
-                        metric_table: met
-                            .source_table
-                            .clone()
-                            .unwrap_or_else(|| met_table.clone()),
-                        dimension_name: dim.name.clone(),
-                        dimension_table: dim_table_raw.clone(),
-                        relationship_name: rel_name,
+                        detail: Box::new(FanTrapError {
+                            view_name: view_name.to_string(),
+                            metric_name: met.name.clone(),
+                            metric_table: met
+                                .source_table
+                                .clone()
+                                .unwrap_or_else(|| met_table.clone()),
+                            dimension_name: dim.name.clone(),
+                            dimension_table: dim_table_raw.clone(),
+                            relationship_name: rel_name,
+                        }),
                     });
                 }
             }
@@ -176,12 +178,14 @@ pub(super) fn check_fan_traps(
                     };
                     if let Some(rel_name) = fanning_edge_on_path(&path, &card_map) {
                         return Err(ExpandError::MetricFanTrap {
-                            view_name: view_name.to_string(),
-                            metric_name: met_a.name.clone(),
-                            metric_table: table_a.clone(),
-                            other_metric_name: met_b.name.clone(),
-                            other_metric_table: table_b.clone(),
-                            relationship_name: rel_name,
+                            detail: Box::new(MetricFanTrapError {
+                                view_name: view_name.to_string(),
+                                metric_name: met_a.name.clone(),
+                                metric_table: table_a.clone(),
+                                other_metric_name: met_b.name.clone(),
+                                other_metric_table: table_b.clone(),
+                                relationship_name: rel_name,
+                            }),
                         });
                     }
                 }
@@ -206,7 +210,6 @@ pub(super) fn check_fan_traps(
 /// fan-trap check passes vacuously. Reject such definitions up front so an
 /// un-upgradeable legacy row (which the `init_catalog` upgrade pass leaves at
 /// `schema_version` 0) fails loudly here instead of under-checking.
-#[allow(clippy::result_large_err)]
 fn build_relationship_graph(
     view_name: &str,
     def: &SemanticViewDefinition,
@@ -437,7 +440,6 @@ fn fanning_edge_on_path(path: &[String], card_map: &CardMap) -> Option<String> {
 ///
 /// Skips validation when there is only one unique table (trivially valid)
 /// or when there are no joins (single-table view).
-#[allow(clippy::result_large_err)]
 pub(super) fn validate_fact_table_path(
     view_name: &str,
     def: &SemanticViewDefinition,
@@ -608,8 +610,8 @@ mod tests {
         let resolved_mets: Vec<&_> = def.metrics.iter().collect();
         let result = check_fan_traps("test", &def, &resolved_dims, &resolved_mets);
         assert!(result.is_err(), "Should detect fan-out");
-        if let Err(ExpandError::FanTrap { metric_name, .. }) = &result {
-            assert_eq!(metric_name, "total");
+        if let Err(ExpandError::FanTrap { detail }) = &result {
+            assert_eq!(detail.metric_name, "total");
         } else {
             panic!("Expected FanTrap error, got: {result:?}");
         }
@@ -817,19 +819,12 @@ mod tests {
         let resolved_mets: Vec<&_> = def.metrics.iter().collect();
         let result = check_fan_traps("test", &def, &[], &resolved_mets);
         match result {
-            Err(ExpandError::MetricFanTrap {
-                metric_name,
-                metric_table,
-                other_metric_name,
-                other_metric_table,
-                relationship_name,
-                ..
-            }) => {
-                assert_eq!(metric_name, "order_total", "inflated metric");
-                assert_eq!(metric_table, "o");
-                assert_eq!(other_metric_name, "item_count");
-                assert_eq!(other_metric_table, "li");
-                assert_eq!(relationship_name, "items_to_orders");
+            Err(ExpandError::MetricFanTrap { detail }) => {
+                assert_eq!(detail.metric_name, "order_total", "inflated metric");
+                assert_eq!(detail.metric_table, "o");
+                assert_eq!(detail.other_metric_name, "item_count");
+                assert_eq!(detail.other_metric_table, "li");
+                assert_eq!(detail.relationship_name, "items_to_orders");
             }
             other => panic!("Expected MetricFanTrap, got: {other:?}"),
         }
@@ -852,13 +847,9 @@ mod tests {
         let resolved_mets: Vec<&_> = def.metrics.iter().collect();
         let result = check_fan_traps("test", &def, &[], &resolved_mets);
         match result {
-            Err(ExpandError::MetricFanTrap {
-                metric_name,
-                other_metric_name,
-                ..
-            }) => {
-                assert_eq!(metric_name, "item_total");
-                assert_eq!(other_metric_name, "payment_total");
+            Err(ExpandError::MetricFanTrap { detail }) => {
+                assert_eq!(detail.metric_name, "item_total");
+                assert_eq!(detail.other_metric_name, "payment_total");
             }
             other => panic!("Expected MetricFanTrap for chasm trap, got: {other:?}"),
         }
@@ -908,15 +899,13 @@ mod tests {
         let resolved_mets: Vec<&_> = def.metrics.iter().collect();
         let result = check_fan_traps("test", &def, &[], &resolved_mets);
         match result {
-            Err(ExpandError::MetricFanTrap {
-                metric_name,
-                metric_table,
-                other_metric_name,
-                ..
-            }) => {
-                assert_eq!(metric_name, "order_total");
-                assert_eq!(metric_table, "o", "base metric resolves to the root grain");
-                assert_eq!(other_metric_name, "item_count");
+            Err(ExpandError::MetricFanTrap { detail }) => {
+                assert_eq!(detail.metric_name, "order_total");
+                assert_eq!(
+                    detail.metric_table, "o",
+                    "base metric resolves to the root grain"
+                );
+                assert_eq!(detail.other_metric_name, "item_count");
             }
             other => panic!("Expected MetricFanTrap, got: {other:?}"),
         }
@@ -1005,11 +994,9 @@ mod tests {
             let resolved_mets: Vec<&_> = def.metrics.iter().collect();
             let result = check_fan_traps("test", &def, &resolved_dims, &resolved_mets);
             match result {
-                Err(ExpandError::FanTrap {
-                    relationship_name, ..
-                }) => {
+                Err(ExpandError::FanTrap { detail }) => {
                     assert_eq!(
-                        relationship_name, "rel_m2o",
+                        detail.relationship_name, "rel_m2o",
                         "error must name the fanning relationship (m2o_first={m2o_first})"
                     );
                 }

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -20,7 +20,9 @@ mod test_helpers;
 // Public API (matches prior expand.rs surface exactly)
 pub use resolution::{quote_ident, quote_ident_if_needed, quote_table_ref};
 pub use sql_gen::expand;
-pub use types::{DimensionName, ExpandError, MetricName, QueryRequest};
+pub use types::{
+    DimensionName, ExpandError, FanTrapError, MetricFanTrapError, MetricName, QueryRequest,
+};
 
 // Crate-internal API (used by ddl/show_dims_for_metric.rs under extension feature)
 #[cfg(feature = "extension")]

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -17,7 +17,8 @@ mod window;
 #[cfg(test)]
 mod test_helpers;
 
-// Public API (matches prior expand.rs surface exactly)
+// Public API (the pre-split expand.rs surface, plus the boxed fan-trap detail
+// structs re-exported for R-9).
 pub use resolution::{quote_ident, quote_ident_if_needed, quote_table_ref};
 pub use sql_gen::expand;
 pub use types::{

--- a/src/expand/role_playing.rs
+++ b/src/expand/role_playing.rs
@@ -65,7 +65,6 @@ pub(super) fn is_role_playing_target(def: &SemanticViewDefinition, target_alias:
 /// - `Ok(None)` if the dimension's table is not a role-playing table (single or no relationship)
 /// - `Ok(Some(scoped_alias))` if exactly one USING path disambiguates
 /// - `Err(ExpandError::AmbiguousPath)` if ambiguous with no single USING context
-#[allow(clippy::result_large_err)]
 pub(super) fn find_using_context(
     view_name: &str,
     def: &SemanticViewDefinition,

--- a/src/expand/semi_additive.rs
+++ b/src/expand/semi_additive.rs
@@ -40,7 +40,7 @@ use crate::util::replace_word_boundary;
 
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{qualify_and_quote_table_ref, quote_ident};
-use super::types::ExpandError;
+use super::types::{ExpandError, ResolvedDim};
 
 /// Returns true when `met` is an ACTIVE semi-additive metric for a query over
 /// `queried_dim_names` (lowercased): it has a NON ADDITIVE BY clause and at
@@ -69,17 +69,16 @@ pub(super) fn is_active_semi_additive(met: &Metric, queried_dim_names: &HashSet<
 pub(super) fn expand_semi_additive(
     view_name: &str,
     def: &SemanticViewDefinition,
-    resolved_dims: &[&crate::model::Dimension],
+    resolved_dims: &[ResolvedDim],
     resolved_mets: &[&Metric],
     resolved_exprs: &HashMap<String, String>,
-    dim_scoped_aliases: &[Option<String>],
 ) -> Result<String, ExpandError> {
     let mut sql = String::with_capacity(512);
 
     // Build set of queried dimension names for classification
     let queried_dim_names: HashSet<String> = resolved_dims
         .iter()
-        .map(|d| d.name.to_ascii_lowercase())
+        .map(|rd| rd.dim.name.to_ascii_lowercase())
         .collect();
 
     // Classify each metric as active semi-additive (shared routing predicate)
@@ -143,9 +142,10 @@ pub(super) fn expand_semi_additive(
     // standard path defends against the same shadowing with GROUP BY
     // ordinals; this is the CTE-path equivalent.
     let mut dim_cte_exprs: Vec<String> = Vec::with_capacity(resolved_dims.len());
-    for (i, dim) in resolved_dims.iter().enumerate() {
+    for rd in resolved_dims {
+        let dim = rd.dim;
         let mut base_expr = dim.expr.clone();
-        if let Some(ref scoped) = dim_scoped_aliases[i] {
+        if let Some(ref scoped) = rd.scoped_alias {
             if let Some(ref st) = dim.source_table {
                 base_expr = replace_word_boundary(&base_expr, st, scoped);
             }
@@ -198,7 +198,7 @@ pub(super) fn expand_semi_additive(
         let partition_dims: Vec<String> = resolved_dims
             .iter()
             .zip(&dim_cte_exprs)
-            .filter(|(d, _)| !na_dim_names.contains(&d.name.to_ascii_lowercase()))
+            .filter(|(rd, _)| !na_dim_names.contains(&rd.dim.name.to_ascii_lowercase()))
             .map(|(_, expr)| expr.clone())
             .collect();
 
@@ -222,7 +222,7 @@ pub(super) fn expand_semi_additive(
                 // Try to find the dimension in resolved (queried) dims first
                 let dim_expr = resolved_dims
                     .iter()
-                    .position(|d| d.name.eq_ignore_ascii_case(&nd.dimension))
+                    .position(|rd| rd.dim.name.eq_ignore_ascii_case(&nd.dimension))
                     .map_or_else(
                         || {
                             // NA dim not in queried dims -- find it in the view definition
@@ -275,7 +275,8 @@ pub(super) fn expand_semi_additive(
     // resolver's extra-alias parameter, which appends each with its path
     // intermediaries (aliases already joined for dims/metrics are skipped).
     let na_dim_sources = collect_na_dim_source_tables(def, &na_groups);
-    let resolved_joins = resolve_joins_pkfk(def, resolved_dims, resolved_mets, &na_dim_sources);
+    let dims: Vec<&crate::model::Dimension> = resolved_dims.iter().map(|rd| rd.dim).collect();
+    let resolved_joins = resolve_joins_pkfk(def, &dims, resolved_mets, &na_dim_sources);
     push_join_clauses(&mut sql, &resolved_joins, def, "\n    LEFT JOIN ");
 
     sql.push_str("\n)\n");
@@ -286,11 +287,11 @@ pub(super) fn expand_semi_additive(
     let mut outer_select_items: Vec<String> = Vec::new();
 
     // Dimension columns: reference CTE aliases
-    for dim in resolved_dims {
+    for rd in resolved_dims {
         outer_select_items.push(format!(
             "    {} AS {}",
-            quote_ident(&dim.name),
-            quote_ident(&dim.name)
+            quote_ident(&rd.dim.name),
+            quote_ident(&rd.dim.name)
         ));
     }
 

--- a/src/expand/semi_additive.rs
+++ b/src/expand/semi_additive.rs
@@ -65,7 +65,7 @@ pub(super) fn is_active_semi_additive(met: &Metric, queried_dim_names: &HashSet<
 ///
 /// Called from `expand()` when `has_active_semi_additive` is true.
 /// Receives already-resolved dims, metrics, expressions, and scoped aliases.
-#[allow(clippy::too_many_lines, clippy::result_large_err)]
+#[allow(clippy::too_many_lines)]
 pub(super) fn expand_semi_additive(
     view_name: &str,
     def: &SemanticViewDefinition,

--- a/src/expand/sql_gen.rs
+++ b/src/expand/sql_gen.rs
@@ -145,7 +145,6 @@ impl Resolvable for Metric {
 /// request string (SG-14): `region` and `o.region` resolve to the same
 /// dimension and are rejected as duplicates instead of emitting the same
 /// column twice.
-#[allow(clippy::result_large_err)]
 fn resolve_names<'a, T: Resolvable, N: AsRef<str>>(
     names: &[N],
     view_name: &str,
@@ -187,7 +186,7 @@ fn resolve_names<'a, T: Resolvable, N: AsRef<str>>(
 ///
 /// Dimensions, when present, add columns to SELECT but do NOT trigger GROUP BY
 /// (unlike metric queries where dims + metrics => GROUP BY).
-#[allow(clippy::too_many_lines, clippy::result_large_err)]
+#[allow(clippy::too_many_lines)]
 fn expand_facts(
     view_name: &str,
     def: &SemanticViewDefinition,
@@ -292,7 +291,7 @@ fn expand_facts(
 /// - Neither dimensions nor metrics are requested (`EmptyRequest`)
 /// - A requested dimension or metric name is not found (`UnknownDimension`, `UnknownMetric`)
 /// - A dimension or metric name is duplicated (`DuplicateDimension`, `DuplicateMetric`)
-#[allow(clippy::too_many_lines, clippy::result_large_err)]
+#[allow(clippy::too_many_lines)]
 pub fn expand(
     view_name: &str,
     def: &SemanticViewDefinition,
@@ -516,7 +515,9 @@ pub fn expand(
 
 #[cfg(test)]
 mod tests {
-    use crate::expand::{expand, DimensionName, ExpandError, MetricName, QueryRequest};
+    use crate::expand::{
+        expand, DimensionName, ExpandError, FanTrapError, MetricName, QueryRequest,
+    };
 
     mod expand_tests {
         use super::*;
@@ -2771,15 +2772,10 @@ GROUP BY
             let result = expand("sales", &def, &req);
             assert!(result.is_err(), "Fan trap must block the query");
             match result.unwrap_err() {
-                ExpandError::FanTrap {
-                    view_name,
-                    metric_name,
-                    dimension_name,
-                    ..
-                } => {
-                    assert_eq!(view_name, "sales");
-                    assert_eq!(metric_name, "order_count");
-                    assert_eq!(dimension_name, "status");
+                ExpandError::FanTrap { detail } => {
+                    assert_eq!(detail.view_name, "sales");
+                    assert_eq!(detail.metric_name, "order_count");
+                    assert_eq!(detail.dimension_name, "status");
                 }
                 other => panic!("Expected FanTrap, got: {other}"),
             }
@@ -2925,13 +2921,9 @@ GROUP BY
                 "Transitive chain fan trap must be detected"
             );
             match result.unwrap_err() {
-                ExpandError::FanTrap {
-                    metric_name,
-                    dimension_name,
-                    ..
-                } => {
-                    assert_eq!(metric_name, "customer_count");
-                    assert_eq!(dimension_name, "status");
+                ExpandError::FanTrap { detail } => {
+                    assert_eq!(detail.metric_name, "customer_count");
+                    assert_eq!(detail.dimension_name, "status");
                 }
                 other => panic!("Expected FanTrap, got: {other}"),
             }
@@ -2960,13 +2952,9 @@ GROUP BY
             let result = expand("sales", &def, &req);
             assert!(result.is_err(), "Derived metric fan trap must be detected");
             match result.unwrap_err() {
-                ExpandError::FanTrap {
-                    metric_name,
-                    dimension_name,
-                    ..
-                } => {
-                    assert_eq!(metric_name, "avg_order");
-                    assert_eq!(dimension_name, "status");
+                ExpandError::FanTrap { detail } => {
+                    assert_eq!(detail.metric_name, "avg_order");
+                    assert_eq!(detail.dimension_name, "status");
                 }
                 other => panic!("Expected FanTrap, got: {other}"),
             }
@@ -2975,12 +2963,14 @@ GROUP BY
         #[test]
         fn fan_trap_error_message_format() {
             let err = ExpandError::FanTrap {
-                view_name: "sales".to_string(),
-                metric_name: "order_count".to_string(),
-                metric_table: "o".to_string(),
-                dimension_name: "status".to_string(),
-                dimension_table: "li".to_string(),
-                relationship_name: "li_to_order".to_string(),
+                detail: Box::new(FanTrapError {
+                    view_name: "sales".to_string(),
+                    metric_name: "order_count".to_string(),
+                    metric_table: "o".to_string(),
+                    dimension_name: "status".to_string(),
+                    dimension_table: "li".to_string(),
+                    relationship_name: "li_to_order".to_string(),
+                }),
             };
             let msg = format!("{err}");
             assert!(msg.contains("sales"), "Must contain view name");

--- a/src/expand/sql_gen.rs
+++ b/src/expand/sql_gen.rs
@@ -8,7 +8,7 @@ use super::fan_trap::{check_fan_traps, validate_fact_table_path};
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{find_dimension, find_metric, qualify_and_quote_table_ref, quote_ident};
 use super::role_playing::find_using_context;
-use super::types::{ExpandError, QueryRequest};
+use super::types::{ExpandError, QueryRequest, ResolvedDim};
 
 /// An entity kind resolvable by name against a [`SemanticViewDefinition`]
 /// (dimensions, metrics, facts). Encapsulates lookup, the PRIVATE-access
@@ -374,12 +374,14 @@ pub fn expand(
     // Phase 31: Check for fan traps before generating SQL.
     check_fan_traps(view_name, def, &resolved_dims, &resolved_mets)?;
 
-    // Phase 32: Pre-compute dimension scoped aliases for role-playing tables.
-    // Maps dimension index -> scoped alias (e.g., "a__dep_airport").
-    let mut dim_scoped_aliases: Vec<Option<String>> = Vec::with_capacity(resolved_dims.len());
-    for dim in &resolved_dims {
-        let scoped = find_using_context(view_name, def, dim, &resolved_mets)?;
-        dim_scoped_aliases.push(scoped);
+    // Phase 32: pair each resolved dimension with its role-playing scoped alias
+    // (e.g. "a__dep_airport"). R-8 (code-review 2026-07-11): zipped into
+    // `ResolvedDim` so the alias travels with its dimension instead of a
+    // position-indexed side array (`dim_scoped_aliases[i]`).
+    let mut resolved: Vec<ResolvedDim> = Vec::with_capacity(resolved_dims.len());
+    for &dim in &resolved_dims {
+        let scoped_alias = find_using_context(view_name, def, dim, &resolved_mets)?;
+        resolved.push(ResolvedDim { dim, scoped_alias });
     }
 
     // Phase 47: Check if any resolved metric ACTUALLY needs semi-additive expansion.
@@ -399,10 +401,9 @@ pub fn expand(
         return super::semi_additive::expand_semi_additive(
             view_name,
             def,
-            &resolved_dims,
+            &resolved,
             &resolved_mets,
             &resolved_exprs,
-            &dim_scoped_aliases,
         );
     }
 
@@ -430,10 +431,9 @@ pub fn expand(
         return super::window::expand_window_metrics(
             view_name,
             def,
-            &resolved_dims,
+            &resolved,
             &resolved_mets,
             &resolved_exprs,
-            &dim_scoped_aliases,
         );
     }
 
@@ -449,10 +449,11 @@ pub fn expand(
     }
 
     let mut select_items: Vec<String> = Vec::new();
-    for (i, dim) in resolved_dims.iter().enumerate() {
+    for rd in &resolved {
+        let dim = rd.dim;
         let mut base_expr = dim.expr.clone();
         // Phase 32: If this dimension has a scoped alias, rewrite the expression.
-        if let Some(ref scoped) = dim_scoped_aliases[i] {
+        if let Some(ref scoped) = rd.scoped_alias {
             if let Some(ref st) = dim.source_table {
                 // Replace bare alias with scoped alias in expression
                 // e.g., "a.city" -> "a__dep_airport.city"

--- a/src/expand/types.rs
+++ b/src/expand/types.rs
@@ -1,136 +1,108 @@
 use std::fmt;
+use std::marker::PhantomData;
 
-/// A dimension name with case-insensitive equality and hashing.
+/// A query-request name (dimension or metric) with case-insensitive ASCII
+/// equality and hashing.
 ///
-/// Wraps a `String` and provides `PartialEq`/`Eq`/`Hash` based on ASCII-lowercased form.
-/// This centralizes the ad-hoc `eq_ignore_ascii_case` / `to_ascii_lowercase` calls
-/// throughout the resolution code.
-#[derive(Debug, Clone)]
-pub struct DimensionName(String);
+/// Semantic-view names are matched case-insensitively, so this newtype provides
+/// `PartialEq`/`Eq`/`Hash` on the ASCII-lowercased form, centralizing the ad-hoc
+/// `eq_ignore_ascii_case` / `to_ascii_lowercase` calls that used to live
+/// throughout the resolution code. The `K` kind marker (see [`DimensionName`]
+/// and [`MetricName`]) keeps the flavors distinct at the type level so a
+/// dimension name can't be passed where a metric name is expected — one impl,
+/// several types (R-7, code-review 2026-07-11, replacing the former per-flavor
+/// copy-paste twins).
+pub struct CiName<K> {
+    raw: String,
+    // `fn() -> K` keeps `CiName<K>: Send + Sync` regardless of `K` and marks the
+    // kind purely at compile time (the marker types are never constructed).
+    _kind: PhantomData<fn() -> K>,
+}
 
-impl DimensionName {
+impl<K> CiName<K> {
     pub fn new(s: impl Into<String>) -> Self {
-        Self(s.into())
+        Self {
+            raw: s.into(),
+            _kind: PhantomData,
+        }
     }
 
     #[must_use]
     pub fn as_str(&self) -> &str {
-        &self.0
+        &self.raw
     }
 }
 
-impl PartialEq for DimensionName {
+impl<K> Clone for CiName<K> {
+    fn clone(&self) -> Self {
+        Self::new(self.raw.clone())
+    }
+}
+
+impl<K> fmt::Debug for CiName<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CiName").field(&self.raw).finish()
+    }
+}
+
+impl<K> PartialEq for CiName<K> {
     fn eq(&self, other: &Self) -> bool {
-        self.0.eq_ignore_ascii_case(&other.0)
+        self.raw.eq_ignore_ascii_case(&other.raw)
     }
 }
 
-impl Eq for DimensionName {}
+impl<K> Eq for CiName<K> {}
 
-impl std::hash::Hash for DimensionName {
+impl<K> std::hash::Hash for CiName<K> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        for byte in self.0.bytes() {
+        for byte in self.raw.bytes() {
             byte.to_ascii_lowercase().hash(state);
         }
     }
 }
 
-impl fmt::Display for DimensionName {
+impl<K> fmt::Display for CiName<K> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.raw)
     }
 }
 
-impl std::ops::Deref for DimensionName {
+impl<K> std::ops::Deref for CiName<K> {
     type Target = str;
     fn deref(&self) -> &str {
-        &self.0
+        &self.raw
     }
 }
 
-impl AsRef<str> for DimensionName {
+impl<K> AsRef<str> for CiName<K> {
     fn as_ref(&self) -> &str {
-        &self.0
+        &self.raw
     }
 }
 
-impl From<String> for DimensionName {
+impl<K> From<String> for CiName<K> {
     fn from(s: String) -> Self {
-        Self(s)
+        Self::new(s)
     }
 }
 
-impl From<&str> for DimensionName {
+impl<K> From<&str> for CiName<K> {
     fn from(s: &str) -> Self {
-        Self(s.to_string())
+        Self::new(s)
     }
 }
 
-/// A metric name with case-insensitive equality and hashing.
-///
-/// Wraps a `String` and provides `PartialEq`/`Eq`/`Hash` based on ASCII-lowercased form.
-/// This centralizes the ad-hoc `eq_ignore_ascii_case` / `to_ascii_lowercase` calls
-/// throughout the resolution code.
-#[derive(Debug, Clone)]
-pub struct MetricName(String);
+/// Kind marker for [`DimensionName`]; never constructed.
+pub enum DimensionKind {}
 
-impl MetricName {
-    pub fn new(s: impl Into<String>) -> Self {
-        Self(s.into())
-    }
+/// Kind marker for [`MetricName`]; never constructed.
+pub enum MetricKind {}
 
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
+/// A dimension name with case-insensitive equality and hashing (see [`CiName`]).
+pub type DimensionName = CiName<DimensionKind>;
 
-impl PartialEq for MetricName {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.eq_ignore_ascii_case(&other.0)
-    }
-}
-
-impl Eq for MetricName {}
-
-impl std::hash::Hash for MetricName {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        for byte in self.0.bytes() {
-            byte.to_ascii_lowercase().hash(state);
-        }
-    }
-}
-
-impl fmt::Display for MetricName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::ops::Deref for MetricName {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl AsRef<str> for MetricName {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<String> for MetricName {
-    fn from(s: String) -> Self {
-        Self(s)
-    }
-}
-
-impl From<&str> for MetricName {
-    fn from(s: &str) -> Self {
-        Self(s.to_string())
-    }
-}
+/// A metric name with case-insensitive equality and hashing (see [`CiName`]).
+pub type MetricName = CiName<MetricKind>;
 
 /// A request to expand a semantic view into SQL.
 ///
@@ -202,6 +174,26 @@ mod tests {
         assert_eq!(name.as_str(), "foo");
         let name2: DimensionName = String::from("bar").into();
         assert_eq!(name2.as_str(), "bar");
+    }
+
+    #[test]
+    fn ci_name_shared_impl_covers_both_kinds() {
+        // R-7 (code-review 2026-07-11): `DimensionName` and `MetricName` are now
+        // `CiName<K>` aliases sharing one impl. Exercise the surface (Clone,
+        // Deref, AsRef, case-insensitive Eq) through both kinds so the generic
+        // impl stays covered for each.
+        let dim = DimensionName::new("Region");
+        let dim_clone = dim.clone();
+        assert_eq!(dim, dim_clone);
+        assert_eq!(dim, DimensionName::new("REGION")); // case-insensitive Eq
+        assert_eq!(&*dim, "Region"); // Deref<Target = str>
+        let as_ref: &str = dim.as_ref(); // AsRef<str>
+        assert_eq!(as_ref, "Region");
+
+        let met = MetricName::new("Total_Revenue");
+        assert_eq!(met, MetricName::new("total_revenue"));
+        assert_eq!(&*met.clone(), "Total_Revenue");
+        assert_eq!(met.as_ref() as &str, "Total_Revenue");
     }
 }
 
@@ -345,10 +337,20 @@ impl fmt::Display for ExpandError {
     #[allow(clippy::too_many_lines)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            // R-16 (code-review 2026-07-11): this arm is the single source of the
+            // empty-request wording. `QueryError::EmptyRequest` renders by
+            // delegating to it, so the two can no longer drift apart (they had:
+            // this side lacked the `facts` option and the DESCRIBE hint). Both
+            // are reachable — the FFI binder short-circuits with the QueryError
+            // form; a direct `expand()` call hits this form.
             Self::EmptyRequest { view_name } => {
                 write!(
                     f,
-                    "semantic view '{view_name}': specify at least dimensions := [...] or metrics := [...]"
+                    "semantic view '{view_name}': specify at least dimensions := [...], metrics := [...], or facts := [...]."
+                )?;
+                write!(
+                    f,
+                    " Run DESCRIBE SEMANTIC VIEW {view_name} to see available dimensions, metrics, and facts."
                 )
             }
             Self::UnknownDimension {

--- a/src/expand/types.rs
+++ b/src/expand/types.rs
@@ -119,6 +119,23 @@ pub struct QueryRequest {
     pub facts: Vec<String>,
 }
 
+/// A resolved dimension paired with its role-playing scoped alias, if any.
+///
+/// R-8 (code-review 2026-07-11): replaces the former parallel slices
+/// `resolved_dims: &[&Dimension]` and `dim_scoped_aliases: &[Option<String>]`,
+/// which were threaded together through several expansion functions and indexed
+/// by position (`dim_scoped_aliases[i]`) — a silent-wrong-results footgun if the
+/// two ever fell out of sync. Zipping them into one value makes the pairing
+/// structural, so an index can't reach the wrong alias.
+pub(crate) struct ResolvedDim<'a> {
+    /// The resolved dimension definition (borrowed from the view definition).
+    pub dim: &'a crate::model::Dimension,
+    /// The role-playing scoped alias for this dimension's source table
+    /// (e.g. `Some("a__dep_airport")`), or `None` when the table is not
+    /// role-played for this query.
+    pub scoped_alias: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/expand/types.rs
+++ b/src/expand/types.rs
@@ -195,6 +195,44 @@ mod tests {
         assert_eq!(&*met.clone(), "Total_Revenue");
         assert_eq!(met.as_ref() as &str, "Total_Revenue");
     }
+
+    #[test]
+    fn expand_error_stays_under_large_err_threshold() {
+        // R-9 (code-review 2026-07-11): the two fattest variants (FanTrap,
+        // MetricFanTrap) are boxed so `ExpandError` fits under clippy's
+        // `result_large_err` threshold (128 bytes) and the `Result<_,
+        // ExpandError>` allows could be dropped. Pin the size so a future fat
+        // variant can't silently reintroduce the bloat (box it instead).
+        assert!(
+            std::mem::size_of::<ExpandError>() <= 128,
+            "ExpandError is {} bytes (> 128); box the newly-added fat variant (see R-9)",
+            std::mem::size_of::<ExpandError>()
+        );
+    }
+}
+
+/// Detail payload for [`ExpandError::FanTrap`], boxed so the enum stays small
+/// (R-9, code-review 2026-07-11 — this variant was one of the two fattest).
+#[derive(Debug)]
+pub struct FanTrapError {
+    pub view_name: String,
+    pub metric_name: String,
+    pub metric_table: String,
+    pub dimension_name: String,
+    pub dimension_table: String,
+    pub relationship_name: String,
+}
+
+/// Detail payload for [`ExpandError::MetricFanTrap`], boxed so the enum stays
+/// small (R-9, code-review 2026-07-11 — the other fat variant).
+#[derive(Debug)]
+pub struct MetricFanTrapError {
+    pub view_name: String,
+    pub metric_name: String,
+    pub metric_table: String,
+    pub other_metric_name: String,
+    pub other_metric_table: String,
+    pub relationship_name: String,
 }
 
 /// Errors that can occur during semantic view expansion.
@@ -221,26 +259,12 @@ pub enum ExpandError {
     /// A metric name was requested more than once.
     DuplicateMetric { view_name: String, name: String },
     /// A metric aggregates across a one-to-many boundary, risking inflated results.
-    FanTrap {
-        view_name: String,
-        metric_name: String,
-        metric_table: String,
-        dimension_name: String,
-        dimension_table: String,
-        relationship_name: String,
-    },
+    FanTrap { detail: Box<FanTrapError> },
     /// Two queried metrics sit at different grains (source tables) and the
     /// join path between those tables crosses a fan-out edge: joining both
     /// source tables multiplies `metric_table`'s rows, silently inflating
     /// `metric_name` (fan trap / chasm trap between metric grains).
-    MetricFanTrap {
-        view_name: String,
-        metric_name: String,
-        metric_table: String,
-        other_metric_name: String,
-        other_metric_table: String,
-        relationship_name: String,
-    },
+    MetricFanTrap { detail: Box<MetricFanTrapError> },
     /// The stored definition's relationship graph could not be rebuilt at
     /// query time, so safety checks (fan-trap detection) cannot run.
     UncheckableDefinition { view_name: String, reason: String },
@@ -394,14 +418,15 @@ impl fmt::Display for ExpandError {
             Self::DuplicateMetric { view_name, name } => {
                 write!(f, "semantic view '{view_name}': duplicate metric '{name}'")
             }
-            Self::FanTrap {
-                view_name,
-                metric_name,
-                metric_table,
-                dimension_name,
-                dimension_table,
-                relationship_name,
-            } => {
+            Self::FanTrap { detail } => {
+                let FanTrapError {
+                    view_name,
+                    metric_name,
+                    metric_table,
+                    dimension_name,
+                    dimension_table,
+                    relationship_name,
+                } = &**detail;
                 write!(
                     f,
                     "semantic view '{view_name}': fan trap detected -- metric '{metric_name}' \
@@ -413,14 +438,15 @@ impl fmt::Display for ExpandError {
                      relationship."
                 )
             }
-            Self::MetricFanTrap {
-                view_name,
-                metric_name,
-                metric_table,
-                other_metric_name,
-                other_metric_table,
-                relationship_name,
-            } => {
+            Self::MetricFanTrap { detail } => {
+                let MetricFanTrapError {
+                    view_name,
+                    metric_name,
+                    metric_table,
+                    other_metric_name,
+                    other_metric_table,
+                    relationship_name,
+                } = &**detail;
                 write!(
                     f,
                     "semantic view '{view_name}': fan trap detected -- metric '{metric_name}' \

--- a/src/expand/window.rs
+++ b/src/expand/window.rs
@@ -15,7 +15,7 @@ use crate::util::replace_word_boundary;
 
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{qualify_and_quote_table_ref, quote_ident};
-use super::types::ExpandError;
+use super::types::{ExpandError, ResolvedDim};
 
 /// Generate CTE-based expansion SQL for queries containing window function metrics.
 ///
@@ -35,15 +35,14 @@ use super::types::ExpandError;
 pub(super) fn expand_window_metrics(
     view_name: &str,
     def: &SemanticViewDefinition,
-    resolved_dims: &[&crate::model::Dimension],
+    resolved_dims: &[ResolvedDim],
     resolved_mets: &[&Metric],
     resolved_exprs: &HashMap<String, String>,
-    dim_scoped_aliases: &[Option<String>],
 ) -> Result<String, ExpandError> {
     // 1. Validate required dimensions for each window metric.
     let queried_dim_names: HashSet<String> = resolved_dims
         .iter()
-        .map(|d| d.name.to_ascii_lowercase())
+        .map(|rd| rd.dim.name.to_ascii_lowercase())
         .collect();
 
     for met in resolved_mets {
@@ -118,9 +117,10 @@ pub(super) fn expand_window_metrics(
     let mut cte_select_items: Vec<String> = Vec::new();
 
     // Dimension columns in CTE
-    for (i, dim) in resolved_dims.iter().enumerate() {
+    for rd in resolved_dims {
+        let dim = rd.dim;
         let mut base_expr = dim.expr.clone();
-        if let Some(ref scoped) = dim_scoped_aliases[i] {
+        if let Some(ref scoped) = rd.scoped_alias {
             if let Some(ref st) = dim.source_table {
                 base_expr = replace_word_boundary(&base_expr, st, scoped);
             }
@@ -156,7 +156,8 @@ pub(super) fn expand_window_metrics(
     }
 
     // CTE JOINs
-    let resolved_joins = resolve_joins_pkfk(def, resolved_dims, resolved_mets, &[]);
+    let dims: Vec<&crate::model::Dimension> = resolved_dims.iter().map(|rd| rd.dim).collect();
+    let resolved_joins = resolve_joins_pkfk(def, &dims, resolved_mets, &[]);
     push_join_clauses(&mut sql, &resolved_joins, def, "\n    LEFT JOIN ");
 
     // CTE GROUP BY (all dimension columns)
@@ -176,11 +177,11 @@ pub(super) fn expand_window_metrics(
     let mut outer_select_items: Vec<String> = Vec::new();
 
     // Dimension columns: reference CTE aliases
-    for dim in resolved_dims {
+    for rd in resolved_dims {
         outer_select_items.push(format!(
             "    {} AS {}",
-            quote_ident(&dim.name),
-            quote_ident(&dim.name)
+            quote_ident(&rd.dim.name),
+            quote_ident(&rd.dim.name)
         ));
     }
 
@@ -208,8 +209,8 @@ pub(super) fn expand_window_metrics(
                 .collect();
             resolved_dims
                 .iter()
-                .filter(|d| !excluding_set.contains(&d.name.to_ascii_lowercase()))
-                .map(|d| quote_ident(&d.name))
+                .filter(|rd| !excluding_set.contains(&rd.dim.name.to_ascii_lowercase()))
+                .map(|rd| quote_ident(&rd.dim.name))
                 .collect()
         } else {
             // Explicit PARTITION BY: use listed dims directly

--- a/src/expand/window.rs
+++ b/src/expand/window.rs
@@ -31,11 +31,7 @@ use super::types::ExpandError;
 /// 2. **Outer SELECT**: Applies each window function over the CTE results with
 ///    computed PARTITION BY (all queried dims minus EXCLUDING dims) and ORDER BY.
 ///    No GROUP BY in the outer query -- window functions are row-level operations.
-#[allow(
-    clippy::too_many_lines,
-    clippy::result_large_err,
-    clippy::unnecessary_wraps
-)]
+#[allow(clippy::too_many_lines, clippy::unnecessary_wraps)]
 pub(super) fn expand_window_metrics(
     view_name: &str,
     def: &SemanticViewDefinition,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,15 +556,24 @@ mod extension {
         info: ffi::duckdb_extension_info,
         access: *const ffi::duckdb_extension_access,
     ) -> std::result::Result<bool, Box<dyn Error>> {
+        // R-13 (code-review 2026-07-11): a panic here degrades to the generic
+        // "panicked unexpectedly" load failure (the `Err(_panic)` arm of the
+        // extern "C" wrapper). Returning `Err` instead routes the real reason
+        // through `set_error` — for the API init that carries the DuckDB
+        // version-mismatch detail, which is exactly what a failed load needs.
         let have_api_struct =
-            ffi::duckdb_rs_extension_api_init(info, access, crate::MINIMUM_DUCKDB_VERSION).unwrap();
+            ffi::duckdb_rs_extension_api_init(info, access, crate::MINIMUM_DUCKDB_VERSION)
+                .map_err(|e| format!("DuckDB extension C API init failed: {e}"))?;
 
         if !have_api_struct {
             return Ok(false);
         }
 
         // Get the raw database handle BEFORE wrapping in Connection.
-        let db_handle: ffi::duckdb_database = *(*access).get_database.unwrap()(info);
+        let Some(get_database) = (*access).get_database else {
+            return Err("DuckDB extension access vtable is missing get_database".into());
+        };
+        let db_handle: ffi::duckdb_database = *get_database(info);
 
         // Create a Connection from the database handle (same as the macro does).
         let connection = Connection::open_from_raw(db_handle.cast())?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,3 +1,24 @@
+//! Serialized model of a stored semantic-view definition.
+//!
+//! # Wire-format freeze (C-11, code-review 2026-07-11)
+//!
+//! These structs ARE the on-disk format: every definition is persisted as JSON
+//! in the catalog and re-emitted verbatim by YAML export, so the serde surface
+//! is a compatibility contract, not an implementation detail. Two conventions
+//! look inconsistent but are deliberate and frozen — do not "tidy" them, and
+//! match them when adding fields:
+//!
+//! - **`source_table` and `output_type` serialize explicit `null`s** (they carry
+//!   `#[serde(default)]` but *not* `skip_serializing_if`), whereas every sibling
+//!   optional/collection field is omitted when empty. These two predate the
+//!   `skip_serializing_if` convention; stored JSON in the wild already contains
+//!   their explicit `null`s, so adding the skip now would change bytes for
+//!   round-tripped definitions. New fields should use `skip_serializing_if`.
+//! - **Enum variants persist in their Rust casing** (e.g. `AccessModifier`,
+//!   `Cardinality`, `SortOrder`, `NullsOrder`) — no `#[serde(rename_all)]`. That
+//!   casing is now baked into stored JSON and the YAML export, so renaming a
+//!   variant or adding a rename attribute is a breaking format change.
+
 use serde::{Deserialize, Serialize};
 
 /// A table alias entry for the `tables` DDL parameter.

--- a/src/query/error.rs
+++ b/src/query/error.rs
@@ -57,16 +57,16 @@ impl fmt::Display for QueryError {
                     " Run FROM list_semantic_views() to see all registered views."
                 )
             }
-            Self::EmptyRequest { view_name } => {
-                write!(
-                    f,
-                    "semantic view '{view_name}': specify at least dimensions := [...], metrics := [...], or facts := [...]."
-                )?;
-                write!(
-                    f,
-                    " Run DESCRIBE SEMANTIC VIEW {view_name} to see available dimensions, metrics, and facts."
-                )
-            }
+            // R-16 (code-review 2026-07-11): delegate to `ExpandError::EmptyRequest`
+            // so the two render identically and can't drift apart. The clone is
+            // cheap — this is the error path.
+            Self::EmptyRequest { view_name } => write!(
+                f,
+                "{}",
+                ExpandError::EmptyRequest {
+                    view_name: view_name.clone(),
+                }
+            ),
             Self::WildcardExpansion { view_name, detail } => {
                 write!(f, "semantic view '{view_name}': {detail}")
             }
@@ -134,5 +134,25 @@ mod tests {
             e.to_string(),
             "semantic view 'orders': unknown alias 'x' in wildcard 'x.*'"
         );
+    }
+
+    #[test]
+    fn empty_request_message_matches_expand_error_verbatim() {
+        // R-16 (code-review 2026-07-11): `QueryError::EmptyRequest` and
+        // `ExpandError::EmptyRequest` now share `expand::write_empty_request`.
+        // Pin that they render byte-for-byte identically so the wording can't
+        // drift apart again (the original defect this refactor removed).
+        let query_side = QueryError::EmptyRequest {
+            view_name: "orders".to_string(),
+        };
+        let expand_side = ExpandError::EmptyRequest {
+            view_name: "orders".to_string(),
+        };
+        assert_eq!(query_side.to_string(), expand_side.to_string());
+        // And that the single source carries the current, fuller wording.
+        assert!(query_side.to_string().contains("facts := [...]"));
+        assert!(query_side
+            .to_string()
+            .contains("DESCRIBE SEMANTIC VIEW orders"));
     }
 }

--- a/src/query/error.rs
+++ b/src/query/error.rs
@@ -138,10 +138,10 @@ mod tests {
 
     #[test]
     fn empty_request_message_matches_expand_error_verbatim() {
-        // R-16 (code-review 2026-07-11): `QueryError::EmptyRequest` and
-        // `ExpandError::EmptyRequest` now share `expand::write_empty_request`.
-        // Pin that they render byte-for-byte identically so the wording can't
-        // drift apart again (the original defect this refactor removed).
+        // R-16 (code-review 2026-07-11): `QueryError::EmptyRequest`'s Display
+        // delegates to `ExpandError::EmptyRequest`, so the two are guaranteed to
+        // render identically. Pin it so the wording can't drift apart again
+        // (the original defect this refactor removed).
         let query_side = QueryError::EmptyRequest {
             view_name: "orders".to_string(),
         };

--- a/src/render_ddl.rs
+++ b/src/render_ddl.rs
@@ -16,7 +16,7 @@ fn escape_single_quote(s: &str) -> String {
 }
 
 /// Append ` COMMENT = '<escaped>'` to `out` if comment is present.
-fn emit_comment(out: &mut String, comment: Option<&String>) {
+fn emit_comment(out: &mut String, comment: Option<&str>) {
     if let Some(c) = comment {
         out.push_str(" COMMENT = '");
         out.push_str(&escape_single_quote(c));
@@ -58,7 +58,7 @@ fn emit_tables(out: &mut String, def: &SemanticViewDefinition) {
             out.push_str(&uc.join(", "));
             out.push(')');
         }
-        emit_comment(out, table.comment.as_ref());
+        emit_comment(out, table.comment.as_deref());
         emit_synonyms(out, &table.synonyms);
         if i + 1 < def.tables.len() {
             out.push(',');
@@ -156,7 +156,7 @@ fn emit_facts(out: &mut String, def: &SemanticViewDefinition) {
         out.push_str(&fact.name);
         out.push_str(" AS ");
         out.push_str(&fact.expr);
-        emit_comment(out, fact.comment.as_ref());
+        emit_comment(out, fact.comment.as_deref());
         emit_synonyms(out, &fact.synonyms);
         if i + 1 < def.facts.len() {
             out.push(',');
@@ -178,7 +178,7 @@ fn emit_dimensions(out: &mut String, def: &SemanticViewDefinition) {
         out.push_str(&dim.name);
         out.push_str(" AS ");
         out.push_str(&dim.expr);
-        emit_comment(out, dim.comment.as_ref());
+        emit_comment(out, dim.comment.as_deref());
         emit_synonyms(out, &dim.synonyms);
         if i + 1 < def.dimensions.len() {
             out.push(',');
@@ -313,7 +313,7 @@ fn emit_metrics(out: &mut String, def: &SemanticViewDefinition) {
         } else {
             out.push_str(&metric.expr);
         }
-        emit_comment(out, metric.comment.as_ref());
+        emit_comment(out, metric.comment.as_deref());
         emit_synonyms(out, &metric.synonyms);
         if i + 1 < def.metrics.len() {
             out.push(',');
@@ -383,7 +383,7 @@ pub fn render_create_ddl(name: &str, def: &SemanticViewDefinition) -> Result<Str
     out.push_str(&crate::expand::quote_ident_if_needed(name));
 
     // View-level comment
-    emit_comment(&mut out, def.comment.as_ref());
+    emit_comment(&mut out, def.comment.as_deref());
 
     // AS keyword
     out.push_str(" AS\n");
@@ -743,7 +743,7 @@ mod tests {
         assert!(out.is_empty());
 
         let hello = "hello".to_string();
-        emit_comment(&mut out, Some(&hello));
+        emit_comment(&mut out, Some(hello.as_str()));
         assert_eq!(out, " COMMENT = 'hello'");
     }
 


### PR DESCRIPTION
Tenth PR of the 2026-07-11 remediation series (follows #71–#80). Groups the remaining **idiomatic-hardening** findings from `_notes/code-review-2026-07-11.md` §5. **No behavioural change** — every item is a refactor, doc, or diagnostics improvement, verified byte-for-byte by the existing test suite plus new pinning tests.

## Items

- **R-7 — one `CiName<K>` generic replaces the `DimensionName`/`MetricName` copy-paste twins.** Zero-sized kind markers (`DimensionKind`/`MetricKind`) keep the flavors distinct at the type level; `DimensionName`/`MetricName` become type aliases, so every call site is unchanged and the case-insensitive `Eq`/`Hash` impl now lives once. (The optional `facts` newtype is intentionally **not** included here — see "Deferred" below.)
- **R-8 — zip the parallel `resolved_dims` + `dim_scoped_aliases` slices into `ResolvedDim { dim, scoped_alias }`.** These were threaded together through `expand_window_metrics`/`expand_semi_additive` and indexed by position (`dim_scoped_aliases[i]`) — a silent-wrong-results footgun if the two fell out of sync. Built once in `expand()`; the two CTE expanders and the main SELECT loop now iterate `ResolvedDim`. The dims-only consumers (`check_fan_traps`, `resolve_joins_pkfk`, `materialization`) keep their `&[&Dimension]` signatures via a local projection, so their test call sites are untouched.
- **R-9 — box the two fattest `ExpandError` variants** (`FanTrap`, `MetricFanTrap`, six `String` fields each) behind detail structs, dropping the enum under clippy's `result_large_err` threshold. Removes all nine `#[allow(clippy::result_large_err)]` attributes. Single-field struct variants keep every `matches!(.. { .. })` test site working. A new test pins `size_of::<ExpandError>() <= 128`.
- **R-13 — diagnosable extension-init failures.** The two init-path `.unwrap()`s (`lib.rs`) become `map_err(..)?` (preserving DuckDB's version-mismatch detail) and a `let … else`, so a failed load routes a real message through `set_error` instead of the generic "panicked unexpectedly".
- **R-15 — `emit_comment` takes `Option<&str>`** instead of `Option<&String>`.
- **R-16 — single-source the empty-request message.** `QueryError::EmptyRequest` now delegates its Display to `ExpandError::EmptyRequest`; the two had drifted (the expand side lacked the `facts` option and the DESCRIBE hint). New test pins byte-identical rendering.
- **C-11 — document the `model.rs` wire-format freeze**: `source_table`/`output_type` serialize explicit nulls (no `skip_serializing_if`), and enum variants persist in Rust casing — both now a frozen on-disk/YAML contract.

## Verification

- `cargo test`: all suites green (unit + proptest + doc tests), including the two new pinning tests.
- `cargo clippy -- -D warnings` **and** `SV_SKIP_CPP_BUILD=1 cargo clippy --no-default-features --features extension -- -D warnings`: both clean.
- `cargo fmt --check`: clean.
- sqllogictest runs in CI on this PR (the integration oracle); the local offline amalgamation uses a placeholder `DUCKDB_SOURCE_ID` that can't load the built extension, so it is validated here by CI rather than locally.

## Deferred (follow-ups, not in this PR)

- **R-14** (`..Default::default()` in test fixtures) — turned out to be 100+ fixture-literal conversions; splitting into its own focused PR to keep this diff reviewable and the elisions easy to audit.
- **Fact / identifier case-sensitivity** — R-7's optional `FactName` newtype is held back. Matching Snowflake requires the quoted-vs-unquoted identifier distinction (unquoted = case-insensitive, quoted = case-sensitive) across all three name kinds and the CREATE/storage path; this will be researched against Snowflake's documentation and proposed as separate work rather than bolted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4)_