### PR TITLE
Code-review 2026-07-11: output-correctness fixes (C-12 + P-14)

### DIFF
--- a/src/body_parser/clause_bounds.rs
+++ b/src/body_parser/clause_bounds.rs
@@ -3,6 +3,15 @@
 use super::scan::QuoteState;
 use crate::errors::ParseError;
 
+/// Decode the character starting at byte offset `i` in `text` for an error
+/// message. `bytes[i] as char` truncated a multibyte codepoint to its lead
+/// byte, so `★` (0xE2 0x98 0x85) surfaced as the mojibake `'â'` (0xE2) —
+/// P-14, code-review 2026-07-11. Returns `None` at end-of-input or a
+/// non-char-boundary offset (both callers pass boundary offsets).
+fn char_at(text: &str, i: usize) -> Option<char> {
+    text.get(i..).and_then(|s| s.chars().next())
+}
+
 /// Known clause keywords for the AS-body scanner.
 const CLAUSE_KEYWORDS: &[&str] = &[
     "tables",
@@ -44,6 +53,7 @@ fn suggest_clause_keyword(word: &str) -> Option<&'static str> {
 }
 
 /// Internal result of scanning a single clause from the AS-body.
+#[derive(Debug)]
 pub(super) struct ClauseBound<'a> {
     pub(super) keyword: &'static str,
     pub(super) content: &'a str,      // text inside the matching parens
@@ -70,7 +80,7 @@ pub(super) fn find_clause_bounds<'a>(
 
     while i < bytes.len() {
         // Skip whitespace
-        while i < bytes.len() && (bytes[i] as char).is_ascii_whitespace() {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
             i += 1;
         }
         if i >= bytes.len() {
@@ -78,9 +88,10 @@ pub(super) fn find_clause_bounds<'a>(
         }
 
         // Collect identifier word
-        if !(bytes[i] as char).is_ascii_alphabetic() {
-            // Unexpected character at top level
-            let ch = bytes[i] as char;
+        if !bytes[i].is_ascii_alphabetic() {
+            // Unexpected character at top level. Decode the real UTF-8 char
+            // (never the mojibake lead byte) for the message (P-14).
+            let ch = char_at(text, i).unwrap_or('\u{FFFD}');
             return Err(ParseError {
                 message: format!(
                     "Unexpected character '{ch}' in AS body; expected a clause keyword (TABLES, RELATIONSHIPS, FACTS, DIMENSIONS, METRICS).",
@@ -90,7 +101,7 @@ pub(super) fn find_clause_bounds<'a>(
         }
 
         let word_start = i;
-        while i < bytes.len() && (bytes[i] as char).is_ascii_alphabetic() {
+        while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
             i += 1;
         }
         let word = &text[word_start..i];
@@ -126,18 +137,16 @@ pub(super) fn find_clause_bounds<'a>(
         }
 
         // Skip whitespace after keyword
-        while i < bytes.len() && (bytes[i] as char).is_ascii_whitespace() {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
             i += 1;
         }
 
         // Expect '('
-        if i >= bytes.len() || bytes[i] as char != '(' {
+        if i >= bytes.len() || bytes[i] != b'(' {
             let kw_upper = keyword.to_ascii_uppercase();
-            let found = if i < bytes.len() {
-                bytes[i] as char
-            } else {
-                '\0'
-            };
+            // Decode the real UTF-8 char for the message; '\0' at EOF keeps
+            // the prior end-of-input sentinel (P-14).
+            let found = char_at(text, i).unwrap_or('\0');
             return Err(ParseError {
                 message: format!(
                     "Expected '(' after clause keyword '{kw_upper}', found '{found}'.",
@@ -238,4 +247,64 @@ pub(super) fn find_clause_bounds<'a>(
     }
 
     Ok(bounds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{char_at, find_clause_bounds};
+
+    /// P-14 (code-review 2026-07-11): a multibyte character at the top level
+    /// of the AS body must appear verbatim in the error, not truncated to its
+    /// UTF-8 lead byte. `bytes[i] as char` rendered `★` (0xE2 0x98 0x85) as
+    /// the mojibake `'â'` (U+00E2), the char for byte 0xE2 alone.
+    #[test]
+    fn unexpected_multibyte_char_reported_verbatim() {
+        let err = find_clause_bounds("★ DIMENSIONS (d AS x)", 0).unwrap_err();
+        assert!(
+            err.message.contains("'★'"),
+            "error must contain the real character, got: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains('\u{00E2}'),
+            "error must not contain the mojibake lead byte: {}",
+            err.message
+        );
+        // Position is the byte offset of the character (unchanged).
+        assert_eq!(err.position, Some(0));
+    }
+
+    /// P-14, the "expected '(' after keyword" arm: a multibyte character where
+    /// a '(' is expected must also render verbatim.
+    #[test]
+    fn expected_paren_multibyte_char_reported_verbatim() {
+        let err = find_clause_bounds("TABLES ★", 0).unwrap_err();
+        assert!(
+            err.message.contains("Expected '('") && err.message.contains("'★'"),
+            "error must name the real character, got: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains('\u{00E2}'),
+            "error must not contain the mojibake lead byte: {}",
+            err.message
+        );
+    }
+
+    /// `char_at` decodes the whole codepoint at a boundary offset and yields
+    /// `None` past end-of-input (the EOF sentinel path for the paren arm).
+    #[test]
+    fn char_at_decodes_codepoint_and_handles_eof() {
+        assert_eq!(char_at("★x", 0), Some('★'));
+        assert_eq!(char_at("a★", 1), Some('★'));
+        assert_eq!(char_at("abc", 3), None);
+    }
+
+    /// A plain ASCII unexpected character still renders correctly (no
+    /// regression for the common case).
+    #[test]
+    fn unexpected_ascii_char_reported() {
+        let err = find_clause_bounds("# DIMENSIONS (d AS x)", 0).unwrap_err();
+        assert!(err.message.contains("'#'"), "got: {}", err.message);
+    }
 }

--- a/src/body_parser/clause_bounds.rs
+++ b/src/body_parser/clause_bounds.rs
@@ -94,7 +94,7 @@ pub(super) fn find_clause_bounds<'a>(
             let ch = char_at(text, i).unwrap_or('\u{FFFD}');
             return Err(ParseError {
                 message: format!(
-                    "Unexpected character '{ch}' in AS body; expected a clause keyword (TABLES, RELATIONSHIPS, FACTS, DIMENSIONS, METRICS).",
+                    "Unexpected character '{ch}' in AS body; expected a clause keyword (TABLES, RELATIONSHIPS, FACTS, DIMENSIONS, METRICS, MATERIALIZATIONS).",
                 ),
                 position: Some(base_offset + i),
             });
@@ -118,7 +118,7 @@ pub(super) fn find_clause_bounds<'a>(
                 format!("Unknown clause keyword '{word}'; did you mean '{sug_upper}'?")
             } else {
                 format!(
-                    "Unknown clause keyword '{word}'; expected one of TABLES, RELATIONSHIPS, FACTS, DIMENSIONS, METRICS.",
+                    "Unknown clause keyword '{word}'; expected one of TABLES, RELATIONSHIPS, FACTS, DIMENSIONS, METRICS, MATERIALIZATIONS.",
                 )
             };
             return Err(ParseError {
@@ -306,5 +306,28 @@ mod tests {
     fn unexpected_ascii_char_reported() {
         let err = find_clause_bounds("# DIMENSIONS (d AS x)", 0).unwrap_err();
         assert!(err.message.contains("'#'"), "got: {}", err.message);
+    }
+
+    /// The clause-keyword lists in the "unexpected character" and "unknown
+    /// keyword" errors must name every keyword the scanner accepts —
+    /// MATERIALIZATIONS was previously omitted from both, while the ordering
+    /// error already listed it (Copilot review, #83).
+    #[test]
+    fn keyword_list_errors_include_materializations() {
+        // "unexpected character" arm (leading non-alphabetic byte).
+        let err = find_clause_bounds("# TABLES (o AS x)", 0).unwrap_err();
+        assert!(
+            err.message.contains("MATERIALIZATIONS"),
+            "unexpected-char message must list MATERIALIZATIONS: {}",
+            err.message
+        );
+        // "unknown clause keyword" arm. ZZZQQQ is >3 edits from every keyword
+        // so it takes the no-suggestion branch that lists the keywords.
+        let err = find_clause_bounds("ZZZQQQ (x)", 0).unwrap_err();
+        assert!(
+            err.message.contains("MATERIALIZATIONS"),
+            "unknown-keyword message must list MATERIALIZATIONS: {}",
+            err.message
+        );
     }
 }

--- a/src/ddl/describe.rs
+++ b/src/ddl/describe.rs
@@ -115,9 +115,19 @@ struct DescribeRow {
 
 /// Format column names as a JSON array: `["col1","col2"]`.
 /// Matches Snowflake format: no spaces after commas.
+///
+/// Delegates to `serde_json` so a value containing `"`, `\`, or a control
+/// character is escaped into valid JSON instead of breaking out of the
+/// string literal (C-12, code-review 2026-07-11) — the previous
+/// `format!("\"{s}\"")` emitted `["a"b"]` for a synonym `a"b`, which the
+/// DESCRIBE output documents as a JSON array. `serde_json` writes no space
+/// after the comma and passes UTF-8 through unescaped, so all-ASCII inputs
+/// stay byte-identical to the prior hand-rolled format.
 pub(crate) fn format_json_array(items: &[String]) -> String {
-    let quoted: Vec<String> = items.iter().map(|s| format!("\"{s}\"")).collect();
-    format!("[{}]", quoted.join(","))
+    // Serializing a slice of `String` to JSON is infallible (no floats, no
+    // non-string map keys, in-memory writer), so `expect` documents an
+    // impossibility rather than swallowing a real error.
+    serde_json::to_string(items).expect("serializing a &[String] to JSON is infallible")
 }
 
 /// Collect TABLE property rows from the definition.
@@ -525,6 +535,37 @@ mod tests {
     fn format_json_array_empty() {
         let cols: Vec<String> = vec![];
         assert_eq!(format_json_array(&cols), "[]");
+    }
+
+    /// C-12 (code-review 2026-07-11): a value containing `"` or `\` must be
+    /// escaped so the DESCRIBE output stays valid JSON. The previous
+    /// `format!("\"{s}\"")` emitted `["a"b"]` — unparseable.
+    #[test]
+    fn format_json_array_escapes_quote_and_backslash() {
+        let items = vec![r#"a"b"#.to_string(), r"c\d".to_string()];
+        let json = format_json_array(&items);
+        assert_eq!(json, r#"["a\"b","c\\d"]"#);
+        // Round-trips through a real JSON parser back to the originals.
+        let parsed: Vec<String> = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(parsed, items);
+    }
+
+    /// C-12: control characters (a synonym pasted with an embedded newline or
+    /// tab) are escaped rather than emitted raw into the JSON string.
+    #[test]
+    fn format_json_array_escapes_control_characters() {
+        let items = vec!["line1\nline2\t".to_string()];
+        let json = format_json_array(&items);
+        assert_eq!(json, r#"["line1\nline2\t"]"#);
+        let parsed: Vec<String> = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(parsed, items);
+    }
+
+    /// C-12: non-ASCII passes through as raw UTF-8 (valid JSON), matching the
+    /// prior format so existing DESCRIBE fixtures stay byte-identical.
+    #[test]
+    fn format_json_array_preserves_utf8_unescaped() {
+        assert_eq!(format_json_array(&["café★".to_string()]), "[\"café★\"]");
     }
 
     #[test]


### PR DESCRIPTION
Two confirmed §2 findings from the 2026-07-11 code review that the R1 correctness bundle (#71) did not include. Both are **output/encoding-correctness** bugs — they garble user-facing text when the input contains special or non-ASCII characters — and neither rejects any input that is currently accepted. Each is byte-identical to the prior output for all-ASCII inputs, so no existing fixture changes.

## C-12 — `DESCRIBE` emits invalid JSON for values containing `"` or `\`

`format_json_array` (`src/ddl/describe.rs`) built each element with `format!("\"{s}\"")` and no escaping, so a synonym or quoted-identifier column containing a double quote produced `["a"b"]` — unparseable — in output the `DESCRIBE SEMANTIC VIEW` command documents as a JSON array (used for `SYNONYMS`, `PRIMARY_KEY`, `fk_columns`, `ref_columns`).

Fix: delegate to `serde_json::to_string`, which escapes `"`, `\`, and control characters, writes no space after the comma, and passes UTF-8 through unescaped. All-ASCII inputs stay byte-identical to the hand-rolled format.

## P-14 — parser error messages mojibake a multibyte character

`find_clause_bounds` (`src/body_parser/clause_bounds.rs`) built two error messages with `bytes[i] as char`, truncating a multibyte codepoint to its UTF-8 lead byte: a `★` (`0xE2 0x98 0x85`) at the top level of the AS body, or where a `(` was expected after a clause keyword, surfaced as the mojibake `'â'` (`U+00E2`).

Fix: decode the real character from the `&str` via a small `char_at` helper (returns `None` at end-of-input / non-boundary offsets — the `'\0'` EOF sentinel for the paren arm is preserved). The surrounding byte scans switch from `(bytes[i] as char).is_ascii_*` to `u8::is_ascii_*` directly, removing the inconsistency the fix would otherwise introduce.

## Tests

Coverage only grows — no existing test changed:

- **C-12**: escaping of `"`/`\` (with a real-parser round-trip), control-character escaping (round-trip), and UTF-8 passthrough (byte-identical assertion).
- **P-14**: multibyte character rendered verbatim in both error arms (asserting the mojibake lead byte is *absent*), `char_at` codepoint/EOF behavior, and an ASCII no-regression case. `ClauseBound` gains `#[derive(Debug)]` so the tests can `unwrap_err()`.

## Verification

- `cargo test` — 1104 lib tests pass (9 new), plus proptest/doc suites green
- `cargo clippy -- -D warnings` — clean (default features)
- `SV_SKIP_CPP_BUILD=1 cargo clippy --no-default-features --features extension -- -D warnings` — clean
- `cargo fmt --check` — clean

sqllogictest / DuckLake integration run in CI (the offline amalgamation can't load the built extension locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4)_