### PR TITLE
Code-review 2026-07-11: test coverage T-7 / T-8 / T-9

### DIFF
--- a/src/body_parser/clause_bounds.rs
+++ b/src/body_parser/clause_bounds.rs
@@ -58,6 +58,7 @@ pub(super) struct ClauseBound<'a> {
     pub(super) keyword: &'static str,
     pub(super) content: &'a str,      // text inside the matching parens
     pub(super) content_offset: usize, // byte offset of content[0] relative to the AS-body text
+    pub(super) keyword_offset: usize, // byte offset of the keyword relative to the AS-body text
 }
 
 /// Scan `text` (the text after "AS") at depth 0 to find clause headers of the form
@@ -208,6 +209,7 @@ pub(super) fn find_clause_bounds<'a>(
             keyword,
             content,
             content_offset,
+            keyword_offset: base_offset + word_start,
         });
     }
 
@@ -224,7 +226,9 @@ pub(super) fn find_clause_bounds<'a>(
                 message: format!(
                     "Clause '{kw_upper}' appears out of order; clauses must appear as: TABLES, RELATIONSHIPS (optional), FACTS (optional), DIMENSIONS (optional), METRICS (optional), MATERIALIZATIONS (optional).",
                 ),
-                position: None,
+                // T-7 (code-review 2026-07-11): point the caret at the
+                // out-of-order clause keyword instead of dropping the position.
+                position: Some(bound.keyword_offset),
             });
         }
         last_order = Some(order);
@@ -329,5 +333,54 @@ mod tests {
             "unknown-keyword message must list MATERIALIZATIONS: {}",
             err.message
         );
+    }
+
+    /// T-7 (code-review 2026-07-11): every 2-clause inversion (a clause
+    /// written before one that must precede it) is rejected as out-of-order,
+    /// and the error caret points at the offending (out-of-order) clause
+    /// keyword rather than being dropped (`position: None` before the fix).
+    /// Exhaustive over all 15 ordered pairs of the 6 clause keywords; empty
+    /// `()` bodies isolate the ordering rule from per-clause content parsing.
+    #[test]
+    fn all_two_clause_order_inversions_rejected_with_caret() {
+        let order = [
+            "tables",
+            "relationships",
+            "facts",
+            "dimensions",
+            "metrics",
+            "materializations",
+        ];
+        for (i, &earlier) in order.iter().enumerate() {
+            for &later in &order[i + 1..] {
+                // Write `later` first, then `earlier` — an inversion.
+                let body = format!("{later} () {earlier} ()");
+                let err = find_clause_bounds(&body, 0).unwrap_err();
+                assert!(
+                    err.message.contains("out of order"),
+                    "`{body}` must be rejected as out of order, got: {}",
+                    err.message
+                );
+                // Caret points at the out-of-order (`earlier`) keyword, which
+                // begins right after "{later} () ".
+                let expected = later.len() + 4;
+                assert_eq!(
+                    err.position,
+                    Some(expected),
+                    "caret for `{body}` should point at the out-of-order '{earlier}' keyword"
+                );
+            }
+        }
+    }
+
+    /// T-7: the out-of-order caret is anchored in the original query via
+    /// `base_offset`, matching every other position this scanner reports.
+    #[test]
+    fn out_of_order_caret_honours_base_offset() {
+        let base = 100;
+        let err = find_clause_bounds("metrics () dimensions ()", base).unwrap_err();
+        assert!(err.message.contains("out of order"), "{}", err.message);
+        // "dimensions" starts at byte 11 within the body ("metrics () " == 11).
+        assert_eq!(err.position, Some(base + 11));
     }
 }

--- a/src/body_parser/clause_bounds.rs
+++ b/src/body_parser/clause_bounds.rs
@@ -56,9 +56,12 @@ fn suggest_clause_keyword(word: &str) -> Option<&'static str> {
 #[derive(Debug)]
 pub(super) struct ClauseBound<'a> {
     pub(super) keyword: &'static str,
-    pub(super) content: &'a str,      // text inside the matching parens
-    pub(super) content_offset: usize, // byte offset of content[0] relative to the AS-body text
-    pub(super) keyword_offset: usize, // byte offset of the keyword relative to the AS-body text
+    pub(super) content: &'a str, // text inside the matching parens
+    // Offsets below include `base_offset`, so they are byte offsets in the
+    // original query string (what `ParseError.position` expects), not relative
+    // to the AS-body `text` this scanner receives.
+    pub(super) content_offset: usize, // byte offset of content[0] in the original query
+    pub(super) keyword_offset: usize, // byte offset of the keyword in the original query
 }
 
 /// Scan `text` (the text after "AS") at depth 0 to find clause headers of the form

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -1963,6 +1963,45 @@ mod tests {
         assert_eq!(kb.metrics[0].expr, "SUM(amount)");
     }
 
+    /// T-8 (code-review 2026-07-11): a large *valid* body parses correctly and
+    /// without arbitrary entry limits. 500 METRICS entries exercise the
+    /// depth-0 comma splitter and per-entry scans at scale; the test also pins
+    /// linearity — an accidentally-quadratic clause scan would blow this up
+    /// into a visible timeout rather than passing in milliseconds.
+    #[test]
+    fn parse_keyword_body_large_metrics_clause() {
+        const N: usize = 500;
+        let mut entries = Vec::with_capacity(N);
+        for i in 0..N {
+            entries.push(format!("o.m{i} AS SUM(amount)"));
+        }
+        let body = format!(
+            "AS TABLES (o AS orders PRIMARY KEY (id)) DIMENSIONS (o.region AS region) METRICS ({})",
+            entries.join(", ")
+        );
+        let kb = parse_keyword_body(&body, 0).unwrap();
+        assert_eq!(kb.metrics.len(), N);
+        // Spot-check the boundaries so a silent off-by-one in the splitter
+        // would surface.
+        assert_eq!(kb.metrics[0].name, "m0");
+        assert_eq!(kb.metrics[N - 1].name, format!("m{}", N - 1));
+        assert!(kb.metrics.iter().all(|m| m.expr == "SUM(amount)"));
+    }
+
+    /// T-8: a deeply-nested but balanced parenthesized metric expression parses
+    /// (the depth counter is a plain `i32`, so 64 levels is far within range)
+    /// and is stored verbatim as an uninterpreted expression.
+    #[test]
+    fn parse_keyword_body_deeply_nested_parens() {
+        const DEPTH: usize = 64;
+        let expr = format!("SUM({}amount{})", "(".repeat(DEPTH), ")".repeat(DEPTH));
+        let body = format!("AS TABLES (o AS orders PRIMARY KEY (id)) METRICS (o.deep AS {expr})");
+        let kb = parse_keyword_body(&body, 0).unwrap();
+        assert_eq!(kb.metrics.len(), 1);
+        assert_eq!(kb.metrics[0].name, "deep");
+        assert_eq!(kb.metrics[0].expr, expr);
+    }
+
     #[test]
     fn parse_keyword_body_with_relationships() {
         let body = "AS TABLES (o AS orders PRIMARY KEY (id), c AS customers PRIMARY KEY (id)) RELATIONSHIPS (o_to_c AS o(cust_id) REFERENCES c) DIMENSIONS (o.reg AS region) METRICS (o.rev AS SUM(amount))";

--- a/tests/differential_proptest.rs
+++ b/tests/differential_proptest.rs
@@ -1,0 +1,269 @@
+//! T-9 (code-review 2026-07-11): Rust-side randomized-schema differential
+//! proptest for the core base-table aggregation path.
+//!
+//! For each case we generate a random single-table star-schema *shape* — a
+//! random number of group-by dimension columns and a random set of aggregate
+//! metrics over random value columns — fill it with random integer rows, then
+//! for a random non-empty subset of dims + metrics compare the semantic-view
+//! expansion (`expand`) against an independently hand-written `GROUP BY` query
+//! over the same physical table.
+//!
+//! The two result sets are multiset-compared *inside `DuckDB`* via a symmetric
+//! `EXCEPT ALL` difference, which is type-agnostic (no Rust-side row decoding)
+//! and order-independent (both sides are projected in a canonical column order
+//! keyed by output alias, so a column-ordering difference between the two
+//! formulations is not a false diff).
+//!
+//! Scope: base-table metrics, single grain, integer data + exact aggregates
+//! (`SUM`/`COUNT`/`MIN`/`MAX` — no floating point, so equality is exact).
+//! Joins, semi-additive, window, wildcard, and USING paths are exercised by
+//! the fixed-schema Python differential harness (`test/integration/
+//! test_differential.py`, extended per T-1); this test adds schema + data +
+//! query randomization for the core path and runs under plain `cargo test`.
+
+use proptest::prelude::*;
+use semantic_views::expand::{expand, DimensionName, MetricName, QueryRequest};
+use semantic_views::model::{AccessModifier, Dimension, Metric, SemanticViewDefinition, TableRef};
+
+/// An aggregate over a generated column (or `COUNT(*)`), rendered to SQL.
+#[derive(Debug, Clone)]
+enum Agg {
+    Sum(usize),
+    Count,
+    Min(usize),
+    Max(usize),
+}
+
+impl Agg {
+    fn to_sql(&self) -> String {
+        match self {
+            Agg::Sum(j) => format!("sum(v{j})"),
+            Agg::Count => "count(*)".to_string(),
+            Agg::Min(j) => format!("min(v{j})"),
+            Agg::Max(j) => format!("max(v{j})"),
+        }
+    }
+}
+
+/// A generated schema shape plus its data. Columns are `d0..d{n_dims-1}`
+/// (group-by dimensions) followed by `v0..v{n_vals-1}` (metric inputs), all
+/// `INTEGER`. `rows` holds `n_dims + n_vals` values per row.
+#[derive(Debug, Clone)]
+struct Schema {
+    n_dims: usize,
+    n_vals: usize,
+    metric_aggs: Vec<Agg>,
+    rows: Vec<Vec<i64>>,
+}
+
+/// A full test case: a schema plus the non-empty subset of dims and metrics to
+/// query (indices into the schema's dimension list / `metric_aggs`).
+#[derive(Debug, Clone)]
+struct Case {
+    schema: Schema,
+    sel_dims: Vec<usize>,
+    sel_metrics: Vec<usize>,
+}
+
+fn arb_schema() -> impl Strategy<Value = Schema> {
+    (1usize..=3, 1usize..=3).prop_flat_map(|(n_dims, n_vals)| {
+        let agg = prop_oneof![
+            (0..n_vals).prop_map(Agg::Sum),
+            Just(Agg::Count),
+            (0..n_vals).prop_map(Agg::Min),
+            (0..n_vals).prop_map(Agg::Max),
+        ];
+        let metrics = prop::collection::vec(agg, 1..=3);
+        let ncols = n_dims + n_vals;
+        // Dimension columns are squashed into a small domain (0..3) so rows
+        // collide into real groups; value columns range wider (0..10).
+        let row = prop::collection::vec(0i64..10, ncols).prop_map(move |mut r| {
+            for cell in r.iter_mut().take(n_dims) {
+                *cell %= 3;
+            }
+            r
+        });
+        let rows = prop::collection::vec(row, 1..=25);
+        (Just(n_dims), Just(n_vals), metrics, rows).prop_map(
+            |(n_dims, n_vals, metric_aggs, rows)| Schema {
+                n_dims,
+                n_vals,
+                metric_aggs,
+                rows,
+            },
+        )
+    })
+}
+
+fn arb_case() -> impl Strategy<Value = Case> {
+    arb_schema().prop_flat_map(|schema| {
+        let nd = schema.n_dims;
+        let nm = schema.metric_aggs.len();
+        let dim_sel = prop::sample::subsequence((0..nd).collect::<Vec<_>>(), 1..=nd);
+        let met_sel = prop::sample::subsequence((0..nm).collect::<Vec<_>>(), 1..=nm);
+        (Just(schema), dim_sel, met_sel).prop_map(|(schema, sel_dims, sel_metrics)| Case {
+            schema,
+            sel_dims,
+            sel_metrics,
+        })
+    })
+}
+
+/// Build the semantic-view definition for a generated schema: base table `t`,
+/// one dimension per `d{i}` (expr == column), one metric per generated agg.
+fn build_def(s: &Schema) -> SemanticViewDefinition {
+    let dimensions = (0..s.n_dims)
+        .map(|i| Dimension {
+            name: format!("d{i}"),
+            expr: format!("d{i}"),
+            source_table: None,
+            output_type: None,
+            comment: None,
+            synonyms: vec![],
+        })
+        .collect();
+    let metrics = s
+        .metric_aggs
+        .iter()
+        .enumerate()
+        .map(|(i, agg)| Metric {
+            name: format!("m{i}"),
+            expr: agg.to_sql(),
+            source_table: None,
+            output_type: None,
+            using_relationships: vec![],
+            comment: None,
+            synonyms: vec![],
+            access: AccessModifier::Public,
+            non_additive_by: vec![],
+            window_spec: None,
+        })
+        .collect();
+    SemanticViewDefinition {
+        tables: vec![TableRef {
+            alias: "t".to_string(),
+            table: "t".to_string(),
+            pk_columns: vec![],
+            unique_constraints: vec![],
+            comment: None,
+            synonyms: vec![],
+        }],
+        dimensions,
+        metrics,
+        joins: vec![],
+        facts: vec![],
+        materializations: vec![],
+        created_on: None,
+        database_name: None,
+        schema_name: None,
+        comment: None,
+    }
+}
+
+/// Create the physical base table `t` and insert the generated rows.
+fn make_db(s: &Schema) -> duckdb::Connection {
+    let conn = duckdb::Connection::open_in_memory().expect("in-memory DuckDB");
+    let mut cols: Vec<String> = (0..s.n_dims).map(|i| format!("d{i} INTEGER")).collect();
+    cols.extend((0..s.n_vals).map(|j| format!("v{j} INTEGER")));
+    conn.execute_batch(&format!("CREATE TABLE t ({});", cols.join(", ")))
+        .expect("create table t");
+    let values: Vec<String> = s
+        .rows
+        .iter()
+        .map(|r| {
+            format!(
+                "({})",
+                r.iter().map(i64::to_string).collect::<Vec<_>>().join(",")
+            )
+        })
+        .collect();
+    if !values.is_empty() {
+        conn.execute_batch(&format!("INSERT INTO t VALUES {};", values.join(",")))
+            .expect("insert rows");
+    }
+    conn
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    /// The semantic-view expansion of a random core query returns exactly the
+    /// same rows (as a multiset) as an independently hand-written GROUP BY over
+    /// the same physical table.
+    #[test]
+    fn expansion_matches_handwritten_group_by(case in arb_case()) {
+        let def = build_def(&case.schema);
+
+        let req = QueryRequest {
+            dimensions: case
+                .sel_dims
+                .iter()
+                .map(|i| DimensionName::new(format!("d{i}")))
+                .collect(),
+            metrics: case
+                .sel_metrics
+                .iter()
+                .map(|i| MetricName::new(format!("m{i}")))
+                .collect(),
+            facts: vec![],
+        };
+
+        let expanded = expand("t_diff", &def, &req)
+            .expect("expand must succeed for a core base-table definition");
+
+        // Independent oracle: a plain GROUP BY over the same table, aliasing
+        // each output column by the same name the expansion uses.
+        let dim_items: Vec<String> = case.sel_dims.iter().map(|i| format!("d{i} AS d{i}")).collect();
+        let met_items: Vec<String> = case
+            .sel_metrics
+            .iter()
+            .map(|i| format!("{} AS m{i}", case.schema.metric_aggs[*i].to_sql()))
+            .collect();
+        let select_items = dim_items
+            .iter()
+            .chain(met_items.iter())
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let group_by = (1..=case.sel_dims.len())
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let oracle = format!("SELECT {select_items} FROM t GROUP BY {group_by}");
+
+        // Canonical projection (columns sorted by output name) so a column
+        // ORDER difference between the two formulations is not a false diff.
+        let mut proj_cols: Vec<String> = case
+            .sel_dims
+            .iter()
+            .map(|i| format!("d{i}"))
+            .chain(case.sel_metrics.iter().map(|i| format!("m{i}")))
+            .collect();
+        proj_cols.sort();
+        let proj = proj_cols.join(", ");
+
+        // Symmetric multiset difference inside DuckDB: 0 iff the two result
+        // sets are equal as multisets.
+        let cmp = format!(
+            "SELECT \
+               (SELECT count(*) FROM (SELECT {proj} FROM ({expanded}) qa \
+                                      EXCEPT ALL \
+                                      SELECT {proj} FROM ({oracle}) qb) e1) \
+             + (SELECT count(*) FROM (SELECT {proj} FROM ({oracle}) qc \
+                                      EXCEPT ALL \
+                                      SELECT {proj} FROM ({expanded}) qd) e2) AS diff"
+        );
+
+        let conn = make_db(&case.schema);
+        let diff: i64 = conn.query_row(&cmp, [], |r| r.get(0)).unwrap_or_else(|e| {
+            panic!("differential comparison query failed: {e}\n--- expanded:\n{expanded}\n--- oracle:\n{oracle}")
+        });
+
+        prop_assert_eq!(
+            diff, 0,
+            "semantic-view expansion disagrees with hand-written GROUP BY \
+             (symmetric multiset diff = {})\n--- expanded:\n{}\n--- oracle:\n{}",
+            diff, expanded, oracle
+        );
+    }
+}


### PR DESCRIPTION
Closes the three remaining §4 test-coverage gaps from the 2026-07-11 code review. Test-only, plus one tiny production fix (T-7 caret).

## T-7 — clause-order caret + exhaustive inversions

The "clause appears out of order" error dropped its caret (`position: None` in `clause_bounds.rs`). `ClauseBound` didn't record where the keyword started. Added a `keyword_offset` field and pointed the caret at the offending clause keyword.

Tests: an exhaustive check over all 15 ordered pairs of the 6 clause keywords (each inversion is rejected with the caret on the out-of-order keyword), plus a `base_offset` variant confirming the caret is anchored in the original query the same way every other position this scanner reports is.

## T-8 — large valid body parses

No test parsed a large *valid* body. Added coverage for:
- a **500-entry METRICS** clause — exercises the depth-0 comma splitter + per-entry scans at scale, and pins linearity (an accidentally-quadratic clause scan would surface here as a timeout rather than passing in milliseconds);
- a **64-deep balanced-paren** metric expression — the depth counter is a plain `i32`, and the expression is stored verbatim as uninterpreted text.

## T-9 — Rust-side randomized-schema differential proptest

New `tests/differential_proptest.rs`. For a randomly-shaped single-table star schema (random group-by dimension columns + random aggregate metrics over random value columns) filled with random integer rows, it compares the semantic-view expansion of a random dim/metric subset against an **independently hand-written `GROUP BY`** over the same physical table.

The two result sets are multiset-compared *inside DuckDB* via a symmetric `EXCEPT ALL` difference — type-agnostic (no Rust-side row decoding) and order-independent (both sides projected in a canonical alias-sorted order, so a column-ordering difference is not a false diff).

Scope: the supported core (base-table metrics, single grain, integer data + exact `SUM`/`COUNT`/`MIN`/`MAX`, so equality is exact). Joins, semi-additive, window, wildcard, and USING remain covered by the fixed-schema Python differential harness (`test/integration/test_differential.py`, extended per T-1). Runs under plain `cargo test` — `expand()` is pure Rust and the emitted SQL executes directly against the physical table, so no extension load is needed.

## Verification (full local gate)

- `cargo test` — 1247 passed, 0 failed (T-9 = 128 randomized cases)
- `make test_debug` (sqllogictest) — 71 tests, 0 failed (T-7 changed production parse code; the out-of-order `statement error` in `phase54_materializations.test` still matches — the message is unchanged, only the caret position was added)
- `make debug` — extension builds/loads
- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` and `SV_SKIP_CPP_BUILD=1 cargo clippy --no-default-features --features extension -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4)_