### PR TITLE
§6.2 (1/n): one shared word-boundary reference-find engine

### DIFF
--- a/src/expand/facts.rs
+++ b/src/expand/facts.rs
@@ -1,7 +1,10 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::model::{Fact, TableRef};
-use crate::util::{is_word_boundary_char, replace_word_boundary_any, replace_word_boundary_pairs};
+use crate::util::{
+    contains_word_boundary_ref, is_word_boundary_char, replace_word_boundary_any,
+    replace_word_boundary_pairs,
+};
 
 use super::resolution::quote_ident;
 
@@ -45,27 +48,10 @@ pub(super) fn collect_derived_metric_using(
                 }
             }
         } else {
-            // Derived metric: find referenced metric names and push to stack
-            let expr_lower = current_met.expr.to_ascii_lowercase();
+            // Derived metric: find referenced metric names and push to stack.
             for name in &all_names {
-                if *name == current_name {
-                    continue;
-                }
-                let expr_bytes = expr_lower.as_bytes();
-                let name_bytes = name.as_bytes();
-                let name_len = name_bytes.len();
-                let mut pos = 0;
-                while pos + name_len <= expr_bytes.len() {
-                    if &expr_bytes[pos..pos + name_len] == name_bytes {
-                        let before_ok = pos == 0 || is_word_boundary_char(expr_bytes[pos - 1]);
-                        let after_ok = pos + name_len == expr_bytes.len()
-                            || is_word_boundary_char(expr_bytes[pos + name_len]);
-                        if before_ok && after_ok {
-                            stack.push(name.clone());
-                            break;
-                        }
-                    }
-                    pos += 1;
+                if *name != current_name && contains_word_boundary_ref(&current_met.expr, name) {
+                    stack.push(name.clone());
                 }
             }
         }
@@ -99,28 +85,14 @@ pub(super) fn toposort_facts(facts: &[Fact]) -> Result<Vec<usize>, String> {
     let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); n]; // dependents[dep] = facts that depend on dep
 
     for (i, fact) in facts.iter().enumerate() {
-        let expr_lower = fact.expr.to_ascii_lowercase();
         for (name, &dep_idx) in &name_to_idx {
             if dep_idx == i {
                 continue; // skip self
             }
-            // Check if this fact's expr references the other fact name using word boundary
-            let expr_bytes = expr_lower.as_bytes();
-            let name_bytes = name.as_bytes();
-            let name_len = name_bytes.len();
-            let mut pos = 0;
-            while pos + name_len <= expr_bytes.len() {
-                if &expr_bytes[pos..pos + name_len] == name_bytes {
-                    let before_ok = pos == 0 || is_word_boundary_char(expr_bytes[pos - 1]);
-                    let after_ok = pos + name_len == expr_bytes.len()
-                        || is_word_boundary_char(expr_bytes[pos + name_len]);
-                    if before_ok && after_ok {
-                        in_degree[i] += 1;
-                        dependents[dep_idx].push(i);
-                        break;
-                    }
-                }
-                pos += 1;
+            // Does this fact's expr reference the other fact name (whole word)?
+            if contains_word_boundary_ref(&fact.expr, name) {
+                in_degree[i] += 1;
+                dependents[dep_idx].push(i);
             }
         }
     }
@@ -328,28 +300,14 @@ fn toposort_derived(
     let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); n];
 
     for (i, (_, met)) in derived.iter().enumerate() {
-        let expr_lower = met.expr.to_ascii_lowercase();
         for (name, &dep_idx) in &name_to_idx {
             if dep_idx == i {
                 continue; // skip self
             }
-            // Check word-boundary reference
-            let expr_bytes = expr_lower.as_bytes();
-            let name_bytes = name.as_bytes();
-            let name_len = name_bytes.len();
-            let mut pos = 0;
-            while pos + name_len <= expr_bytes.len() {
-                if &expr_bytes[pos..pos + name_len] == name_bytes {
-                    let before_ok = pos == 0 || is_word_boundary_char(expr_bytes[pos - 1]);
-                    let after_ok = pos + name_len == expr_bytes.len()
-                        || is_word_boundary_char(expr_bytes[pos + name_len]);
-                    if before_ok && after_ok {
-                        in_degree[i] += 1;
-                        dependents[dep_idx].push(i);
-                        break;
-                    }
-                }
-                pos += 1;
+            // Only derived-to-derived edges: does this expr reference `name`?
+            if contains_word_boundary_ref(&met.expr, name) {
+                in_degree[i] += 1;
+                dependents[dep_idx].push(i);
             }
         }
     }
@@ -521,29 +479,6 @@ pub(super) fn inline_derived_metrics(
     })
 }
 
-/// True when `expr_lower` references `name` at a word boundary.
-///
-/// Both arguments must already be lowercased. Shared byte-scan used by the
-/// transitive metric walks.
-fn references_name(expr_lower: &str, name: &str) -> bool {
-    let expr_bytes = expr_lower.as_bytes();
-    let name_bytes = name.as_bytes();
-    let name_len = name_bytes.len();
-    let mut pos = 0;
-    while pos + name_len <= expr_bytes.len() {
-        if &expr_bytes[pos..pos + name_len] == name_bytes {
-            let before_ok = pos == 0 || is_word_boundary_char(expr_bytes[pos - 1]);
-            let after_ok = pos + name_len == expr_bytes.len()
-                || is_word_boundary_char(expr_bytes[pos + name_len]);
-            if before_ok && after_ok {
-                return true;
-            }
-        }
-        pos += 1;
-    }
-    false
-}
-
 /// Collect the lowercased names of `met` and every metric it transitively
 /// depends on: derived metrics contribute the metric names referenced in
 /// their expressions; window metrics contribute their inner metric.
@@ -577,10 +512,9 @@ pub(super) fn collect_transitive_metric_names(
             stack.push(ws.inner_metric.to_ascii_lowercase());
         }
         if current_met.source_table.is_none() {
-            // Derived metric: find referenced metric names and push to stack
-            let expr_lower = current_met.expr.to_ascii_lowercase();
+            // Derived metric: find referenced metric names and push to stack.
             for name in &all_names {
-                if *name != current_name && references_name(&expr_lower, name) {
+                if *name != current_name && contains_word_boundary_ref(&current_met.expr, name) {
                     stack.push(name.clone());
                 }
             }
@@ -624,28 +558,10 @@ pub(crate) fn collect_derived_metric_source_tables(
             // Base metric: add its source table
             sources.insert(st.to_ascii_lowercase());
         } else {
-            // Derived metric: find referenced metric names and push to stack
-            let expr_lower = current_met.expr.to_ascii_lowercase();
+            // Derived metric: find referenced metric names and push to stack.
             for name in &all_names {
-                if *name == current_name {
-                    continue;
-                }
-                // Word-boundary check
-                let expr_bytes = expr_lower.as_bytes();
-                let name_bytes = name.as_bytes();
-                let name_len = name_bytes.len();
-                let mut pos = 0;
-                while pos + name_len <= expr_bytes.len() {
-                    if &expr_bytes[pos..pos + name_len] == name_bytes {
-                        let before_ok = pos == 0 || is_word_boundary_char(expr_bytes[pos - 1]);
-                        let after_ok = pos + name_len == expr_bytes.len()
-                            || is_word_boundary_char(expr_bytes[pos + name_len]);
-                        if before_ok && after_ok {
-                            stack.push(name.clone());
-                            break;
-                        }
-                    }
-                    pos += 1;
+                if *name != current_name && contains_word_boundary_ref(&current_met.expr, name) {
+                    stack.push(name.clone());
                 }
             }
         }

--- a/src/graph/facts.rs
+++ b/src/graph/facts.rs
@@ -7,44 +7,20 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::Write as _;
 
 use crate::model::SemanticViewDefinition;
-use crate::util::{is_word_boundary_char, suggest_closest};
+use crate::util::suggest_closest;
 
 /// Find references to known fact names in an expression using word-boundary matching.
 ///
 /// Returns a list of fact names found in `expr`. Only matches whole words:
 /// `net_price` matches in `SUM(net_price)` and `net_price + tax`
-/// but NOT in `net_price_total` or `my_net_price`.
+/// but NOT in `net_price_total` or `my_net_price`. Case-insensitive.
+///
+/// A thin domain-named view over the shared reference engine
+/// [`crate::util::find_word_boundary_refs`] (§6.2, code-review 2026-07-11) —
+/// this used to hand-roll its own dual-buffer byte scan.
 #[must_use]
 pub fn find_fact_references<'a>(expr: &str, fact_names: &[&'a str]) -> Vec<&'a str> {
-    let bytes = expr.as_bytes();
-    let expr_lower = expr.to_ascii_lowercase();
-    let lower_bytes = expr_lower.as_bytes();
-    let mut found = Vec::new();
-
-    for &fact_name in fact_names {
-        let fn_lower = fact_name.to_ascii_lowercase();
-        let fn_bytes = fn_lower.as_bytes();
-        let fn_len = fn_bytes.len();
-        if fn_len == 0 || fn_len > bytes.len() {
-            continue;
-        }
-
-        let mut i = 0;
-        while i + fn_len <= lower_bytes.len() {
-            if &lower_bytes[i..i + fn_len] == fn_bytes {
-                let before_ok = i == 0 || is_word_boundary_char(bytes[i - 1]);
-                let after_ok =
-                    i + fn_len == bytes.len() || is_word_boundary_char(bytes[i + fn_len]);
-                if before_ok && after_ok {
-                    found.push(fact_name);
-                    break; // Each fact name only counted once
-                }
-            }
-            i += 1;
-        }
-    }
-
-    found
+    crate::util::find_word_boundary_refs(expr, fact_names)
 }
 
 /// Validate facts in a semantic view definition.

--- a/src/util.rs
+++ b/src/util.rs
@@ -212,6 +212,62 @@ pub fn is_word_boundary_char(b: u8) -> bool {
     !is_ident_byte(b)
 }
 
+/// Does `haystack` reference `needle` at a word boundary?
+///
+/// `true` iff `needle` occurs in `haystack` delimited on both sides by
+/// [`is_word_boundary_char`], compared ASCII-case-insensitively — so `revenue`
+/// matches in `SUM(Revenue)` and `revenue + tax` but not in `revenue_total`,
+/// `my_revenue`, or `revenueΩ`.
+///
+/// This is the FIND counterpart of [`replace_word_boundary`] and the single
+/// primitive for the fact / derived-metric *dependency* scans (`expand::facts`,
+/// `graph::facts`), replacing the byte loops those sites hand-rolled. Like the
+/// replace primitives it is **not** quote-aware and does not treat `.`
+/// specially — it answers "does this bare identifier appear as a whole word",
+/// which is what dependency discovery over an expression needs. (The
+/// aggregate-function detector and identifier tokenizer in `graph` additionally
+/// need quote-skipping and lookahead, so they stay separate.)
+#[must_use]
+pub fn contains_word_boundary_ref(haystack: &str, needle: &str) -> bool {
+    let n_bytes = needle.as_bytes();
+    let n_len = n_bytes.len();
+    if n_len == 0 || n_len > haystack.len() {
+        return false;
+    }
+    let h_bytes = haystack.as_bytes();
+    // Byte-wise scan is safe: we only index byte windows and test boundary
+    // bytes (never slice `haystack` by `i`), and `eq_ignore_ascii_case` folds
+    // only ASCII letters, so a multi-byte needle byte is compared exactly.
+    let mut i = 0;
+    while i + n_len <= h_bytes.len() {
+        if h_bytes[i..i + n_len].eq_ignore_ascii_case(n_bytes) {
+            let before_ok = i == 0 || is_word_boundary_char(h_bytes[i - 1]);
+            let after_ok = i + n_len == h_bytes.len() || is_word_boundary_char(h_bytes[i + n_len]);
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Of `needles`, those referenced in `haystack` at a word boundary — the
+/// multi-needle FIND counterpart of [`replace_word_boundary_pairs`].
+///
+/// Each needle contributes at most one entry (even if it occurs several times),
+/// and results follow `needles` order. Matching rules are exactly
+/// [`contains_word_boundary_ref`]'s. This is the "which known names does this
+/// expression reference" primitive for metric/fact dependency discovery.
+#[must_use]
+pub fn find_word_boundary_refs<'a>(haystack: &str, needles: &[&'a str]) -> Vec<&'a str> {
+    needles
+        .iter()
+        .copied()
+        .filter(|needle| contains_word_boundary_ref(haystack, needle))
+        .collect()
+}
+
 /// Does `s` start with the ASCII keyword `kw`, case-insensitively?
 ///
 /// Compares raw *bytes*, so it is safe on any UTF-8 input: the old
@@ -562,6 +618,55 @@ mod tests {
             replace_word_boundary("Net_Price_total", "net_price", "(x)"),
             "Net_Price_total"
         );
+    }
+
+    #[test]
+    fn contains_word_boundary_ref_whole_word_only() {
+        // Matches as a whole word...
+        assert!(contains_word_boundary_ref("SUM(revenue)", "revenue"));
+        assert!(contains_word_boundary_ref("revenue + tax", "revenue"));
+        assert!(contains_word_boundary_ref("tax - revenue", "revenue"));
+        assert!(contains_word_boundary_ref("revenue", "revenue"));
+        // ...but not as a substring of a larger identifier.
+        assert!(!contains_word_boundary_ref("revenue_total", "revenue"));
+        assert!(!contains_word_boundary_ref("my_revenue", "revenue"));
+        // Non-ASCII abutting bytes are identifier continuation (E-5), not
+        // boundaries, so an ASCII needle must not match against them.
+        assert!(!contains_word_boundary_ref("revenueΩ", "revenue"));
+        assert!(!contains_word_boundary_ref("Ωrevenue", "revenue"));
+        // A genuine ASCII boundary (`.`) is still a boundary here — this
+        // primitive, unlike the inliner, does not special-case `.`.
+        assert!(contains_word_boundary_ref("x.revenue", "revenue"));
+    }
+
+    #[test]
+    fn contains_word_boundary_ref_case_insensitive() {
+        assert!(contains_word_boundary_ref("SUM(Revenue)", "revenue"));
+        assert!(contains_word_boundary_ref("sum(revenue)", "REVENUE"));
+    }
+
+    #[test]
+    fn contains_word_boundary_ref_edge_cases() {
+        assert!(!contains_word_boundary_ref("anything", "")); // empty needle
+        assert!(!contains_word_boundary_ref("ab", "abc")); // needle longer than haystack
+        assert!(!contains_word_boundary_ref("", "x"));
+    }
+
+    #[test]
+    fn find_word_boundary_refs_returns_referenced_subset_in_order() {
+        let needles = ["revenue", "cost", "tax", "profit"];
+        // `profit` and `tax` are not referenced; result keeps `needles` order.
+        assert_eq!(
+            find_word_boundary_refs("revenue - cost", &needles),
+            vec!["revenue", "cost"]
+        );
+        // Each needle contributes at most one entry even if it occurs twice.
+        assert_eq!(
+            find_word_boundary_refs("revenue + revenue", &["revenue"]),
+            vec!["revenue"]
+        );
+        // Nothing referenced.
+        assert!(find_word_boundary_refs("count(*)", &needles).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
First slice of the code-review §6.2 (expansion-layer) structural work: consolidate the duplicated word-boundary reference **find** scanners into one shared engine. Pure refactor — no behaviour change.

## Why

The fact / derived-metric *dependency* scans hand-rolled the same "does this expression reference this known name as a whole word, case-insensitively" byte loop in six places:

- `graph::facts::find_fact_references` (the dual-buffer seed the review names)
- `expand::facts`: `collect_derived_metric_using`, `toposort_facts`, `toposort_derived`, `collect_derived_metric_source_tables`
- `expand::facts::references_name` (private single-needle variant)

Duplicated scanners are exactly how the boundary-predicate drift bug class (E-3/E-5) re-grows — the review's central thesis. This is §6.2 move 2, the "one reference-scanning engine (find path)."

## What

- Add **`util::contains_word_boundary_ref(haystack, needle) -> bool`** — allocation-free (`eq_ignore_ascii_case` over byte windows, boundary via `is_word_boundary_char`); the FIND counterpart of the existing `replace_word_boundary*` inliners.
- Add **`util::find_word_boundary_refs(haystack, needles) -> Vec<&str>`** — its multi-needle filter.
- Route every find site through them: `find_fact_references` becomes a thin domain view over `find_word_boundary_refs`; the four `expand::facts` loops call the primitive; `references_name` is deleted (its one caller uses the primitive).
- Unit tests for both helpers (whole-word-only, case-insensitivity, non-ASCII boundary, edge cases, multi-needle order/dedup).

Net: −135 / +132, with the boundary/case rules now defined once.

## Scope notes

- The **quote-aware / lookahead** scanners (`contains_aggregate_function`'s `(`-lookahead, `extract_identifiers` tokenizer, `rewrite_count_star`) are genuinely different operations and intentionally stay separate.
- **E-2** (case-insensitive refs in stored expressions) was already fixed by the earlier case-insensitivity work (oracle: `cr20260711_correctness.test`); this PR does not change that behaviour, only removes the duplication the review flagged as "unify later."
- Follow-up §6.2 slices (separate PRs): SelectSpec builder (move 3), materialization-matcher dedup (move 4), one `JoinTree` per expansion (move 5, E-7), and splitting `sql_gen.rs`'s phase-named tests into behaviour-named files (move 6).

## Verification (full local gate)

- `cargo test` — 1145 passed, 0 failed (+ integration proptests incl. `differential_proptest`, `expand_proptest`)
- `make test_debug` (sqllogictest) — 71 tests, 0 failed, incl. the E-2/E-3/E-5 oracle `cr20260711_correctness.test` and the fact/derived-metric suites
- `make debug` — extension builds + loads (sqllogictest runs against it end-to-end)
- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` and `SV_SKIP_CPP_BUILD=1 cargo clippy --no-default-features --features extension -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4)_