### PR TITLE
§6.2 (3a/n): SelectItem for the output_type CAST-wrap idiom

### DIFF
--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -4,6 +4,7 @@ mod join_resolver;
 mod materialization;
 mod resolution;
 mod role_playing;
+mod select_spec;
 mod semi_additive;
 mod sql_gen;
 mod types;

--- a/src/expand/select_spec.rs
+++ b/src/expand/select_spec.rs
@@ -1,0 +1,88 @@
+//! Shared building blocks for the SELECT-emitting expansion strategies.
+//!
+//! §6.2 (code-review 2026-07-11) consolidates the four hand-rolled
+//! SELECT-statement emitters (base, semi-additive, window, materialization)
+//! onto shared pieces so their common shapes are defined once. This module is
+//! grown incrementally, one piece per PR, under the sqllogictest / proptest /
+//! differential oracle.
+//!
+//! First piece: [`SelectItem`], which owns the `[CAST(expr AS type)] AS alias`
+//! rendering the emitters previously inlined at ~11 sites (the `if let
+//! Some(type_str) = ...output_type { format!("CAST(...)") }` idiom). Callers
+//! pass the already-resolved expression (scoped-alias rewrite / fact inlining
+//! done) and the already-quoted output alias; the item owns only the optional
+//! `output_type` CAST wrap and the trailing `AS alias`.
+
+/// One `SELECT`-list item: an expression, an optional `output_type` CAST wrap,
+/// and an output alias.
+///
+/// `expr` is the fully-resolved SQL expression (any scoped-alias rewrite or
+/// fact/derived-metric inlining is the caller's responsibility) and `alias` is
+/// the already-quoted output column name (via
+/// [`super::resolution::quote_ident`]). [`SelectItem::render`] emits no leading
+/// indentation, so callers keep control of clause layout.
+pub(super) struct SelectItem {
+    expr: String,
+    cast: Option<String>,
+    alias: String,
+}
+
+impl SelectItem {
+    /// Build a select item. `cast` is the dimension/metric/fact `output_type`
+    /// (rendered as `CAST(expr AS <cast>)` when `Some`).
+    pub(super) fn new(expr: String, cast: Option<String>, alias: String) -> Self {
+        Self { expr, cast, alias }
+    }
+
+    /// Render as `CAST(expr AS <cast>) AS alias` (when a cast is set) or
+    /// `expr AS alias`. No leading indent — the caller prepends clause
+    /// indentation.
+    pub(super) fn render(&self) -> String {
+        match &self.cast {
+            Some(ty) => format!("CAST({} AS {}) AS {}", self.expr, ty, self.alias),
+            None => format!("{} AS {}", self.expr, self.alias),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SelectItem;
+
+    #[test]
+    fn renders_without_cast() {
+        let item = SelectItem::new("o.region".to_string(), None, "\"region\"".to_string());
+        assert_eq!(item.render(), "o.region AS \"region\"");
+    }
+
+    #[test]
+    fn renders_with_cast() {
+        let item = SelectItem::new(
+            "SUM(o.amount)".to_string(),
+            Some("DECIMAL(18,2)".to_string()),
+            "\"revenue\"".to_string(),
+        );
+        assert_eq!(
+            item.render(),
+            "CAST(SUM(o.amount) AS DECIMAL(18,2)) AS \"revenue\""
+        );
+    }
+
+    /// Byte-identical to the pre-refactor idiom: the caller's
+    /// `format!("    {}", item.render())` must equal the old
+    /// `format!("    {} AS {}", final_expr, alias)` for both branches.
+    #[test]
+    fn matches_legacy_indented_format() {
+        let alias = "\"m\"".to_string();
+        // no cast
+        let legacy_expr = "expr".to_string();
+        let legacy = format!("    {} AS {}", legacy_expr, alias);
+        let item = SelectItem::new("expr".to_string(), None, alias.clone());
+        assert_eq!(format!("    {}", item.render()), legacy);
+        // with cast (legacy pre-wraps the expr into final_expr)
+        let legacy_final = format!("CAST({} AS {})", "expr", "INT");
+        let legacy_cast = format!("    {} AS {}", legacy_final, alias);
+        let item_cast = SelectItem::new("expr".to_string(), Some("INT".to_string()), alias.clone());
+        assert_eq!(format!("    {}", item_cast.render()), legacy_cast);
+    }
+}

--- a/src/expand/sql_gen.rs
+++ b/src/expand/sql_gen.rs
@@ -8,6 +8,7 @@ use super::fan_trap::{check_fan_traps, validate_fact_table_path};
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{find_dimension, find_metric, qualify_and_quote_table_ref, quote_ident};
 use super::role_playing::find_using_context;
+use super::select_spec::SelectItem;
 use super::types::{ExpandError, QueryRequest, ResolvedDim};
 
 /// An entity kind resolvable by name against a [`SemanticViewDefinition`]
@@ -236,24 +237,23 @@ fn expand_facts(
 
     // Dimensions first
     for dim in &resolved_dims {
-        let base_expr = dim.expr.clone();
-        let final_expr = if let Some(ref type_str) = dim.output_type {
-            format!("CAST({base_expr} AS {type_str})")
-        } else {
-            base_expr
-        };
-        select_items.push(format!("    {} AS {}", final_expr, quote_ident(&dim.name)));
+        let item = SelectItem::new(
+            dim.expr.clone(),
+            dim.output_type.clone(),
+            quote_ident(&dim.name),
+        );
+        select_items.push(format!("    {}", item.render()));
     }
 
     // Then facts (inlined expressions, no aggregation)
     for fact in &resolved_facts {
         let resolved_expr = inline_facts(&fact.expr, &def.facts, &topo_order);
-        let final_expr = if let Some(ref type_str) = fact.output_type {
-            format!("CAST({resolved_expr} AS {type_str})")
-        } else {
-            resolved_expr
-        };
-        select_items.push(format!("    {} AS {}", final_expr, quote_ident(&fact.name)));
+        let item = SelectItem::new(
+            resolved_expr,
+            fact.output_type.clone(),
+            quote_ident(&fact.name),
+        );
+        select_items.push(format!("    {}", item.render()));
     }
     sql.push_str(&select_items.join(",\n"));
 
@@ -462,13 +462,8 @@ pub fn expand(
                 base_expr = replace_word_boundary(&base_expr, st, scoped);
             }
         }
-        // If output_type is set, wrap the expression in CAST(... AS <type>).
-        let final_expr = if let Some(ref type_str) = dim.output_type {
-            format!("CAST({base_expr} AS {type_str})")
-        } else {
-            base_expr
-        };
-        select_items.push(format!("    {} AS {}", final_expr, quote_ident(&dim.name)));
+        let item = SelectItem::new(base_expr, dim.output_type.clone(), quote_ident(&dim.name));
+        select_items.push(format!("    {}", item.render()));
     }
     for met in &resolved_mets {
         // Look up the pre-computed resolved expression (handles both base + derived metrics)
@@ -476,13 +471,12 @@ pub fn expand(
             .get(&met.name.to_ascii_lowercase())
             .cloned()
             .unwrap_or_else(|| met.expr.clone());
-        // If output_type is set, wrap the aggregate in CAST(... AS <type>).
-        let final_expr = if let Some(ref type_str) = met.output_type {
-            format!("CAST({resolved_expr} AS {type_str})")
-        } else {
-            resolved_expr
-        };
-        select_items.push(format!("    {} AS {}", final_expr, quote_ident(&met.name)));
+        let item = SelectItem::new(
+            resolved_expr,
+            met.output_type.clone(),
+            quote_ident(&met.name),
+        );
+        select_items.push(format!("    {}", item.render()));
     }
     sql.push_str(&select_items.join(",\n"));
 


### PR DESCRIPTION
First slice of the SelectSpec builder (§6.2 move 3), phased to keep each PR small and byte-identical. Pure refactor — no behaviour change.

## Why

The four SELECT-emitting strategies inline the **same** `output_type` CAST wrap at ~11 sites:

```rust
let final_expr = if let Some(ref type_str) = x.output_type {
    format!("CAST({expr} AS {type_str})")
} else { expr };
select_items.push(format!("    {} AS {}", final_expr, quote_ident(&x.name)));
```

It's the single most-duplicated emission fragment (the review's "the `output_type` CAST-wrap `if let` appears ~10×") and the clearest first extraction toward one `SelectSpec`.

## What

- New `src/expand/select_spec.rs` with **`SelectItem { expr, cast, alias }`** and one `render()` that owns the optional `CAST(expr AS type)` wrap and the trailing `AS alias`. Callers pass the already-resolved expression (scoped-alias rewrite / fact inlining stays their job) and the already-quoted alias; `render()` emits no leading indent so callers keep clause layout.
- Migrate the four `sql_gen.rs` sites — base dimension, base metric, facts dimension, fact expression — onto `SelectItem`.
- Unit tests for `render()` including a **byte-identical-to-legacy** assertion for both the cast and no-cast branches.

Output is byte-identical: the exact-string `sql_gen` tests are unchanged and pass.

## Next slices (separate PRs)

3b — migrate the CTE emitters (`semi_additive`, `window`) and the materialization column renderer onto `SelectItem`. Then the shared FROM-base + GROUP-BY-ordinals helpers, the full `SelectSpec` statement wrapper (with the E-1 alias-shadowing invariant baked in), one `JoinTree` per expansion (move 5), and the `sql_gen.rs` test-file split (move 6). Then §6.1 (lexer).

## Verification (full local gate)

- `cargo test` — 1148 passed, 0 failed (+3 new `select_spec` tests; the exact-string `sql_gen` emission tests unchanged)
- `make test_debug` (sqllogictest) — 71 tests, 0 failed
- `make debug` — extension builds + loads
- `cargo fmt --check` clean; `cargo clippy -- -D warnings` and the `--features extension` clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4)_