### PR TITLE
§6.2 (3b/n): SelectItem for the CTE emitters

### DIFF
--- a/src/expand/select_spec.rs
+++ b/src/expand/select_spec.rs
@@ -34,6 +34,24 @@ impl SelectItem {
         Self { expr, cast, alias }
     }
 
+    /// Write `CAST(expr AS <cast>)` (or bare `expr`) into `out`. The single
+    /// source of the CAST-wrap rendering, shared by [`Self::rendered_expr`] and
+    /// [`Self::render`] so they cannot diverge (the E-1 invariant lives here);
+    /// writing into the caller's buffer keeps `render` to one allocation and
+    /// avoids cloning `expr` in the common no-cast case.
+    fn write_expr(&self, out: &mut String) {
+        match &self.cast {
+            Some(ty) => {
+                out.push_str("CAST(");
+                out.push_str(&self.expr);
+                out.push_str(" AS ");
+                out.push_str(ty);
+                out.push(')');
+            }
+            None => out.push_str(&self.expr),
+        }
+    }
+
     /// The rendered expression with the optional CAST wrap applied, WITHOUT the
     /// trailing `AS alias`: `CAST(expr AS <cast>)` when a cast is set, else
     /// `expr`. Use where the same expression must be repeated elsewhere in the
@@ -41,17 +59,20 @@ impl SelectItem {
     /// CTE column by its expression rather than the shadowing select alias
     /// (E-1, code-review 2026-07-11).
     pub(super) fn rendered_expr(&self) -> String {
-        match &self.cast {
-            Some(ty) => format!("CAST({} AS {})", self.expr, ty),
-            None => self.expr.clone(),
-        }
+        let mut out = String::with_capacity(self.expr.len() + 16);
+        self.write_expr(&mut out);
+        out
     }
 
     /// Render as `<rendered_expr> AS alias` — i.e. `CAST(expr AS <cast>) AS
     /// alias` when a cast is set, else `expr AS alias`. No leading indent — the
     /// caller prepends clause indentation.
     pub(super) fn render(&self) -> String {
-        format!("{} AS {}", self.rendered_expr(), self.alias)
+        let mut out = String::with_capacity(self.expr.len() + self.alias.len() + 24);
+        self.write_expr(&mut out);
+        out.push_str(" AS ");
+        out.push_str(&self.alias);
+        out
     }
 }
 

--- a/src/expand/select_spec.rs
+++ b/src/expand/select_spec.rs
@@ -34,14 +34,24 @@ impl SelectItem {
         Self { expr, cast, alias }
     }
 
-    /// Render as `CAST(expr AS <cast>) AS alias` (when a cast is set) or
-    /// `expr AS alias`. No leading indent — the caller prepends clause
-    /// indentation.
-    pub(super) fn render(&self) -> String {
+    /// The rendered expression with the optional CAST wrap applied, WITHOUT the
+    /// trailing `AS alias`: `CAST(expr AS <cast>)` when a cast is set, else
+    /// `expr`. Use where the same expression must be repeated elsewhere in the
+    /// query — e.g. a window `PARTITION BY` / `ORDER BY` that must reference a
+    /// CTE column by its expression rather than the shadowing select alias
+    /// (E-1, code-review 2026-07-11).
+    pub(super) fn rendered_expr(&self) -> String {
         match &self.cast {
-            Some(ty) => format!("CAST({} AS {}) AS {}", self.expr, ty, self.alias),
-            None => format!("{} AS {}", self.expr, self.alias),
+            Some(ty) => format!("CAST({} AS {})", self.expr, ty),
+            None => self.expr.clone(),
         }
+    }
+
+    /// Render as `<rendered_expr> AS alias` — i.e. `CAST(expr AS <cast>) AS
+    /// alias` when a cast is set, else `expr AS alias`. No leading indent — the
+    /// caller prepends clause indentation.
+    pub(super) fn render(&self) -> String {
+        format!("{} AS {}", self.rendered_expr(), self.alias)
     }
 }
 
@@ -66,6 +76,22 @@ mod tests {
             item.render(),
             "CAST(SUM(o.amount) AS DECIMAL(18,2)) AS \"revenue\""
         );
+    }
+
+    #[test]
+    fn rendered_expr_omits_alias() {
+        // No cast: the bare expression.
+        let plain = SelectItem::new("upper(o.region)".to_string(), None, "\"r\"".to_string());
+        assert_eq!(plain.rendered_expr(), "upper(o.region)");
+        // With cast: the CAST wrap, still no `AS alias`. This is what the E-1
+        // window PARTITION/ORDER clauses repeat instead of the select alias.
+        let cast = SelectItem::new(
+            "o.d".to_string(),
+            Some("DATE".to_string()),
+            "\"d\"".to_string(),
+        );
+        assert_eq!(cast.rendered_expr(), "CAST(o.d AS DATE)");
+        assert_eq!(cast.render(), "CAST(o.d AS DATE) AS \"d\"");
     }
 
     /// Byte-identical to the pre-refactor idiom: the caller's

--- a/src/expand/semi_additive.rs
+++ b/src/expand/semi_additive.rs
@@ -40,6 +40,7 @@ use crate::util::replace_word_boundary;
 
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{qualify_and_quote_table_ref, quote_ident};
+use super::select_spec::SelectItem;
 use super::types::{ExpandError, ResolvedDim};
 
 /// Returns true when `met` is an ACTIVE semi-additive metric for a query over
@@ -150,17 +151,11 @@ pub(super) fn expand_semi_additive(
                 base_expr = replace_word_boundary(&base_expr, st, scoped);
             }
         }
-        let final_expr = if let Some(ref type_str) = dim.output_type {
-            format!("CAST({base_expr} AS {type_str})")
-        } else {
-            base_expr
-        };
-        cte_select_items.push(format!(
-            "        {} AS {}",
-            final_expr,
-            quote_ident(&dim.name)
-        ));
-        dim_cte_exprs.push(final_expr);
+        let item = SelectItem::new(base_expr, dim.output_type.clone(), quote_ident(&dim.name));
+        cte_select_items.push(format!("        {}", item.render()));
+        // The window PARTITION/ORDER clauses must repeat this EXPRESSION, never
+        // the select alias (E-1) — see the comment above.
+        dim_cte_exprs.push(item.rendered_expr());
     }
 
     // Metric raw columns in CTE -- the validated inner expression of each
@@ -286,41 +281,28 @@ pub(super) fn expand_semi_additive(
 
     let mut outer_select_items: Vec<String> = Vec::new();
 
-    // Dimension columns: reference CTE aliases
+    // Dimension columns: reference CTE aliases (outer query over the CTE, so
+    // referencing the alias is safe — no physical column shadows it here).
     for rd in resolved_dims {
-        outer_select_items.push(format!(
-            "    {} AS {}",
-            quote_ident(&rd.dim.name),
-            quote_ident(&rd.dim.name)
-        ));
+        let item = SelectItem::new(quote_ident(&rd.dim.name), None, quote_ident(&rd.dim.name));
+        outer_select_items.push(format!("    {}", item.render()));
     }
 
     // Metric columns
     for (met_idx, met) in resolved_mets.iter().enumerate() {
         let agg_func = &decomposed[met_idx].0;
 
-        if is_active_semi(met) {
-            // Active semi-additive: aggregate only rows at the snapshot rank.
-            // All rows tied at rank 1 contribute (RANK semantics, SG-4).
+        // Active semi-additive aggregates only rows at the snapshot rank (all
+        // rows tied at rank 1 contribute — RANK semantics, SG-4); regular
+        // metrics aggregate over all rows.
+        let inner = if is_active_semi(met) {
             let rn_col = get_rn_column_for_metric(met_idx, &na_groups);
-            let final_expr =
-                format!("{agg_func}(CASE WHEN \"{rn_col}\" = 1 THEN \"__sv_semi_{met_idx}\" END)");
-            let cast_expr = if let Some(ref type_str) = met.output_type {
-                format!("CAST({final_expr} AS {type_str})")
-            } else {
-                final_expr
-            };
-            outer_select_items.push(format!("    {} AS {}", cast_expr, quote_ident(&met.name)));
+            format!("{agg_func}(CASE WHEN \"{rn_col}\" = 1 THEN \"__sv_semi_{met_idx}\" END)")
         } else {
-            // Regular or effectively-regular: aggregate normally over all rows
-            let final_expr = format!("{agg_func}(\"__sv_reg_{met_idx}\")");
-            let cast_expr = if let Some(ref type_str) = met.output_type {
-                format!("CAST({final_expr} AS {type_str})")
-            } else {
-                final_expr
-            };
-            outer_select_items.push(format!("    {} AS {}", cast_expr, quote_ident(&met.name)));
-        }
+            format!("{agg_func}(\"__sv_reg_{met_idx}\")")
+        };
+        let item = SelectItem::new(inner, met.output_type.clone(), quote_ident(&met.name));
+        outer_select_items.push(format!("    {}", item.render()));
     }
 
     sql.push_str(&outer_select_items.join(",\n"));

--- a/src/expand/window.rs
+++ b/src/expand/window.rs
@@ -15,6 +15,7 @@ use crate::util::replace_word_boundary;
 
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::{qualify_and_quote_table_ref, quote_ident};
+use super::select_spec::SelectItem;
 use super::types::{ExpandError, ResolvedDim};
 
 /// Generate CTE-based expansion SQL for queries containing window function metrics.
@@ -125,16 +126,8 @@ pub(super) fn expand_window_metrics(
                 base_expr = replace_word_boundary(&base_expr, st, scoped);
             }
         }
-        let final_expr = if let Some(ref type_str) = dim.output_type {
-            format!("CAST({base_expr} AS {type_str})")
-        } else {
-            base_expr
-        };
-        cte_select_items.push(format!(
-            "        {} AS {}",
-            final_expr,
-            quote_ident(&dim.name)
-        ));
+        let item = SelectItem::new(base_expr, dim.output_type.clone(), quote_ident(&dim.name));
+        cte_select_items.push(format!("        {}", item.render()));
     }
 
     // Inner metric aggregated columns in CTE
@@ -176,13 +169,11 @@ pub(super) fn expand_window_metrics(
 
     let mut outer_select_items: Vec<String> = Vec::new();
 
-    // Dimension columns: reference CTE aliases
+    // Dimension columns: reference CTE aliases (outer query over the CTE, so
+    // referencing the alias is safe here).
     for rd in resolved_dims {
-        outer_select_items.push(format!(
-            "    {} AS {}",
-            quote_ident(&rd.dim.name),
-            quote_ident(&rd.dim.name)
-        ));
+        let item = SelectItem::new(quote_ident(&rd.dim.name), None, quote_ident(&rd.dim.name));
+        outer_select_items.push(format!("    {}", item.render()));
     }
 
     // Window metric columns
@@ -247,13 +238,8 @@ pub(super) fn expand_window_metrics(
         let over_clause = over_parts.join(" ");
         let window_expr = format!("{func_call} OVER ({over_clause})");
 
-        let final_expr = if let Some(ref type_str) = met.output_type {
-            format!("CAST({window_expr} AS {type_str})")
-        } else {
-            window_expr
-        };
-
-        outer_select_items.push(format!("    {} AS {}", final_expr, quote_ident(&met.name)));
+        let item = SelectItem::new(window_expr, met.output_type.clone(), quote_ident(&met.name));
+        outer_select_items.push(format!("    {}", item.render()));
     }
 
     sql.push_str(&outer_select_items.join(",\n"));


### PR DESCRIPTION
Continues the SelectSpec builder (§6.2 move 3, following #94). Routes the remaining `output_type` CAST-wrap sites — the semi-additive and window CTE emitters — through `select_spec::SelectItem`. Pure refactor, byte-identical output.

## What

- Add **`SelectItem::rendered_expr()`** — the CAST-wrapped expression *without* the `AS alias` — and have `render()` reuse it (`format!("{} AS {}", rendered_expr(), alias)`).
- Migrate `semi_additive.rs`: CTE dimension (+ its `dim_cte_exprs` entry via `rendered_expr()`), outer dimension projection, outer active-semi and regular metric columns.
- Migrate `window.rs`: CTE dimension, outer dimension projection, outer window-metric column.

### Why `rendered_expr()` matters (E-1)

The semi-additive `RANK()` `PARTITION BY` / `ORDER BY` clauses must repeat the dimension **expression**, never the select alias — inside the CTE's own SELECT, DuckDB binds a window-clause identifier to a same-named physical column before the lateral alias, which silently partitioned on the raw column and produced wrong snapshot sums (E-1). That expression list (`dim_cte_exprs`) now comes from the **same `SelectItem`** that renders the column, so the "render column" and "repeat expression in window clause" paths can't drift.

## Scope note

Materialization's column renderer is **intentionally not migrated**: its no-cast case emits a bare `col` (no `AS col`), which `SelectItem`'s always-aliased `render()` would change. Deliberate difference, left as-is.

## Verification (full local gate)

- `cargo test` — 1149 passed, 0 failed (+1 `rendered_expr` test; exact-string `semi_additive`/`window`/`sql_gen` emission tests unchanged)
- `make test_debug` (sqllogictest) — 71 tests, 0 failed (incl. `phase47_semi_additive`, `phase48_window_metrics`, and the E-1 oracle `cr20260711_correctness`)
- `make debug` — extension builds + loads
- `cargo fmt --check` clean; `cargo clippy -- -D warnings` and the `--features extension` clippy clean

## §6.2 remaining after this

Shared FROM-base + GROUP-BY-ordinals helpers → the full `SelectSpec` statement wrapper (with the E-1 alias-shadowing invariant baked in) → one `JoinTree` per expansion (move 5) → split `sql_gen.rs`'s phase-named tests into behaviour-named files (move 6). Then §6.1 (lexer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4)_