### PR TITLE
§6.2 (3c/n): shared FROM-base + GROUP-BY-ordinals emit helpers

### DIFF
--- a/src/expand/select_spec.rs
+++ b/src/expand/select_spec.rs
@@ -12,6 +12,14 @@
 //! pass the already-resolved expression (scoped-alias rewrite / fact inlining
 //! done) and the already-quoted output alias; the item owns only the optional
 //! `output_type` CAST wrap and the trailing `AS alias`.
+//!
+//! Also here: the shared [`push_from_base`] (base-table FROM clause) and
+//! [`push_group_by_ordinals`] (ordinal GROUP BY) emit helpers, each previously
+//! copied across the base / CTE strategies.
+
+use crate::model::SemanticViewDefinition;
+
+use super::resolution::{qualify_and_quote_table_ref, quote_ident};
 
 /// One `SELECT`-list item: an expression, an optional `output_type` CAST wrap,
 /// and an output alias.
@@ -76,9 +84,50 @@ impl SelectItem {
     }
 }
 
+/// Append the base-table FROM clause: `<lead>FROM <qualified-table> [AS
+/// <alias>]`.
+///
+/// `lead` is the whitespace before `FROM` — `"\n"` at the top level, `"\n    "`
+/// inside a CTE. The base table is qualified + quoted via
+/// [`qualify_and_quote_table_ref`]; the first declared table's alias is
+/// appended as `AS <quote_ident>` when present. Shared by the base, facts,
+/// semi-additive, and window emitters (§6.2). The materialization renderer
+/// intentionally does not use this — it selects from the pre-aggregated table
+/// with no alias.
+pub(super) fn push_from_base(sql: &mut String, def: &SemanticViewDefinition, lead: &str) {
+    sql.push_str(lead);
+    sql.push_str("FROM ");
+    sql.push_str(&qualify_and_quote_table_ref(def.base_table(), def));
+    if let Some(base_ref) = def.tables.first() {
+        sql.push_str(" AS ");
+        sql.push_str(&quote_ident(&base_ref.alias));
+    }
+}
+
+/// Append an ordinal `GROUP BY` for `n` grouping columns: `<lead>GROUP BY\n`
+/// then `<item_indent>1,\n<item_indent>2,…`. No-op when `n == 0`.
+///
+/// Ordinal grouping (never expressions) is what defends the base + CTE
+/// aggregation paths from the E-1 alias-shadowing pitfall — `GROUP BY 1` can't
+/// be captured by a same-named physical column the way `GROUP BY "region"`
+/// could. Callers own the decision of WHETHER to group (the emptiness guard
+/// differs by strategy: the base path needs both dimensions and metrics, the
+/// CTE paths need only dimensions). `lead` is the whitespace before `GROUP BY`
+/// (`"\n"` flat, `"\n    "` in a CTE); `item_indent` the per-ordinal indent
+/// (`"    "` flat, `"        "` in a CTE).
+pub(super) fn push_group_by_ordinals(sql: &mut String, n: usize, lead: &str, item_indent: &str) {
+    if n == 0 {
+        return;
+    }
+    sql.push_str(lead);
+    sql.push_str("GROUP BY\n");
+    let items: Vec<String> = (1..=n).map(|i| format!("{item_indent}{i}")).collect();
+    sql.push_str(&items.join(",\n"));
+}
+
 #[cfg(test)]
 mod tests {
-    use super::SelectItem;
+    use super::{push_group_by_ordinals, SelectItem};
 
     #[test]
     fn renders_without_cast() {
@@ -132,4 +181,27 @@ mod tests {
         let item_cast = SelectItem::new("expr".to_string(), Some("INT".to_string()), alias.clone());
         assert_eq!(format!("    {}", item_cast.render()), legacy_cast);
     }
+
+    #[test]
+    fn group_by_ordinals_flat_and_cte_indents() {
+        // Flat (top-level) layout: "\nGROUP BY\n" + 4-space ordinals.
+        let mut flat = String::new();
+        push_group_by_ordinals(&mut flat, 3, "\n", "    ");
+        assert_eq!(flat, "\nGROUP BY\n    1,\n    2,\n    3");
+        // CTE layout: "\n    GROUP BY\n" + 8-space ordinals.
+        let mut cte = String::new();
+        push_group_by_ordinals(&mut cte, 2, "\n    ", "        ");
+        assert_eq!(cte, "\n    GROUP BY\n        1,\n        2");
+    }
+
+    #[test]
+    fn group_by_ordinals_zero_is_noop() {
+        let mut s = String::from("prefix");
+        push_group_by_ordinals(&mut s, 0, "\n", "    ");
+        assert_eq!(s, "prefix");
+    }
+
+    // push_from_base is covered end-to-end (byte-identical) by the exact-string
+    // emission tests in sql_gen / semi_additive / window; a direct unit test
+    // would need a full SemanticViewDefinition fixture for little added signal.
 }

--- a/src/expand/semi_additive.rs
+++ b/src/expand/semi_additive.rs
@@ -39,8 +39,8 @@ use crate::model::{Metric, NonAdditiveDim, NullsOrder, SemanticViewDefinition, S
 use crate::util::replace_word_boundary;
 
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
-use super::resolution::{qualify_and_quote_table_ref, quote_ident};
-use super::select_spec::SelectItem;
+use super::resolution::quote_ident;
+use super::select_spec::{push_from_base, push_group_by_ordinals, SelectItem};
 use super::types::{ExpandError, ResolvedDim};
 
 /// Returns true when `met` is an ACTIVE semi-additive metric for a query over
@@ -257,12 +257,7 @@ pub(super) fn expand_semi_additive(
     sql.push_str(&cte_select_items.join(",\n"));
 
     // CTE FROM clause (same logic as expand())
-    sql.push_str("\n    FROM ");
-    sql.push_str(&qualify_and_quote_table_ref(def.base_table(), def));
-    if let Some(base_ref) = def.tables.first() {
-        sql.push_str(" AS ");
-        sql.push_str(&quote_ident(&base_ref.alias));
-    }
+    push_from_base(&mut sql, def, "\n    ");
 
     // CTE JOINs. SG-9: the snapshot ORDER BY references each active NA dim's
     // raw expression even when that dim is not queried, so the NA dims'
@@ -312,11 +307,7 @@ pub(super) fn expand_semi_additive(
 
     // GROUP BY (when dims are present)
     if !resolved_dims.is_empty() {
-        sql.push_str("\nGROUP BY\n");
-        let group_items: Vec<String> = (1..=resolved_dims.len())
-            .map(|i| format!("    {i}"))
-            .collect();
-        sql.push_str(&group_items.join(",\n"));
+        push_group_by_ordinals(&mut sql, resolved_dims.len(), "\n", "    ");
     }
 
     Ok(sql)

--- a/src/expand/sql_gen.rs
+++ b/src/expand/sql_gen.rs
@@ -6,9 +6,9 @@ use super::facts::{
 };
 use super::fan_trap::{check_fan_traps, validate_fact_table_path};
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
-use super::resolution::{find_dimension, find_metric, qualify_and_quote_table_ref, quote_ident};
+use super::resolution::{find_dimension, find_metric, quote_ident};
 use super::role_playing::find_using_context;
-use super::select_spec::SelectItem;
+use super::select_spec::{push_from_base, push_group_by_ordinals, SelectItem};
 use super::types::{ExpandError, QueryRequest, ResolvedDim};
 
 /// An entity kind resolvable by name against a [`SemanticViewDefinition`]
@@ -258,12 +258,7 @@ fn expand_facts(
     sql.push_str(&select_items.join(",\n"));
 
     // 6. FROM clause — same pattern as expand().
-    sql.push_str("\nFROM ");
-    sql.push_str(&qualify_and_quote_table_ref(def.base_table(), def));
-    if let Some(base_ref) = def.tables.first() {
-        sql.push_str(" AS ");
-        sql.push_str(&quote_ident(&base_ref.alias));
-    }
+    push_from_base(&mut sql, def, "\n");
 
     // 7. JOIN clauses — resolve required joins for dim + fact source tables.
     // Fact queries have no metrics; fact source tables are resolved through
@@ -480,15 +475,8 @@ pub fn expand(
     }
     sql.push_str(&select_items.join(",\n"));
 
-    // 6. FROM clause with base table.
-    sql.push_str("\nFROM ");
-    sql.push_str(&qualify_and_quote_table_ref(def.base_table(), def));
-
-    // If tables aliases are declared, emit AS "alias" after the base table.
-    if let Some(base_ref) = def.tables.first() {
-        sql.push_str(" AS ");
-        sql.push_str(&quote_ident(&base_ref.alias));
-    }
+    // 6. FROM clause with base table (+ AS "alias" when declared).
+    push_from_base(&mut sql, def, "\n");
 
     // Join resolution via PK/FK graph.
     // The resolver returns structured edges in emission order; role-playing
@@ -497,14 +485,10 @@ pub fn expand(
     push_join_clauses(&mut sql, &resolved_joins, def, "\nLEFT JOIN ");
 
     // 7. GROUP BY (only when both dimensions and metrics are present).
-    //    Use ordinal positions (GROUP BY 1, 2, ...) instead of expressions to avoid
-    //    ambiguity when an expression matches its alias (e.g., `status AS "status"`).
+    //    Ordinal positions avoid ambiguity when an expression matches its alias
+    //    (e.g. `status AS "status"`) — see push_group_by_ordinals (E-1).
     if !resolved_dims.is_empty() && !resolved_mets.is_empty() {
-        sql.push_str("\nGROUP BY\n");
-        let group_items: Vec<String> = (1..=resolved_dims.len())
-            .map(|i| format!("    {i}"))
-            .collect();
-        sql.push_str(&group_items.join(",\n"));
+        push_group_by_ordinals(&mut sql, resolved_dims.len(), "\n", "    ");
     }
 
     Ok(sql)

--- a/src/expand/window.rs
+++ b/src/expand/window.rs
@@ -14,8 +14,8 @@ use crate::model::{Metric, NullsOrder, SemanticViewDefinition, SortOrder};
 use crate::util::replace_word_boundary;
 
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
-use super::resolution::{qualify_and_quote_table_ref, quote_ident};
-use super::select_spec::SelectItem;
+use super::resolution::quote_ident;
+use super::select_spec::{push_from_base, push_group_by_ordinals, SelectItem};
 use super::types::{ExpandError, ResolvedDim};
 
 /// Generate CTE-based expansion SQL for queries containing window function metrics.
@@ -141,12 +141,7 @@ pub(super) fn expand_window_metrics(
     sql.push_str(&cte_select_items.join(",\n"));
 
     // CTE FROM clause
-    sql.push_str("\n    FROM ");
-    sql.push_str(&qualify_and_quote_table_ref(def.base_table(), def));
-    if let Some(base_ref) = def.tables.first() {
-        sql.push_str(" AS ");
-        sql.push_str(&quote_ident(&base_ref.alias));
-    }
+    push_from_base(&mut sql, def, "\n    ");
 
     // CTE JOINs
     let dims: Vec<&crate::model::Dimension> = resolved_dims.iter().map(|rd| rd.dim).collect();
@@ -155,11 +150,7 @@ pub(super) fn expand_window_metrics(
 
     // CTE GROUP BY (all dimension columns)
     if !resolved_dims.is_empty() {
-        sql.push_str("\n    GROUP BY\n");
-        let group_items: Vec<String> = (1..=resolved_dims.len())
-            .map(|i| format!("        {i}"))
-            .collect();
-        sql.push_str(&group_items.join(",\n"));
+        push_group_by_ordinals(&mut sql, resolved_dims.len(), "\n    ", "        ");
     }
 
     sql.push_str("\n)\n");


### PR DESCRIPTION
Continues the SelectSpec builder (§6.2 move 3, following #94/#95). Consolidates two more copied emission shapes. Pure refactor, byte-identical output.

## What

Two more emission fragments were copied across the four strategies:
- **base-table FROM clause** (`FROM <qualified-table> [AS <alias>]`) — 4 copies (`sql_gen` facts + base, `semi_additive` CTE, `window` CTE)
- **ordinal GROUP BY** (`GROUP BY\n    1,\n    2,…`) — 3 copies (`sql_gen` base, `semi_additive` outer, `window` CTE)

Add to `select_spec.rs`:
- **`push_from_base(sql, def, lead)`** — `lead` is the whitespace before `FROM` (`"\n"` flat, `"\n    "` CTE).
- **`push_group_by_ordinals(sql, n, lead, item_indent)`** — parameterized by the pre-`GROUP BY` whitespace and per-ordinal indent; no-op when `n == 0`.

Callers keep the *emptiness guard* (the base path needs both dims and metrics; the CTE paths need only dims) — the helper owns only the formatting. The ordinal-GROUP-BY **E-1 defense** (`GROUP BY 1` can't be shadowed by a same-named physical column the way `GROUP BY "region"` could) is now documented in one place.

Materialization's FROM (pre-aggregated table, no alias, no GROUP BY) is intentionally left as-is.

## Verification (full local gate)

- `cargo test` — 1151 passed, 0 failed (+2 `push_group_by_ordinals` tests; exact-string emission tests unchanged)
- `make test_debug` (sqllogictest) — 71 tests, 0 failed
- `make debug` — extension builds + loads
- `cargo fmt --check` clean; `cargo clippy -- -D warnings` and the `--features extension` clippy clean

## §6.2 remaining after this

The full `SelectSpec` statement wrapper (items/from/joins/group_by/optional-CTE → constructors + one `render()`, with the E-1 invariant baked in) → one `JoinTree` per expansion (move 5) → split `sql_gen.rs`'s phase-named tests into behaviour-named files (move 6). Then §6.1 (lexer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4)_