### PR TITLE
§6.2 (move 3): SelectSpec top-level statement wrapper

### DIFF
--- a/src/expand/select_spec.rs
+++ b/src/expand/select_spec.rs
@@ -19,6 +19,7 @@
 
 use crate::model::SemanticViewDefinition;
 
+use super::join_resolver::{push_join_clauses, ResolvedJoin};
 use super::resolution::{qualify_and_quote_table_ref, quote_ident};
 
 /// One `SELECT`-list item: an expression, an optional `output_type` CAST wrap,
@@ -125,9 +126,104 @@ pub(super) fn push_group_by_ordinals(sql: &mut String, n: usize, lead: &str, ite
     sql.push_str(&items.join(",\n"));
 }
 
+/// The `GROUP BY` of a top-level [`SelectSpec`].
+pub(super) enum GroupBy {
+    /// No `GROUP BY` — a dimensions-only `DISTINCT` query, a global aggregate
+    /// (metrics, no dimensions), an unaggregated fact query, or a window outer
+    /// query (window functions are row-level).
+    None,
+    /// Ordinal `GROUP BY` over the first `n` select items. The emitters always
+    /// place the grouping dimensions first, so `1..=n` names exactly them.
+    /// Ordinals — never expressions — are the E-1 alias-shadowing defense; see
+    /// [`push_group_by_ordinals`].
+    Ordinals(usize),
+}
+
+/// The `FROM` source of a top-level [`SelectSpec`].
+pub(super) enum FromSource<'a> {
+    /// The declared base table plus the resolver-selected `LEFT JOIN`s:
+    /// `FROM <qualified-base> [AS <alias>]` followed by each join. Carries
+    /// `def` for table qualification (both the base ref via [`push_from_base`]
+    /// and each join's physical table via [`push_join_clauses`]).
+    BaseTable {
+        def: &'a SemanticViewDefinition,
+        joins: Vec<ResolvedJoin<'a>>,
+    },
+    /// A bare, already-safe relation name — a CTE alias such as `__sv_snapshot`
+    /// / `__sv_agg`: emitted as `FROM <name>`, with no qualification, no `AS`
+    /// alias, and (structurally) no joins.
+    Named(String),
+}
+
+/// A whole top-level `SELECT` statement: `SELECT[ DISTINCT]` + select list +
+/// `FROM` (+ `LEFT JOIN`s) + optional ordinal `GROUP BY`.
+///
+/// The culmination of §6.2 move 3 (code-review 2026-07-11): the four
+/// hand-rolled top-level emitters — base ([`super::sql_gen::expand`]), facts
+/// (`sql_gen`'s `expand_facts`), and the OUTER query of the two CTE strategies
+/// ([`super::semi_additive`], [`super::window`]) — construct a `SelectSpec` and
+/// call [`Self::render`] instead of assembling the string by hand, so the
+/// statement skeleton (and the E-1 ordinal-`GROUP BY` defense) lives in one
+/// place.
+///
+/// The CTE strategies' INNER `SELECT` is deliberately NOT modelled here: its
+/// select list interleaves bespoke `RANK() OVER (...)` / decomposed-aggregate
+/// columns at a deeper indent, so it keeps hand-emitting while still sharing the
+/// lower-level [`SelectItem`], [`push_from_base`], [`push_join_clauses`], and
+/// [`push_group_by_ordinals`] pieces (the goal is the shared alias-shadowing
+/// defense + one render path for the common shape, not forcing every byte
+/// through it).
+pub(super) struct SelectSpec<'a> {
+    /// Emit `SELECT DISTINCT` rather than `SELECT` (dimensions-only base query).
+    pub(super) distinct: bool,
+    /// The select-list items in emission order. When [`Self::group_by`] is
+    /// [`GroupBy::Ordinals`], the grouping dimensions are the leading items.
+    pub(super) items: Vec<SelectItem>,
+    /// The `FROM` source (+ joins, for the base-table case).
+    pub(super) from: FromSource<'a>,
+    /// The `GROUP BY`, if any.
+    pub(super) group_by: GroupBy,
+}
+
+impl SelectSpec<'_> {
+    /// Render the whole statement — no leading indentation and no trailing
+    /// newline. Top-level callers place these at column 0; the CTE strategies
+    /// append the outer statement directly after the `)\n` closing the CTE.
+    pub(super) fn render(&self) -> String {
+        let mut sql = String::with_capacity(256);
+        sql.push_str(if self.distinct {
+            "SELECT DISTINCT\n"
+        } else {
+            "SELECT\n"
+        });
+        let rendered: Vec<String> = self
+            .items
+            .iter()
+            .map(|item| format!("    {}", item.render()))
+            .collect();
+        sql.push_str(&rendered.join(",\n"));
+        match &self.from {
+            FromSource::BaseTable { def, joins } => {
+                push_from_base(&mut sql, def, "\n");
+                push_join_clauses(&mut sql, joins, def, "\nLEFT JOIN ");
+            }
+            FromSource::Named(name) => {
+                sql.push_str("\nFROM ");
+                sql.push_str(name);
+            }
+        }
+        match self.group_by {
+            GroupBy::None => {}
+            GroupBy::Ordinals(n) => push_group_by_ordinals(&mut sql, n, "\n", "    "),
+        }
+        sql
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{push_group_by_ordinals, SelectItem};
+    use super::{push_group_by_ordinals, FromSource, GroupBy, SelectItem, SelectSpec};
+    use crate::expand::test_helpers::minimal_def;
 
     #[test]
     fn renders_without_cast() {
@@ -204,4 +300,95 @@ mod tests {
     // push_from_base is covered end-to-end (byte-identical) by the exact-string
     // emission tests in sql_gen / semi_additive / window; a direct unit test
     // would need a full SemanticViewDefinition fixture for little added signal.
+
+    #[test]
+    fn render_base_table_with_group_by() {
+        // The base metrics-and-dimensions shape: SELECT + items + FROM base +
+        // ordinal GROUP BY. `minimal_def("orders", …)` has no db/schema, so the
+        // base table qualifies to `"orders" AS "orders"`.
+        let def = minimal_def("orders", "region", "region", "cnt", "count(*)");
+        let spec = SelectSpec {
+            distinct: false,
+            items: vec![
+                SelectItem::new("region".to_string(), None, "\"region\"".to_string()),
+                SelectItem::new("count(*)".to_string(), None, "\"cnt\"".to_string()),
+            ],
+            from: FromSource::BaseTable {
+                def: &def,
+                joins: Vec::new(),
+            },
+            group_by: GroupBy::Ordinals(1),
+        };
+        assert_eq!(
+            spec.render(),
+            "SELECT\n    region AS \"region\",\n    count(*) AS \"cnt\"\n\
+             FROM \"orders\" AS \"orders\"\nGROUP BY\n    1"
+        );
+    }
+
+    #[test]
+    fn render_base_table_distinct_no_group_by() {
+        // Dimensions-only base query: SELECT DISTINCT, no GROUP BY.
+        let def = minimal_def("orders", "region", "region", "cnt", "count(*)");
+        let spec = SelectSpec {
+            distinct: true,
+            items: vec![SelectItem::new(
+                "region".to_string(),
+                None,
+                "\"region\"".to_string(),
+            )],
+            from: FromSource::BaseTable {
+                def: &def,
+                joins: Vec::new(),
+            },
+            group_by: GroupBy::None,
+        };
+        assert_eq!(
+            spec.render(),
+            "SELECT DISTINCT\n    region AS \"region\"\nFROM \"orders\" AS \"orders\""
+        );
+    }
+
+    #[test]
+    fn render_named_source_with_group_by() {
+        // The semi-additive OUTER shape: SELECT over a bare CTE name (no
+        // qualification, no alias, no joins) with an ordinal GROUP BY.
+        let spec = SelectSpec {
+            distinct: false,
+            items: vec![
+                SelectItem::new("\"region\"".to_string(), None, "\"region\"".to_string()),
+                SelectItem::new(
+                    "SUM(\"__sv_reg_0\")".to_string(),
+                    None,
+                    "\"total\"".to_string(),
+                ),
+            ],
+            from: FromSource::Named("__sv_snapshot".to_string()),
+            group_by: GroupBy::Ordinals(1),
+        };
+        assert_eq!(
+            spec.render(),
+            "SELECT\n    \"region\" AS \"region\",\n    SUM(\"__sv_reg_0\") AS \"total\"\n\
+             FROM __sv_snapshot\nGROUP BY\n    1"
+        );
+    }
+
+    #[test]
+    fn render_named_source_no_group_by() {
+        // The window OUTER shape: SELECT over a bare CTE name, no GROUP BY.
+        let spec = SelectSpec {
+            distinct: false,
+            items: vec![SelectItem::new(
+                "AVG(\"q\") OVER ()".to_string(),
+                None,
+                "\"m\"".to_string(),
+            )],
+            from: FromSource::Named("__sv_agg".to_string()),
+            group_by: GroupBy::None,
+        };
+        assert_eq!(
+            spec.render(),
+            "SELECT\n    AVG(\"q\") OVER () AS \"m\"\nFROM __sv_agg"
+        );
+    }
 }

--- a/src/expand/semi_additive.rs
+++ b/src/expand/semi_additive.rs
@@ -40,7 +40,7 @@ use crate::util::replace_word_boundary;
 
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::quote_ident;
-use super::select_spec::{push_from_base, push_group_by_ordinals, SelectItem};
+use super::select_spec::{push_from_base, FromSource, GroupBy, SelectItem, SelectSpec};
 use super::types::{ExpandError, ResolvedDim};
 
 /// Returns true when `met` is an ACTIVE semi-additive metric for a query over
@@ -271,16 +271,17 @@ pub(super) fn expand_semi_additive(
 
     sql.push_str("\n)\n");
 
-    // === Outer SELECT ===
-    sql.push_str("SELECT\n");
-
-    let mut outer_select_items: Vec<String> = Vec::new();
+    // === Outer SELECT over the snapshot CTE ===
+    let mut outer_items: Vec<SelectItem> = Vec::new();
 
     // Dimension columns: reference CTE aliases (outer query over the CTE, so
     // referencing the alias is safe — no physical column shadows it here).
     for rd in resolved_dims {
-        let item = SelectItem::new(quote_ident(&rd.dim.name), None, quote_ident(&rd.dim.name));
-        outer_select_items.push(format!("    {}", item.render()));
+        outer_items.push(SelectItem::new(
+            quote_ident(&rd.dim.name),
+            None,
+            quote_ident(&rd.dim.name),
+        ));
     }
 
     // Metric columns
@@ -296,19 +297,30 @@ pub(super) fn expand_semi_additive(
         } else {
             format!("{agg_func}(\"__sv_reg_{met_idx}\")")
         };
-        let item = SelectItem::new(inner, met.output_type.clone(), quote_ident(&met.name));
-        outer_select_items.push(format!("    {}", item.render()));
+        outer_items.push(SelectItem::new(
+            inner,
+            met.output_type.clone(),
+            quote_ident(&met.name),
+        ));
     }
 
-    sql.push_str(&outer_select_items.join(",\n"));
+    // Dimensions present ⇒ ordinal GROUP BY over them; a metrics-only snapshot
+    // query is a global aggregate with no GROUP BY.
+    let group_by = if resolved_dims.is_empty() {
+        GroupBy::None
+    } else {
+        GroupBy::Ordinals(resolved_dims.len())
+    };
 
-    // FROM the CTE
-    sql.push_str("\nFROM __sv_snapshot");
-
-    // GROUP BY (when dims are present)
-    if !resolved_dims.is_empty() {
-        push_group_by_ordinals(&mut sql, resolved_dims.len(), "\n", "    ");
-    }
+    sql.push_str(
+        &SelectSpec {
+            distinct: false,
+            items: outer_items,
+            from: FromSource::Named("__sv_snapshot".to_string()),
+            group_by,
+        }
+        .render(),
+    );
 
     Ok(sql)
 }

--- a/src/expand/sql_gen.rs
+++ b/src/expand/sql_gen.rs
@@ -5,10 +5,10 @@ use super::facts::{
     collect_transitive_metric_names, inline_derived_metrics, inline_facts, toposort_facts,
 };
 use super::fan_trap::{check_fan_traps, validate_fact_table_path};
-use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
+use super::join_resolver::resolve_joins_pkfk;
 use super::resolution::{find_dimension, find_metric, quote_ident};
 use super::role_playing::find_using_context;
-use super::select_spec::{push_from_base, push_group_by_ordinals, SelectItem};
+use super::select_spec::{FromSource, GroupBy, SelectItem, SelectSpec};
 use super::types::{ExpandError, QueryRequest, ResolvedDim};
 
 /// An entity kind resolvable by name against a [`SemanticViewDefinition`]
@@ -229,38 +229,29 @@ fn expand_facts(
         cycle_description: e,
     })?;
 
-    // 5. Build SELECT clause (no DISTINCT, no aggregation).
-    let mut sql = String::with_capacity(256);
-    sql.push_str("SELECT\n");
-
-    let mut select_items: Vec<String> = Vec::new();
+    // 5. Build the SELECT list (no DISTINCT, no aggregation).
+    let mut items: Vec<SelectItem> = Vec::new();
 
     // Dimensions first
     for dim in &resolved_dims {
-        let item = SelectItem::new(
+        items.push(SelectItem::new(
             dim.expr.clone(),
             dim.output_type.clone(),
             quote_ident(&dim.name),
-        );
-        select_items.push(format!("    {}", item.render()));
+        ));
     }
 
     // Then facts (inlined expressions, no aggregation)
     for fact in &resolved_facts {
         let resolved_expr = inline_facts(&fact.expr, &def.facts, &topo_order);
-        let item = SelectItem::new(
+        items.push(SelectItem::new(
             resolved_expr,
             fact.output_type.clone(),
             quote_ident(&fact.name),
-        );
-        select_items.push(format!("    {}", item.render()));
+        ));
     }
-    sql.push_str(&select_items.join(",\n"));
 
-    // 6. FROM clause — same pattern as expand().
-    push_from_base(&mut sql, def, "\n");
-
-    // 7. JOIN clauses — resolve required joins for dim + fact source tables.
+    // 6. JOIN clauses — resolve required joins for dim + fact source tables.
     // Fact queries have no metrics; fact source tables are resolved through
     // the same path walk as dimensions (SG-10) and their joins are appended
     // after the dimension-driven joins.
@@ -268,12 +259,17 @@ fn expand_facts(
         .iter()
         .filter_map(|f| f.source_table.clone())
         .collect();
-    let resolved_joins = resolve_joins_pkfk(def, &resolved_dims, &[], &fact_sources);
-    push_join_clauses(&mut sql, &resolved_joins, def, "\nLEFT JOIN ");
+    let joins = resolve_joins_pkfk(def, &resolved_dims, &[], &fact_sources);
 
-    // NO GROUP BY — fact queries are unaggregated
-
-    Ok(sql)
+    // 7. A fact query is an unaggregated top-level SELECT over the base table
+    //    (+ joins): no DISTINCT, no GROUP BY.
+    Ok(SelectSpec {
+        distinct: false,
+        items,
+        from: FromSource::BaseTable { def, joins },
+        group_by: GroupBy::None,
+    }
+    .render())
 }
 
 /// Expand a semantic view definition into a SQL query string.
@@ -434,18 +430,13 @@ pub fn expand(
         );
     }
 
-    // 5. Build the SELECT clause.
+    // 5. Build the top-level SELECT.
     //    Dimensions-only (no metrics): SELECT DISTINCT, no GROUP BY.
     //    Metrics-only (no dimensions): SELECT (global aggregate), no GROUP BY.
-    //    Both: SELECT with GROUP BY.
-    let mut sql = String::with_capacity(256);
-    if !resolved_dims.is_empty() && resolved_mets.is_empty() {
-        sql.push_str("SELECT DISTINCT\n");
-    } else {
-        sql.push_str("SELECT\n");
-    }
+    //    Both: SELECT with an ordinal GROUP BY over the dimensions.
+    let distinct = !resolved_dims.is_empty() && resolved_mets.is_empty();
 
-    let mut select_items: Vec<String> = Vec::new();
+    let mut items: Vec<SelectItem> = Vec::new();
     for rd in &resolved {
         let dim = rd.dim;
         let mut base_expr = dim.expr.clone();
@@ -457,8 +448,11 @@ pub fn expand(
                 base_expr = replace_word_boundary(&base_expr, st, scoped);
             }
         }
-        let item = SelectItem::new(base_expr, dim.output_type.clone(), quote_ident(&dim.name));
-        select_items.push(format!("    {}", item.render()));
+        items.push(SelectItem::new(
+            base_expr,
+            dim.output_type.clone(),
+            quote_ident(&dim.name),
+        ));
     }
     for met in &resolved_mets {
         // Look up the pre-computed resolved expression (handles both base + derived metrics)
@@ -466,32 +460,34 @@ pub fn expand(
             .get(&met.name.to_ascii_lowercase())
             .cloned()
             .unwrap_or_else(|| met.expr.clone());
-        let item = SelectItem::new(
+        items.push(SelectItem::new(
             resolved_expr,
             met.output_type.clone(),
             quote_ident(&met.name),
-        );
-        select_items.push(format!("    {}", item.render()));
+        ));
     }
-    sql.push_str(&select_items.join(",\n"));
 
-    // 6. FROM clause with base table (+ AS "alias" when declared).
-    push_from_base(&mut sql, def, "\n");
-
-    // Join resolution via PK/FK graph.
-    // The resolver returns structured edges in emission order; role-playing
-    // scoped joins (e.g. "a__dep_airport") follow the bare joins.
-    let resolved_joins = resolve_joins_pkfk(def, &resolved_dims, &resolved_mets, &[]);
-    push_join_clauses(&mut sql, &resolved_joins, def, "\nLEFT JOIN ");
+    // 6. Join resolution via PK/FK graph.
+    //    The resolver returns structured edges in emission order; role-playing
+    //    scoped joins (e.g. "a__dep_airport") follow the bare joins.
+    let joins = resolve_joins_pkfk(def, &resolved_dims, &resolved_mets, &[]);
 
     // 7. GROUP BY (only when both dimensions and metrics are present).
     //    Ordinal positions avoid ambiguity when an expression matches its alias
     //    (e.g. `status AS "status"`) — see push_group_by_ordinals (E-1).
-    if !resolved_dims.is_empty() && !resolved_mets.is_empty() {
-        push_group_by_ordinals(&mut sql, resolved_dims.len(), "\n", "    ");
-    }
+    let group_by = if !resolved_dims.is_empty() && !resolved_mets.is_empty() {
+        GroupBy::Ordinals(resolved_dims.len())
+    } else {
+        GroupBy::None
+    };
 
-    Ok(sql)
+    Ok(SelectSpec {
+        distinct,
+        items,
+        from: FromSource::BaseTable { def, joins },
+        group_by,
+    }
+    .render())
 }
 
 #[cfg(test)]

--- a/src/expand/window.rs
+++ b/src/expand/window.rs
@@ -15,7 +15,9 @@ use crate::util::replace_word_boundary;
 
 use super::join_resolver::{push_join_clauses, resolve_joins_pkfk};
 use super::resolution::quote_ident;
-use super::select_spec::{push_from_base, push_group_by_ordinals, SelectItem};
+use super::select_spec::{
+    push_from_base, push_group_by_ordinals, FromSource, GroupBy, SelectItem, SelectSpec,
+};
 use super::types::{ExpandError, ResolvedDim};
 
 /// Generate CTE-based expansion SQL for queries containing window function metrics.
@@ -155,16 +157,17 @@ pub(super) fn expand_window_metrics(
 
     sql.push_str("\n)\n");
 
-    // 4. Build outer SELECT
-    sql.push_str("SELECT\n");
-
-    let mut outer_select_items: Vec<String> = Vec::new();
+    // 4. Build the outer SELECT over the aggregation CTE.
+    let mut outer_items: Vec<SelectItem> = Vec::new();
 
     // Dimension columns: reference CTE aliases (outer query over the CTE, so
     // referencing the alias is safe here).
     for rd in resolved_dims {
-        let item = SelectItem::new(quote_ident(&rd.dim.name), None, quote_ident(&rd.dim.name));
-        outer_select_items.push(format!("    {}", item.render()));
+        outer_items.push(SelectItem::new(
+            quote_ident(&rd.dim.name),
+            None,
+            quote_ident(&rd.dim.name),
+        ));
     }
 
     // Window metric columns
@@ -229,16 +232,23 @@ pub(super) fn expand_window_metrics(
         let over_clause = over_parts.join(" ");
         let window_expr = format!("{func_call} OVER ({over_clause})");
 
-        let item = SelectItem::new(window_expr, met.output_type.clone(), quote_ident(&met.name));
-        outer_select_items.push(format!("    {}", item.render()));
+        outer_items.push(SelectItem::new(
+            window_expr,
+            met.output_type.clone(),
+            quote_ident(&met.name),
+        ));
     }
 
-    sql.push_str(&outer_select_items.join(",\n"));
-
-    // FROM the CTE
-    sql.push_str("\nFROM __sv_agg");
-
-    // No GROUP BY in the outer query -- window functions are row-level
+    // Window functions are row-level ⇒ no GROUP BY in the outer query.
+    sql.push_str(
+        &SelectSpec {
+            distinct: false,
+            items: outer_items,
+            from: FromSource::Named("__sv_agg".to_string()),
+            group_by: GroupBy::None,
+        }
+        .render(),
+    );
 
     Ok(sql)
 }


### PR DESCRIPTION
The culmination of §6.2 move 3 (code-review 2026-07-11), building on the shared pieces landed in slices 3a–3c (`SelectItem`, `push_from_base`, `push_group_by_ordinals`, `push_join_clauses`). Pure refactor, byte-identical output.

## What

Introduce **`SelectSpec`** in `select_spec.rs` — a single renderer for a whole top-level `SELECT` statement:

```
SELECT[ DISTINCT]
    <items…>
FROM <base [AS alias] + LEFT JOINs>  |  FROM <cte-name>
[GROUP BY  1, 2, …]
```

The four hand-rolled top-level emitters now **construct** a `SelectSpec` and call `render()` instead of assembling the string by hand:

| Strategy | `from` | `group_by` |
| --- | --- | --- |
| base (`sql_gen::expand`) | `BaseTable { def, joins }` | `Ordinals(n)` when dims+metrics, else `None` (`DISTINCT` for dims-only) |
| facts (`sql_gen::expand_facts`) | `BaseTable { def, joins }` | `None` (unaggregated) |
| semi-additive **outer** | `Named("__sv_snapshot")` | `Ordinals(n)` when dims, else `None` |
| window **outer** | `Named("__sv_agg")` | `None` (row-level) |

- **`from` is an enum** (`BaseTable { def, joins }` vs `Named(name)`), so *"a CTE outer query has no base-table joins"* is structural, not a convention.
- The **E-1 alias-shadowing defense** (ordinal `GROUP BY`, never expressions) now lives in exactly one place: `SelectSpec::render` → `push_group_by_ordinals`.

The two CTE **inner** SELECTs deliberately keep hand-emitting — their select lists interleave bespoke `RANK() OVER (…)` / decomposed-aggregate columns at a deeper indent, so routing them through `SelectSpec` would add more parameters than it removes. They still share the lower-level `SelectItem` / `push_from_base` / `push_join_clauses` / `push_group_by_ordinals` pieces from 3a–3c.

## Verification (full local gate)

- `cargo test` — 1155 passed, 0 failed (+4 `SelectSpec::render` exact-string unit tests; the existing per-strategy exact-string emission tests + differential proptest are unchanged)
- `make test_debug` (sqllogictest) — 71 tests, 0 failed
- `make debug` — extension builds + loads
- `cargo fmt --check` clean; `cargo clippy -- -D warnings` and `--features extension` clippy clean

## §6.2 remaining after this

Move 5 — one `JoinTree` per expansion for fan-trap / join-emit / fact-path (E-7; three graph traversals today) → move 6 — split `sql_gen.rs`'s phase-named tests into behaviour-named files. Then §6.1 (lexer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4)_