### PR TITLE
§6.2 (move 5): one JoinTree for the directed join-edge walks (E-7)

### DIFF
--- a/src/ddl/show_dims_for_metric.rs
+++ b/src/ddl/show_dims_for_metric.rs
@@ -16,8 +16,8 @@ use crate::ddl::read_ffi::{
     probe_catalog_table_present, read_str_arg, run_dispatcher, serialize_varchar_bool_rows,
     BorrowedConnection,
 };
-use crate::expand::{ancestors_to_root, collect_derived_metric_source_tables};
-use crate::graph::RelationshipGraph;
+use crate::expand::collect_derived_metric_source_tables;
+use crate::graph::{JoinTree, RelationshipGraph};
 use crate::model::{Cardinality, Dimension, SemanticViewDefinition};
 use crate::util::suggest_closest;
 
@@ -159,12 +159,8 @@ unsafe fn show_dims_for_metric(
     } else {
         let graph =
             RelationshipGraph::from_definition(&def).map_err(|e| format!("graph error: {e}"))?;
-        let mut parent_map: HashMap<String, String> = HashMap::new();
-        for (child, parents) in &graph.reverse {
-            if let Some(parent) = parents.first() {
-                parent_map.insert(child.clone(), parent.clone());
-            }
-        }
+        // The directed parent tree — same derivation the fan-trap check uses (E-7).
+        let tree = JoinTree::from_graph(&graph);
         let card_map: HashMap<(String, String), Cardinality> = def
             .joins
             .iter()
@@ -181,7 +177,7 @@ unsafe fn show_dims_for_metric(
             .collect();
         def.dimensions
             .iter()
-            .filter(|d| is_dimension_reachable_for_metric(d, &met_tables, &parent_map, &card_map))
+            .filter(|d| is_dimension_reachable_for_metric(d, &met_tables, &tree, &card_map))
             .map(|d| {
                 let table_name = d
                     .source_table
@@ -215,7 +211,7 @@ unsafe fn show_dims_for_metric(
 fn is_dimension_reachable_for_metric(
     dim: &Dimension,
     met_tables: &[String],
-    parent_map: &HashMap<String, String>,
+    tree: &JoinTree,
     card_map: &HashMap<(String, String), Cardinality>,
 ) -> bool {
     // Base table dimension (no source_table): always reachable
@@ -229,8 +225,8 @@ fn is_dimension_reachable_for_metric(
             return true; // Same table, no fan-out possible
         }
 
-        let met_ancestors = ancestors_to_root(met_table, parent_map);
-        let dim_ancestors = ancestors_to_root(&dim_table, parent_map);
+        let met_ancestors = tree.ancestors_to_root(met_table);
+        let dim_ancestors = tree.ancestors_to_root(&dim_table);
 
         // Find the lowest common ancestor (LCA)
         let dim_ancestor_set: HashSet<&String> = dim_ancestors.iter().collect();
@@ -249,7 +245,7 @@ fn is_dimension_reachable_for_metric(
         // Walking current -> parent at each step.
         let mut current = met_table.clone();
         while current != lca {
-            let Some(parent) = parent_map.get(&current) else {
+            let Some(parent) = tree.parent_of(&current) else {
                 break;
             };
 

--- a/src/expand/fan_trap.rs
+++ b/src/expand/fan_trap.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use crate::graph::JoinTree;
 use crate::model::{Cardinality, Metric, SemanticViewDefinition};
 
 use super::facts::collect_derived_metric_source_tables;
@@ -46,14 +47,10 @@ pub(super) fn check_fan_traps(
     let graph = build_relationship_graph(view_name, def)?;
     let card_map = build_card_map(def);
 
-    // Build parent map for tree path finding.
-    // In a validated tree, each non-root node has exactly one parent via the reverse map.
-    let mut parent_map: HashMap<String, String> = HashMap::new();
-    for (child, parents) in &graph.reverse {
-        if let Some(parent) = parents.first() {
-            parent_map.insert(child.clone(), parent.clone());
-        }
-    }
+    // The directed parent tree for path finding — derived once and shared with
+    // the fact-path validator + the SHOW-dims filter (E-7). In a validated tree
+    // each non-root node has exactly one parent via the reverse map.
+    let tree = JoinTree::from_graph(&graph);
 
     let queried_dim_names: HashSet<String> = resolved_dims
         .iter()
@@ -94,8 +91,8 @@ pub(super) fn check_fan_traps(
 
                 // Find path from met_table to dim_table through the tree.
                 // Walk both up to root to get ancestor chains, then derive path.
-                let met_ancestors = ancestors_to_root(met_table, &parent_map);
-                let dim_ancestors = ancestors_to_root(&dim_table, &parent_map);
+                let met_ancestors = tree.ancestors_to_root(met_table);
+                let dim_ancestors = tree.ancestors_to_root(&dim_table);
 
                 // Find the lowest common ancestor (LCA)
                 let dim_ancestor_set: HashSet<&String> = dim_ancestors.iter().collect();
@@ -110,8 +107,8 @@ pub(super) fn check_fan_traps(
 
                 // Build path: met_table -> ... -> LCA -> ... -> dim_table,
                 // then scan the up-leg and down-leg for a fanning edge.
-                let up_path = path_to_ancestor(met_table, &lca, &parent_map);
-                let down_path = path_from_ancestor_to_node(&lca, &dim_table, &dim_ancestors);
+                let up_path = tree.path_to_ancestor(met_table, &lca);
+                let down_path = tree.path_from_ancestor_to_node(&lca, &dim_table);
                 let fanning = fanning_edge_on_path(&up_path, &card_map)
                     .or_else(|| fanning_edge_on_path(&down_path, &card_map));
                 if let Some(rel_name) = fanning {
@@ -146,7 +143,7 @@ pub(super) fn check_fan_traps(
         .map(|m| {
             let tables = metric_grain_tables(m, def);
             if tables.is_empty() {
-                vec![graph.root.clone()]
+                vec![tree.root().to_string()]
             } else {
                 tables
             }
@@ -372,38 +369,6 @@ fn find_path(
     None
 }
 
-/// Walk from `node` to the root through the parent map, returning the chain
-/// including `node` itself. The last element is the root.
-pub(crate) fn ancestors_to_root(node: &str, parent_map: &HashMap<String, String>) -> Vec<String> {
-    let mut chain = vec![node.to_string()];
-    let mut current = node.to_string();
-    while let Some(parent) = parent_map.get(&current) {
-        chain.push(parent.clone());
-        current = parent.clone();
-    }
-    chain
-}
-
-/// Build the chain `[start, parent, ..., ancestor]` by walking the parent
-/// map. Stops early (returning a partial chain) if the parent chain breaks
-/// before reaching `ancestor`.
-fn path_to_ancestor(
-    start: &str,
-    ancestor: &str,
-    parent_map: &HashMap<String, String>,
-) -> Vec<String> {
-    let mut path = vec![start.to_string()];
-    let mut current = start.to_string();
-    while current != ancestor {
-        let Some(parent) = parent_map.get(&current) else {
-            break;
-        };
-        path.push(parent.clone());
-        current = parent.clone();
-    }
-    path
-}
-
 /// Scan consecutive pairs along `path` for an edge traversed in the fan-out
 /// direction, returning the fanning relationship's name.
 ///
@@ -467,21 +432,16 @@ pub(super) fn validate_fact_table_path(
     // SG-7: an unbuildable graph is an error, not a skipped check.
     let graph = build_relationship_graph(view_name, def)?;
 
-    // Build parent map from reverse adjacency
-    let mut parent_map: HashMap<String, String> = HashMap::new();
-    for (child, parents) in &graph.reverse {
-        if let Some(parent) = parents.first() {
-            parent_map.insert(child.clone(), parent.clone());
-        }
-    }
+    // The directed parent tree (shared derivation with check_fan_traps, E-7).
+    let tree = JoinTree::from_graph(&graph);
 
     // For each pair, verify one is an ancestor of the other
     for i in 0..all_tables.len() {
         for j in (i + 1)..all_tables.len() {
             let a = &all_tables[i];
             let b = &all_tables[j];
-            let a_ancestors = ancestors_to_root(a, &parent_map);
-            let b_ancestors = ancestors_to_root(b, &parent_map);
+            let a_ancestors = tree.ancestors_to_root(a);
+            let b_ancestors = tree.ancestors_to_root(b);
             let a_is_ancestor_of_b = b_ancestors.iter().any(|x| x == a);
             let b_is_ancestor_of_a = a_ancestors.iter().any(|x| x == b);
             if !a_is_ancestor_of_b && !b_is_ancestor_of_a {
@@ -497,53 +457,14 @@ pub(super) fn validate_fact_table_path(
     Ok(())
 }
 
-/// Build the path from an ancestor down to a target node, given the target's ancestor chain.
-/// Returns a vec starting at `ancestor` and ending at `target`.
-fn path_from_ancestor_to_node(
-    ancestor: &str,
-    target: &str,
-    target_ancestors: &[String],
-) -> Vec<String> {
-    // target_ancestors is [target, parent, grandparent, ..., root]
-    // Find ancestor in this chain and take the sub-chain, reversed.
-    if let Some(pos) = target_ancestors.iter().position(|a| a == ancestor) {
-        let mut path: Vec<String> = target_ancestors[..=pos].to_vec();
-        path.reverse();
-        path
-    } else {
-        vec![ancestor.to_string(), target.to_string()]
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::expand::test_helpers::{minimal_def, orders_view, TestFixtureExt};
     use crate::model::{Cardinality, NullsOrder, SortOrder, WindowSpec};
 
-    #[test]
-    fn test_ancestors_to_root_at_root() {
-        let parent_map: HashMap<String, String> = HashMap::new();
-        let result = ancestors_to_root("root", &parent_map);
-        assert_eq!(result, vec!["root"]);
-    }
-
-    #[test]
-    fn test_ancestors_to_root_single_parent() {
-        let mut parent_map: HashMap<String, String> = HashMap::new();
-        parent_map.insert("child".to_string(), "root".to_string());
-        let result = ancestors_to_root("child", &parent_map);
-        assert_eq!(result, vec!["child", "root"]);
-    }
-
-    #[test]
-    fn test_ancestors_to_root_multi_level() {
-        let mut parent_map: HashMap<String, String> = HashMap::new();
-        parent_map.insert("leaf".to_string(), "mid".to_string());
-        parent_map.insert("mid".to_string(), "root".to_string());
-        let result = ancestors_to_root("leaf", &parent_map);
-        assert_eq!(result, vec!["leaf", "mid", "root"]);
-    }
+    // The directed ancestor-walk helpers now live on `crate::graph::JoinTree`,
+    // where their unit tests moved too (§6.2 move 5, E-7).
 
     #[test]
     fn test_check_fan_traps_no_joins_ok() {

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -65,6 +65,4 @@ pub use types::{
 #[cfg(feature = "extension")]
 pub(crate) use facts::collect_derived_metric_source_tables;
 #[cfg(feature = "extension")]
-pub(crate) use fan_trap::ancestors_to_root;
-#[cfg(feature = "extension")]
 pub(crate) use materialization::find_routing_materialization_name;

--- a/src/graph/join_tree.rs
+++ b/src/graph/join_tree.rs
@@ -88,15 +88,15 @@ impl JoinTree {
     }
 
     /// Build the path from `ancestor` down to `target`: `[ancestor, …,
-    /// target]`. Derived from `target`'s ancestor chain (so `ancestor` must be
-    /// an ancestor of `target`); falls back to `[ancestor, target]` when it is
-    /// not on the chain.
+    /// target]`. Walks `target` UP to `ancestor` (a prefix of `target`'s full
+    /// ancestor chain — it stops at `ancestor` rather than continuing to the
+    /// root) and reverses, so callers that already hold `target`'s ancestor
+    /// chain don't pay for a second full walk to the root. Falls back to
+    /// `[ancestor, target]` when `ancestor` is not on `target`'s parent chain.
     pub(crate) fn path_from_ancestor_to_node(&self, ancestor: &str, target: &str) -> Vec<String> {
-        let target_ancestors = self.ancestors_to_root(target);
-        if let Some(pos) = target_ancestors.iter().position(|a| a == ancestor) {
-            let mut path: Vec<String> = target_ancestors[..=pos].to_vec();
-            path.reverse();
-            path
+        let up = self.path_to_ancestor(target, ancestor);
+        if up.last().is_some_and(|last| last == ancestor) {
+            up.into_iter().rev().collect()
         } else {
             vec![ancestor.to_string(), target.to_string()]
         }

--- a/src/graph/join_tree.rs
+++ b/src/graph/join_tree.rs
@@ -1,0 +1,174 @@
+//! The rooted parent tree of a validated relationship graph.
+//!
+//! §6.2 move 5 (E-7, code-review 2026-07-11): the fan-trap safety check, the
+//! fact-path validator, and the `SHOW ... DIMENSIONS FOR METRIC` reachability
+//! filter each independently rebuilt the *same* child→parent map from
+//! [`RelationshipGraph::reverse`] (the map was literally built three times —
+//! twice in `fan_trap.rs`, once in `ddl/show_dims_for_metric.rs`) and carried
+//! their own copies of the ancestor / ancestor-path walks over it. [`JoinTree`]
+//! owns that directed parent tree and those walks once.
+//!
+//! Scope: this is the DIRECTED FK parent tree (each non-root alias → the
+//! neighbor toward the root along an FK edge). The UNDIRECTED traversals —
+//! `expand::join_resolver`'s BFS `build_tree_parents` (which also spans the
+//! FK-side-of-root, SG-10) and `fan_trap`'s `find_path` adjacency BFS — are a
+//! genuinely different tree and are intentionally NOT folded in here: they walk
+//! different edges, and merging them would change which path the fan-trap check
+//! inspects.
+
+use std::collections::HashMap;
+
+use super::relationship::RelationshipGraph;
+
+/// The directed parent tree of a validated relationship graph: each non-root
+/// alias mapped to its single parent (the first reverse edge — in a validated
+/// tree each non-root node has exactly one, and role-playing multi-edges to one
+/// node all share the same parent table).
+pub(crate) struct JoinTree {
+    root: String,
+    parent: HashMap<String, String>,
+}
+
+impl JoinTree {
+    /// Derive the parent tree from a relationship graph's reverse adjacency.
+    /// This is the map that `fan_trap` and `show_dims_for_metric` previously
+    /// built inline (identically).
+    pub(crate) fn from_graph(graph: &RelationshipGraph) -> Self {
+        let mut parent: HashMap<String, String> = HashMap::new();
+        for (child, parents) in &graph.reverse {
+            if let Some(p) = parents.first() {
+                parent.insert(child.clone(), p.clone());
+            }
+        }
+        Self {
+            root: graph.root.clone(),
+            parent,
+        }
+    }
+
+    /// The root (base-table) alias.
+    pub(crate) fn root(&self) -> &str {
+        &self.root
+    }
+
+    /// This alias's parent (the neighbor toward the root), if any. Used by the
+    /// `extension`-gated `SHOW ... DIMENSIONS FOR METRIC` reachability walk; dead
+    /// in the default build, like the rest of that FFI path.
+    #[cfg_attr(not(feature = "extension"), allow(dead_code))]
+    pub(crate) fn parent_of(&self, node: &str) -> Option<&String> {
+        self.parent.get(node)
+    }
+
+    /// Walk from `node` to the root, returning the chain including `node`
+    /// itself (`[node, parent, …, root]`; the last element is the root).
+    pub(crate) fn ancestors_to_root(&self, node: &str) -> Vec<String> {
+        let mut chain = vec![node.to_string()];
+        let mut current = node.to_string();
+        while let Some(parent) = self.parent.get(&current) {
+            chain.push(parent.clone());
+            current = parent.clone();
+        }
+        chain
+    }
+
+    /// Build the chain `[start, parent, …, ancestor]` by walking toward the
+    /// root. Stops early (returning a partial chain) if the parent chain breaks
+    /// before reaching `ancestor`.
+    pub(crate) fn path_to_ancestor(&self, start: &str, ancestor: &str) -> Vec<String> {
+        let mut path = vec![start.to_string()];
+        let mut current = start.to_string();
+        while current != ancestor {
+            let Some(parent) = self.parent.get(&current) else {
+                break;
+            };
+            path.push(parent.clone());
+            current = parent.clone();
+        }
+        path
+    }
+
+    /// Build the path from `ancestor` down to `target`: `[ancestor, …,
+    /// target]`. Derived from `target`'s ancestor chain (so `ancestor` must be
+    /// an ancestor of `target`); falls back to `[ancestor, target]` when it is
+    /// not on the chain.
+    pub(crate) fn path_from_ancestor_to_node(&self, ancestor: &str, target: &str) -> Vec<String> {
+        let target_ancestors = self.ancestors_to_root(target);
+        if let Some(pos) = target_ancestors.iter().position(|a| a == ancestor) {
+            let mut path: Vec<String> = target_ancestors[..=pos].to_vec();
+            path.reverse();
+            path
+        } else {
+            vec![ancestor.to_string(), target.to_string()]
+        }
+    }
+}
+
+#[cfg(test)]
+impl JoinTree {
+    /// Build directly from a root + parent map (test-only; production always
+    /// derives via [`Self::from_graph`]).
+    fn from_parts(root: &str, parent: HashMap<String, String>) -> Self {
+        Self {
+            root: root.to_string(),
+            parent,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ancestors_to_root_at_root() {
+        let tree = JoinTree::from_parts("root", HashMap::new());
+        assert_eq!(tree.ancestors_to_root("root"), vec!["root"]);
+    }
+
+    #[test]
+    fn ancestors_to_root_single_parent() {
+        let mut parent = HashMap::new();
+        parent.insert("child".to_string(), "root".to_string());
+        let tree = JoinTree::from_parts("root", parent);
+        assert_eq!(tree.ancestors_to_root("child"), vec!["child", "root"]);
+    }
+
+    #[test]
+    fn ancestors_to_root_multi_level() {
+        let mut parent = HashMap::new();
+        parent.insert("leaf".to_string(), "mid".to_string());
+        parent.insert("mid".to_string(), "root".to_string());
+        let tree = JoinTree::from_parts("root", parent);
+        assert_eq!(tree.ancestors_to_root("leaf"), vec!["leaf", "mid", "root"]);
+    }
+
+    #[test]
+    fn path_to_ancestor_walks_up() {
+        let mut parent = HashMap::new();
+        parent.insert("leaf".to_string(), "mid".to_string());
+        parent.insert("mid".to_string(), "root".to_string());
+        let tree = JoinTree::from_parts("root", parent);
+        assert_eq!(tree.path_to_ancestor("leaf", "mid"), vec!["leaf", "mid"]);
+        assert_eq!(
+            tree.path_to_ancestor("leaf", "root"),
+            vec!["leaf", "mid", "root"]
+        );
+    }
+
+    #[test]
+    fn path_from_ancestor_to_node_walks_down() {
+        let mut parent = HashMap::new();
+        parent.insert("leaf".to_string(), "mid".to_string());
+        parent.insert("mid".to_string(), "root".to_string());
+        let tree = JoinTree::from_parts("root", parent);
+        assert_eq!(
+            tree.path_from_ancestor_to_node("root", "leaf"),
+            vec!["root", "mid", "leaf"]
+        );
+        // Not an ancestor -> direct two-element fallback.
+        assert_eq!(
+            tree.path_from_ancestor_to_node("sibling", "leaf"),
+            vec!["sibling", "leaf"]
+        );
+    }
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -3,6 +3,7 @@
 mod cardinality;
 mod derived_metrics;
 mod facts;
+mod join_tree;
 mod names;
 mod relationship;
 mod toposort;
@@ -15,6 +16,7 @@ mod test_helpers;
 pub(crate) use cardinality::infer_cardinality;
 pub use derived_metrics::{contains_aggregate_function, validate_derived_metrics};
 pub use facts::{find_fact_references, validate_facts};
+pub(crate) use join_tree::JoinTree;
 pub use names::validate_name_uniqueness;
 pub use relationship::{validate_graph, RelationshipGraph};
 pub use using::validate_using_relationships;


### PR DESCRIPTION
The final §6.2 move (code-review 2026-07-11). Strictly behavior-preserving — same algorithms, deduplicated construction.

## Why (E-7)

Three code paths each rebuilt the **same** child→parent map from `RelationshipGraph.reverse` and carried their own copies of the ancestor / ancestor-path walks over it:

- `fan_trap::check_fan_traps` (the fan-trap safety check) — built the parent map inline
- `fan_trap::validate_fact_table_path` (fact-path validator) — built it **again** in the same file
- `ddl::show_dims_for_metric` (the `SHOW … DIMENSIONS FOR METRIC` reachability filter) — built a **third** copy, plus a near-duplicate of the met→dim LCA/fan-out walk

## What

Introduce **`graph::JoinTree`** — the directed FK parent tree, derived **once** from the relationship graph — owning `ancestors_to_root` / `path_to_ancestor` / `path_from_ancestor_to_node` (moved verbatim from `fan_trap.rs`, with their unit tests). All three sites now share one `JoinTree` instead of three inline parent maps + two copies of the walk. The `expand::ancestors_to_root` `pub(crate)` export (consumed by the DDL layer) is retired in favour of the method.

Net: `fan_trap.rs` −84 lines; the shared logic lives in one 174-line module.

## Scope — what is deliberately *not* folded in

This is the **directed** FK tree only. The **undirected** traversals — `join_resolver::build_tree_parents` (which also spans the FK-side-of-root, SG-10) and `fan_trap::find_path`'s adjacency BFS — walk a genuinely different edge set. Merging them would change *which path* the fan-trap check inspects, i.e. a correctness input to a safety check, so they are intentionally left in place. That's the documented residual of E-7; the win here is killing the triplicated parent-map + ancestor logic without touching any traversal semantics.

## Verification

Behavior-preserving (identical parent-map derivation + walk logic), guarded by the full oracle:
- `cargo test` — 1157 passed / 0 failed (the extensive `fan_trap` fan-out / chasm / role-playing tests + the differential proptest all unchanged; the 3 ancestor unit tests moved to `graph::join_tree`)
- `make test_debug` (sqllogictest) — 71/0; `make debug` builds; `cargo clippy -- -D warnings` **and** the `--features extension` clippy both clean.

## §6.2 status

With this, §6.2 is complete: move 1 (reference engine) · 2 (materialization matcher) · 3 (SelectSpec) · 6 (test split) · 5 (JoinTree) — all merged/queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ7HmHTfBxBWBCxzNBDZr4)_