### PR TITLE
§6.1 (phase 1): incremental lexer + cursor; migrate TABLES clause

### DIFF
--- a/src/body_parser/cursor.rs
+++ b/src/body_parser/cursor.rs
@@ -1,0 +1,216 @@
+//! A forward token cursor over a lexed clause (§6.1 incremental lexer + cursor
+//! migration, code-review 2026-07-11).
+//!
+//! The cursor is the layer the recursive-descent clause parsers talk to. It
+//! owns the token vector produced by [`super::lexer::lex`] and exposes exactly
+//! the primitives a clause parser needs: look at the next token, consume it,
+//! recognize a bare keyword, scan ahead for a keyword, consume a balanced
+//! `(...)` group, and build a [`ParseError`] whose caret is a real token
+//! offset (no manual `+2` / `- len` byte arithmetic — the source of the P-4
+//! caret-drift class).
+//!
+//! `base` is the absolute byte offset of `src[0]` within the original query,
+//! so [`Cursor::err`] and [`Cursor::abs`] map a source-relative offset back to
+//! a caret position in the user's SQL.
+
+use super::lexer::{lex, Token, TokenKind};
+use crate::errors::ParseError;
+
+pub(super) struct Cursor<'a> {
+    src: &'a str,
+    base: usize,
+    toks: Vec<Token>,
+    idx: usize,
+}
+
+impl<'a> Cursor<'a> {
+    /// Lex `src` and position the cursor at the first token. `base` is the
+    /// absolute offset of `src[0]` in the original query (for carets).
+    pub(super) fn new(src: &'a str, base: usize) -> Self {
+        Cursor {
+            src,
+            base,
+            toks: lex(src),
+            idx: 0,
+        }
+    }
+
+    /// The next unconsumed token, if any.
+    pub(super) fn peek(&self) -> Option<Token> {
+        self.toks.get(self.idx).copied()
+    }
+
+    /// Consume and return the next token, if any.
+    pub(super) fn bump(&mut self) -> Option<Token> {
+        let t = self.toks.get(self.idx).copied();
+        if t.is_some() {
+            self.idx += 1;
+        }
+        t
+    }
+
+    /// The source text of `t`.
+    pub(super) fn text(&self, t: Token) -> &'a str {
+        &self.src[t.start..t.end]
+    }
+
+    /// Byte offset (in `src`) of the next unconsumed token, or `src.len()` when
+    /// the cursor is exhausted. This is where "the rest of the input" begins.
+    pub(super) fn byte_pos(&self) -> usize {
+        self.toks.get(self.idx).map_or(self.src.len(), |t| t.start)
+    }
+
+    /// The remaining source from [`Cursor::byte_pos`] to end — handed verbatim
+    /// to a sub-parser (e.g. the shared trailing-annotation parser) so
+    /// uninterpreted tails stay re-sliced source, never re-tokenized twice.
+    pub(super) fn rest(&self) -> &'a str {
+        &self.src[self.byte_pos()..]
+    }
+
+    /// Absolute caret position for a source-relative byte offset.
+    pub(super) fn abs(&self, off: usize) -> usize {
+        self.base + off
+    }
+
+    /// Build a [`ParseError`] anchored at a source-relative offset.
+    pub(super) fn err(&self, off: usize, message: String) -> ParseError {
+        ParseError {
+            message,
+            position: Some(self.abs(off)),
+        }
+    }
+
+    /// Is `t` a *bare* identifier equal to `kw` (ASCII case-insensitive)? A
+    /// double-quoted `"..."` never matches — quoting means the text is data,
+    /// not a keyword.
+    pub(super) fn is_kw(&self, t: Token, kw: &str) -> bool {
+        matches!(t.kind, TokenKind::Ident { quoted: false })
+            && self.text(t).eq_ignore_ascii_case(kw)
+    }
+
+    /// The first token at/after the cursor that is a bare keyword `kw`,
+    /// without consuming anything. Quote-aware by construction (a quoted
+    /// `"UNIQUE"` is not a keyword token).
+    pub(super) fn find_kw(&self, kw: &str) -> Option<Token> {
+        self.toks[self.idx..]
+            .iter()
+            .copied()
+            .find(|&t| self.is_kw(t, kw))
+    }
+
+    /// The first token at/after the cursor that is a bare keyword `kw1`
+    /// *immediately followed* by a bare keyword `kw2` (only whitespace between
+    /// them, since whitespace is the only thing that separates two adjacent
+    /// tokens). Reproduces the two-word keyword match (`PRIMARY KEY`) without a
+    /// substring scan.
+    pub(super) fn find_kw_pair(&self, kw1: &str, kw2: &str) -> Option<Token> {
+        let rest = &self.toks[self.idx..];
+        rest.windows(2)
+            .find(|w| self.is_kw(w[0], kw1) && self.is_kw(w[1], kw2))
+            .map(|w| w[0])
+    }
+
+    /// If the next token is `(`, consume the whole balanced `(...)` group and
+    /// return its inner source slice (between the parens). Advances past the
+    /// matching `)`. Returns `None` when the next token is not `(` *or* the
+    /// group never closes — the caller distinguishes the two with a prior
+    /// [`Cursor::peek`] and reports "Expected '('" vs "Unclosed '('".
+    ///
+    /// Quote-awareness is free: a `)` inside a string or quoted identifier is
+    /// part of that single token, never a `Symbol(b')')`, so it cannot close
+    /// the group.
+    pub(super) fn take_parens(&mut self) -> Option<&'a str> {
+        let open = self.peek()?;
+        if open.kind != TokenKind::Symbol(b'(') {
+            return None;
+        }
+        self.bump();
+        let inner_start = open.end;
+        let mut depth = 1i32;
+        while let Some(t) = self.peek() {
+            match t.kind {
+                TokenKind::Symbol(b'(') => depth += 1,
+                TokenKind::Symbol(b')') => {
+                    depth -= 1;
+                    if depth == 0 {
+                        let inner = &self.src[inner_start..t.start];
+                        self.bump();
+                        return Some(inner);
+                    }
+                }
+                _ => {}
+            }
+            self.bump();
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn peek_bump_and_kw() {
+        let mut c = Cursor::new("o AS orders", 100);
+        let a = c.peek().unwrap();
+        assert_eq!(c.text(a), "o");
+        assert!(c.is_kw(c.peek().unwrap(), "o"));
+        c.bump();
+        assert!(c.is_kw(c.peek().unwrap(), "as")); // case-insensitive
+        c.bump();
+        assert_eq!(c.text(c.peek().unwrap()), "orders");
+    }
+
+    #[test]
+    fn abs_carets_are_base_relative() {
+        let c = Cursor::new("xy", 100);
+        assert_eq!(c.abs(0), 100);
+        assert_eq!(c.err(1, "boom".to_string()).position, Some(101));
+    }
+
+    #[test]
+    fn find_kw_pair_only_matches_adjacent_words() {
+        let c = Cursor::new("orders PRIMARY KEY (id)", 0);
+        let t = c.find_kw_pair("PRIMARY", "KEY").unwrap();
+        assert_eq!(c.text(t), "PRIMARY");
+        // `PRIMARY , KEY` — a comma between → not a pair.
+        let c2 = Cursor::new("PRIMARY , KEY", 0);
+        assert!(c2.find_kw_pair("PRIMARY", "KEY").is_none());
+    }
+
+    #[test]
+    fn find_kw_skips_quoted_and_strings() {
+        // A quoted "UNIQUE" and a string 'UNIQUE' are not keyword tokens.
+        let c = Cursor::new("\"UNIQUE\" 'UNIQUE'", 0);
+        assert!(c.find_kw("UNIQUE").is_none());
+    }
+
+    #[test]
+    fn take_parens_is_quote_and_nest_aware() {
+        let mut c = Cursor::new("(a, (b), \"x)y\")", 0);
+        assert_eq!(c.take_parens(), Some("a, (b), \"x)y\""));
+        assert!(c.peek().is_none());
+    }
+
+    #[test]
+    fn take_parens_unclosed_is_none() {
+        let mut c = Cursor::new("(a, b", 0);
+        assert_eq!(c.take_parens(), None);
+    }
+
+    #[test]
+    fn take_parens_not_a_paren_is_none() {
+        let mut c = Cursor::new("id", 0);
+        assert_eq!(c.take_parens(), None);
+        // Cursor did not advance.
+        assert_eq!(c.text(c.peek().unwrap()), "id");
+    }
+
+    #[test]
+    fn rest_returns_remaining_source() {
+        let mut c = Cursor::new("a b   c", 0);
+        c.bump();
+        assert_eq!(c.rest(), "b   c");
+    }
+}

--- a/src/body_parser/lexer.rs
+++ b/src/body_parser/lexer.rs
@@ -163,7 +163,10 @@ mod tests {
     }
 
     /// Every token span lands on a char boundary and the spans tile the
-    /// non-whitespace bytes left to right without overlap.
+    /// non-whitespace bytes left to right without overlap — i.e. the only bytes
+    /// NOT covered by a token are whitespace. Asserting the gaps are whitespace
+    /// (not just that tokens don't overlap) is what makes this catch a `lex()`
+    /// regression that silently drops a non-whitespace byte.
     fn assert_well_formed(src: &str) {
         let toks = lex(src);
         let mut prev_end = 0;
@@ -175,9 +178,19 @@ mod tests {
             assert!(src.is_char_boundary(t.end), "end not on boundary: {src:?}");
             assert!(t.start >= prev_end, "overlap in {src:?}");
             assert!(t.end > t.start, "empty token in {src:?}");
+            assert!(
+                src[prev_end..t.start]
+                    .bytes()
+                    .all(|b| b.is_ascii_whitespace()),
+                "non-whitespace bytes dropped in gap {prev_end}..{} of {src:?}",
+                t.start
+            );
             prev_end = t.end;
         }
-        assert!(prev_end <= src.len());
+        assert!(
+            src[prev_end..].bytes().all(|b| b.is_ascii_whitespace()),
+            "non-whitespace trailing bytes dropped after {prev_end} in {src:?}"
+        );
     }
 
     #[test]

--- a/src/body_parser/lexer.rs
+++ b/src/body_parser/lexer.rs
@@ -309,4 +309,31 @@ mod tests {
             assert_well_formed(s);
         }
     }
+
+    // The tiling invariant is the whole point of the lexer — it must hold for
+    // ARBITRARY input, not just the curated cases above (PR #100 review). These
+    // proptests make the "no byte-slice ever cuts a codepoint" / "no
+    // non-whitespace byte is dropped" guarantees generative rather than sampled.
+    mod proptests {
+        use super::assert_well_formed;
+        use proptest::prelude::*;
+
+        proptest! {
+            /// A dense hostile alphabet: `"`/`'` (forming `""`/`''` escapes and
+            /// unterminated regions), `(` `)` `;` `.` `=` `-`, unicode, and
+            /// whitespace — the bytes whose handling the lexer is responsible for.
+            #[test]
+            fn tiling_holds_over_hostile_alphabet(s in r#"[-a-zé_ "'(),.;=]{0,48}"#) {
+                assert_well_formed(&s);
+            }
+
+            /// Fully arbitrary Unicode (control bytes, astral-plane codepoints)
+            /// the curated alphabet can't reach — the generative form of the
+            /// char-boundary guarantee.
+            #[test]
+            fn tiling_holds_over_arbitrary_unicode(s in r"[\s\S]{0,32}") {
+                assert_well_formed(&s);
+            }
+        }
+    }
 }

--- a/src/body_parser/lexer.rs
+++ b/src/body_parser/lexer.rs
@@ -1,0 +1,299 @@
+//! Token stream over SQL clause text (§6.1 incremental lexer + cursor
+//! migration, code-review 2026-07-11).
+//!
+//! This is the shared tokenizer the clause parsers are being migrated onto,
+//! one clause per phase (TABLES first). It replaces the family of ad-hoc
+//! quote-state loops and "find keyword anywhere and slice" scanners that let
+//! the P-1/P-2/P-3 silent-discard bug class re-emerge in every new grammar
+//! slot: once identifiers, strings, and punctuation are *tokens*, a keyword
+//! search can only ever match a real keyword token — never a substring inside
+//! a quoted identifier or a string literal — and a clause parser consumes its
+//! tokens in order, so "text between the name and the constraint" becomes a
+//! visible unexpected token rather than a region silently skipped over.
+//!
+//! ## Scope (grows per phase)
+//!
+//! The token kinds are exactly what the migrated clauses need today:
+//! double-quoted / bare identifiers, single-quoted string literals, and
+//! single-byte symbols. Comment handling still lives upstream in
+//! [`crate::util::blank_sql_comments`] (length-preserving, so byte offsets and
+//! carets stay valid); folding it into the lexer is a later phase, once every
+//! clause parser reads its input through this tokenizer. Numeric and
+//! dollar-quoted literals get their own kinds when a consumer first needs them
+//! distinguished (numbers currently tokenize as bare identifiers, which is
+//! harmless for the identifier-only clauses migrated so far).
+//!
+//! ## UTF-8 safety
+//!
+//! Only ASCII bytes (`"`, `'`, whitespace, punctuation) are ever compared, and
+//! [`crate::util::is_ident_byte`] classifies every byte `>= 0x80` as an
+//! identifier byte, so a multi-byte UTF-8 codepoint is consumed whole into a
+//! bare-identifier token. Token spans therefore always land on char
+//! boundaries — no byte-slice ever cuts a codepoint (the PA-1/PA-2 class).
+
+use crate::util::is_ident_byte;
+
+/// What a [`Token`] is. `Symbol` carries the raw punctuation byte so a cursor
+/// can match `(`, `)`, `,`, `.`, `=` etc. directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TokenKind {
+    /// A bare (`orders`) or double-quoted (`"my table"`) identifier. `quoted`
+    /// distinguishes the two so keyword matching only ever fires on bare
+    /// idents — a quoted `"PRIMARY"` is data, never the keyword.
+    Ident { quoted: bool },
+    /// A single-quoted string literal `'...'`, `''` treated as an escape.
+    String,
+    /// A single punctuation byte outside any quoted region.
+    Symbol(u8),
+    /// An unterminated `"..."` (`ident = true`) or `'...'` (`ident = false`)
+    /// region. Spans from the opening quote to end-of-input; the clause parser
+    /// turns this into a context-specific "Unterminated quoted identifier" /
+    /// "Unterminated string literal" error rather than the lexer guessing the
+    /// message.
+    Unterminated { ident: bool },
+}
+
+/// A lexed token: its [`TokenKind`] and its half-open byte span `[start, end)`
+/// in the lexed source string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Token {
+    pub(super) kind: TokenKind,
+    pub(super) start: usize,
+    pub(super) end: usize,
+}
+
+/// Tokenize `src`. Infallible: unterminated quotes/strings become
+/// [`TokenKind::Unterminated`] tokens (so the parser owns the error message)
+/// and whitespace is skipped. Spans are byte offsets into `src`.
+pub(super) fn lex(src: &str) -> Vec<Token> {
+    let bytes = src.as_bytes();
+    let mut toks = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b.is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        match b {
+            b'"' => {
+                let start = i;
+                i += 1;
+                let mut terminated = false;
+                while i < bytes.len() {
+                    if bytes[i] == b'"' {
+                        // `""` is an escape — stay inside the quoted region.
+                        if i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+                            i += 2;
+                            continue;
+                        }
+                        i += 1;
+                        terminated = true;
+                        break;
+                    }
+                    i += 1;
+                }
+                toks.push(Token {
+                    kind: if terminated {
+                        TokenKind::Ident { quoted: true }
+                    } else {
+                        TokenKind::Unterminated { ident: true }
+                    },
+                    start,
+                    end: i,
+                });
+            }
+            b'\'' => {
+                let start = i;
+                i += 1;
+                let mut terminated = false;
+                while i < bytes.len() {
+                    if bytes[i] == b'\'' {
+                        // `''` is an escape — stay inside the string.
+                        if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                            i += 2;
+                            continue;
+                        }
+                        i += 1;
+                        terminated = true;
+                        break;
+                    }
+                    i += 1;
+                }
+                toks.push(Token {
+                    kind: if terminated {
+                        TokenKind::String
+                    } else {
+                        TokenKind::Unterminated { ident: false }
+                    },
+                    start,
+                    end: i,
+                });
+            }
+            _ if is_ident_byte(b) => {
+                let start = i;
+                while i < bytes.len() && is_ident_byte(bytes[i]) {
+                    i += 1;
+                }
+                toks.push(Token {
+                    kind: TokenKind::Ident { quoted: false },
+                    start,
+                    end: i,
+                });
+            }
+            _ => {
+                toks.push(Token {
+                    kind: TokenKind::Symbol(b),
+                    start: i,
+                    end: i + 1,
+                });
+                i += 1;
+            }
+        }
+    }
+    toks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(src: &str) -> Vec<TokenKind> {
+        lex(src).into_iter().map(|t| t.kind).collect()
+    }
+
+    /// Every token span lands on a char boundary and the spans tile the
+    /// non-whitespace bytes left to right without overlap.
+    fn assert_well_formed(src: &str) {
+        let toks = lex(src);
+        let mut prev_end = 0;
+        for t in &toks {
+            assert!(
+                src.is_char_boundary(t.start),
+                "start not on boundary: {src:?}"
+            );
+            assert!(src.is_char_boundary(t.end), "end not on boundary: {src:?}");
+            assert!(t.start >= prev_end, "overlap in {src:?}");
+            assert!(t.end > t.start, "empty token in {src:?}");
+            prev_end = t.end;
+        }
+        assert!(prev_end <= src.len());
+    }
+
+    #[test]
+    fn bare_idents_and_symbols() {
+        assert_eq!(
+            kinds("o AS orders"),
+            vec![
+                TokenKind::Ident { quoted: false },
+                TokenKind::Ident { quoted: false },
+                TokenKind::Ident { quoted: false },
+            ]
+        );
+    }
+
+    #[test]
+    fn dotted_name_is_ident_dot_ident() {
+        let toks = lex("schema.orders");
+        assert_eq!(
+            toks.iter().map(|t| t.kind).collect::<Vec<_>>(),
+            vec![
+                TokenKind::Ident { quoted: false },
+                TokenKind::Symbol(b'.'),
+                TokenKind::Ident { quoted: false },
+            ]
+        );
+        // Contiguity: no whitespace gaps between the three tokens.
+        assert_eq!(toks[0].end, toks[1].start);
+        assert_eq!(toks[1].end, toks[2].start);
+    }
+
+    #[test]
+    fn quoted_ident_keeps_quotes_and_inner_bytes() {
+        let toks = lex("\"my table\"");
+        assert_eq!(toks.len(), 1);
+        assert_eq!(toks[0].kind, TokenKind::Ident { quoted: true });
+        assert_eq!(&"\"my table\""[toks[0].start..toks[0].end], "\"my table\"");
+    }
+
+    #[test]
+    fn quoted_ident_doubled_quote_escape() {
+        // `"a""b"` is ONE token — the `""` does not close it.
+        let toks = lex("\"a\"\"b\"");
+        assert_eq!(toks.len(), 1);
+        assert_eq!(toks[0].kind, TokenKind::Ident { quoted: true });
+        assert_eq!(toks[0].end, "\"a\"\"b\"".len());
+    }
+
+    #[test]
+    fn keyword_inside_quoted_ident_is_one_token() {
+        // The whole point: `"PRIMARY KEY (id)"` never surfaces PRIMARY/KEY as
+        // matchable keyword tokens.
+        let toks = lex("\"PRIMARY KEY (id)\"");
+        assert_eq!(toks.len(), 1);
+        assert_eq!(toks[0].kind, TokenKind::Ident { quoted: true });
+    }
+
+    #[test]
+    fn string_literal_with_escape_and_keywords() {
+        let toks = lex("'a UNIQUE ''x'' mention'");
+        assert_eq!(toks.len(), 1);
+        assert_eq!(toks[0].kind, TokenKind::String);
+        assert_eq!(toks[0].end, "'a UNIQUE ''x'' mention'".len());
+    }
+
+    #[test]
+    fn unterminated_quote_and_string() {
+        assert_eq!(
+            lex("\"unclosed").first().map(|t| t.kind),
+            Some(TokenKind::Unterminated { ident: true })
+        );
+        assert_eq!(
+            lex("'unclosed").first().map(|t| t.kind),
+            Some(TokenKind::Unterminated { ident: false })
+        );
+        // Doubled-quote then no close is still unbalanced → unterminated.
+        assert_eq!(
+            lex("\"a\"\"b").first().map(|t| t.kind),
+            Some(TokenKind::Unterminated { ident: true })
+        );
+    }
+
+    #[test]
+    fn non_ascii_is_one_bare_ident_no_midcodepoint_span() {
+        let toks = lex("café東京");
+        assert_eq!(toks.len(), 1);
+        assert_eq!(toks[0].kind, TokenKind::Ident { quoted: false });
+        assert_eq!(&"café東京"[toks[0].start..toks[0].end], "café東京");
+    }
+
+    #[test]
+    fn paren_group_tokens() {
+        assert_eq!(
+            kinds("(a, b)"),
+            vec![
+                TokenKind::Symbol(b'('),
+                TokenKind::Ident { quoted: false },
+                TokenKind::Symbol(b','),
+                TokenKind::Ident { quoted: false },
+                TokenKind::Symbol(b')'),
+            ]
+        );
+    }
+
+    #[test]
+    fn well_formed_over_hostile_inputs() {
+        for s in [
+            "",
+            "   ",
+            "o AS \"weird PRIMARY KEY name\" PRIMARY KEY (id)",
+            "\"a\"\"b\".\"c d\" UNIQUE (\"x)y\")",
+            "COMMENT = 'the PRIMARY KEY (id) lives here'",
+            "café AS \"東京 table\"",
+            "'unterminated and PRIMARY KEY (id)",
+            "\"unterminated ident",
+        ] {
+            assert_well_formed(s);
+        }
+    }
+}

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -5,7 +5,9 @@
 
 mod annotations;
 mod clause_bounds;
+mod cursor;
 mod entries;
+mod lexer;
 mod materializations;
 mod metrics;
 mod relationships;
@@ -399,7 +401,7 @@ pub fn parse_keyword_body(text: &str, base_offset: usize) -> Result<KeywordBody,
 #[cfg(test)]
 mod tests {
     use super::annotations::parse_trailing_annotations;
-    use super::scan::{find_keyword_ci, find_primary_key};
+    use super::scan::find_keyword_ci;
     use super::*;
     use crate::model::{Cardinality, NullsOrder, SortOrder};
 
@@ -982,18 +984,21 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Phase 68 A7: `find_primary_key`'s three word-boundary checks align with
-    // `find_unique`'s `_`-exclusion pattern. Identifiers like `my_PRIMARY`
-    // (prefix) or `PRIMARY KEY_extra` (suffix) must NOT match.
+    // Phase 68 A7, re-pinned at the clause level after the §6.1 TABLES
+    // migration (code-review 2026-07-11): a constraint keyword is now a token,
+    // so word-boundary correctness is structural. A source-table name whose
+    // bytes merely CONTAIN `PRIMARY` (`my_primary`, underscore-joined) is a
+    // single identifier token and must not be read as a PRIMARY KEY constraint.
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_find_primary_key_word_boundary_underscore() {
-        // Underscore-prefixed: `_PRIMARY` should not match because `_` is now
-        // excluded from the before-boundary set.
-        assert!(find_primary_key(&"my_PRIMARY KEY".to_ascii_uppercase()).is_none());
-        // Underscore-suffixed on KEY: `KEY_extra` should not match.
-        assert!(find_primary_key(&"PRIMARY KEY_extra".to_ascii_uppercase()).is_none());
+    fn test_underscore_joined_primary_in_name_is_not_a_constraint() {
+        // `my_primary` is one identifier token — no PRIMARY KEY here, so the
+        // table is a bare (no-PK) table, not a table named `my` with a PK.
+        let result = parse_tables_clause("o AS my_primary", 0).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].table, "my_primary");
+        assert!(result[0].pk_columns.is_empty());
     }
 
     // -----------------------------------------------------------------------
@@ -1014,11 +1019,17 @@ mod tests {
     }
 
     #[test]
-    fn test_find_primary_key_non_ascii_no_panic() {
-        assert!(find_primary_key("ΩΩ NO PK HERE Ω").is_none());
-        let upper = "\"CAFÉ\" PRIMARY KEY (ID)".to_string();
-        let (start, end) = find_primary_key(&upper).expect("PRIMARY KEY found");
-        assert_eq!(&upper[start..end], "PRIMARY KEY");
+    fn test_non_ascii_name_then_primary_key_no_panic() {
+        // A non-ASCII quoted source-table name followed by PRIMARY KEY must
+        // tokenize without a mid-codepoint panic and still resolve the
+        // constraint (was `find_primary_key`'s PA-1 byte-scan guarantee).
+        let result = parse_tables_clause("o AS \"CAFÉ\" PRIMARY KEY (id)", 0).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].table, "\"CAFÉ\"");
+        assert_eq!(result[0].pk_columns, vec!["id"]);
+        // Pure non-ASCII with no constraint keyword: bare table, no panic.
+        let bare = parse_tables_clause("o AS \"ΩΩ Ω\"", 0).unwrap();
+        assert!(bare[0].pk_columns.is_empty());
     }
 
     #[test]

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -1019,6 +1019,25 @@ mod tests {
     }
 
     #[test]
+    fn test_leading_symbol_in_name_slot_is_missing_name() {
+        // §6.1 (PR #100 review): when the name slot begins with a non-`(`/`;`
+        // symbol (`.foo`, `=x`, `-1`), the token cursor surfaces the missing-name
+        // error at parse time. The pre-migration `find_identifier_end` folded a
+        // leading `.`/`=`/`-` INTO the table name (a latent bug — no SQL
+        // identifier starts with one), so this is a deliberate, stricter
+        // behaviour on input the old code left undefined-by-test. Pinned here so
+        // it stays intentional rather than drifting.
+        for entry in ["o AS .foo", "o AS =x", "o AS -1"] {
+            let err = parse_tables_clause(entry, 0).unwrap_err();
+            assert!(
+                err.message.contains("Missing physical table name"),
+                "{entry}: got {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
     fn test_bare_paren_immediately_after_name_terminates_name() {
         // §6.1 (PR #100 review): the name-capture loop stops at a contiguous
         // `(`, mirroring `find_identifier_end(.., allow_paren = true)`. The stop

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -1019,6 +1019,29 @@ mod tests {
     }
 
     #[test]
+    fn test_bare_paren_immediately_after_name_terminates_name() {
+        // §6.1 (PR #100 review): the name-capture loop stops at a contiguous
+        // `(`, mirroring `find_identifier_end(.., allow_paren = true)`. The stop
+        // is expressed as the or-pattern `Symbol(b'(' | b';')` — this test would
+        // fail (name greedily swallowing `(foo)`, parsing to Ok) if that arm
+        // ever stopped matching `(`. Expected: name is `v`, and the trailing
+        // `(foo)` is reported as unexpected text, not folded into the name.
+        let err = parse_tables_clause("o AS v(foo)", 0).unwrap_err();
+        assert!(
+            err.message.contains("after table declaration"),
+            "got: {}",
+            err.message
+        );
+        // A contiguous `;` likewise ends the name (the other or-pattern arm).
+        let err2 = parse_tables_clause("o AS v;junk", 0).unwrap_err();
+        assert!(
+            err2.message.contains("after table declaration"),
+            "got: {}",
+            err2.message
+        );
+    }
+
+    #[test]
     fn test_non_ascii_name_then_primary_key_no_panic() {
         // A non-ASCII quoted source-table name followed by PRIMARY KEY must
         // tokenize without a mid-codepoint panic and still resolve the

--- a/src/body_parser/scan.rs
+++ b/src/body_parser/scan.rs
@@ -367,77 +367,9 @@ pub(super) fn find_depth0_keyword(
     None
 }
 
-/// Find the byte position of a keyword (already uppercased) in `upper_text`.
-/// Find "PRIMARY KEY" with any amount of whitespace between the two words.
-/// Returns `(start, end)` byte offsets into `upper_text`, where `upper_text` is already uppercased.
-/// `start` points at 'P', `end` points past 'Y' (exclusive).
-pub(super) fn find_primary_key(upper_text: &str) -> Option<(usize, usize)> {
-    let bytes = upper_text.as_bytes();
-    let mut st = QuoteState::default();
-    let mut i = 0;
-    while i < bytes.len() {
-        let (next, live) = st.step(bytes, i);
-        if !live || i + 7 > bytes.len() {
-            i = next;
-            continue;
-        }
-        // Look for "PRIMARY". Compare BYTES, not string slices: `i` advances
-        // one byte at a time, so `&upper_text[i..]` panics mid-codepoint on
-        // non-ASCII input (PA-1). A multi-byte char can never byte-match an
-        // ASCII keyword, so byte comparison is also correct. Quote-aware
-        // (PA-3): `COMMENT = 'the PRIMARY KEY (id) lives here'` must not
-        // fabricate a primary key from string-literal text.
-        if &bytes[i..i + 7] == b"PRIMARY" {
-            // Phase 68 A7: align word-boundary checks with `find_unique` —
-            // `_` is a valid identifier continuation byte, so exclude it from
-            // the "non-identifier" boundary set in all three checks below.
-            let before_ok = i == 0 || !is_ident_continuation(bytes[i - 1]);
-            let after_primary = i + 7;
-            if before_ok
-                && (after_primary == bytes.len() || !is_ident_continuation(bytes[after_primary]))
-            {
-                // Skip whitespace between PRIMARY and KEY
-                let mut j = after_primary;
-                while j < bytes.len() && (bytes[j] as char).is_ascii_whitespace() {
-                    j += 1;
-                }
-                // Match "KEY"
-                if j + 3 <= bytes.len() && &bytes[j..j + 3] == b"KEY" {
-                    let after_key = j + 3;
-                    let after_ok =
-                        after_key == bytes.len() || !is_ident_continuation(bytes[after_key]);
-                    if after_ok {
-                        return Some((i, after_key));
-                    }
-                }
-            }
-        }
-        i = next;
-    }
-    None
-}
-
-/// Find "UNIQUE" keyword with word-boundary matching in `upper_text`.
-/// Returns `(start, end)` byte offsets where start points at 'U' and end is past 'E'.
-///
-/// Quote-aware (PA-3): a `UNIQUE` inside a `'...'` string literal (e.g. a
-/// COMMENT payload) or a `"..."` quoted identifier does not match.
-pub(super) fn find_unique(upper_text: &str) -> Option<(usize, usize)> {
-    let bytes = upper_text.as_bytes();
-    let kw = b"UNIQUE";
-    let kw_len = kw.len(); // 6
-    let mut st = QuoteState::default();
-    let mut i = 0;
-    while i < bytes.len() {
-        let (next, live) = st.step(bytes, i);
-        if live && i + kw_len <= bytes.len() && &bytes[i..i + kw_len] == kw {
-            let before_ok = i == 0 || !is_ident_continuation(bytes[i - 1]);
-            let after_ok = i + kw_len == bytes.len() || !is_ident_continuation(bytes[i + kw_len]);
-            if before_ok && after_ok {
-                return Some((i, i + kw_len));
-            }
-        }
-        i = next;
-    }
-    None
-}
+// `find_primary_key` / `find_unique` (the case-insensitive, quote-aware
+// "find this constraint keyword anywhere in the post-name slice and slice from
+// it" scanners) were retired in the §6.1 TABLES migration: the TABLES clause
+// now consumes tokens in order via `super::cursor::Cursor`, so a constraint
+// keyword is recognized as a bare-identifier token — inherently quote-aware and
+// UTF-8-safe — rather than by a substring scan (code-review 2026-07-11).

--- a/src/body_parser/tables.rs
+++ b/src/body_parser/tables.rs
@@ -51,7 +51,6 @@ fn missing_name_msg(alias: &str) -> String {
 /// - `alias AS physical_table PRIMARY KEY (cols) [UNIQUE (cols)]*`
 /// - `alias AS physical_table [UNIQUE (cols)]*`   (no PRIMARY KEY -- fact tables)
 /// - `alias AS physical_table`                    (bare -- no PK, no UNIQUE)
-#[allow(clippy::too_many_lines)]
 fn parse_single_table_entry(entry: &str, entry_offset: usize) -> Result<TableRef, ParseError> {
     let entry = entry.trim();
     let mut cur = Cursor::new(entry, entry_offset);
@@ -79,54 +78,8 @@ fn parse_single_table_entry(entry: &str, entry_offset: usize) -> Result<TableRef
         }
     }
 
-    // Step 3: the source-table name — a maximal run of tokens with no
-    // whitespace gap, stopping before `(` / `;`. This reproduces
-    // `find_identifier_end`: a dotted / quoted FQN like `"my db"."sch"."t"` is
-    // contiguous and captured whole, while a following ` PRIMARY KEY` is
-    // separated by whitespace and left for the constraint parser.
-    let Some(first) = cur.peek() else {
-        return Err(cur.err(cur.byte_pos(), missing_name_msg(alias)));
-    };
-    if matches!(first.kind, TokenKind::Symbol(_)) {
-        // A leading `(` / `.` / etc. where the name should be.
-        return Err(cur.err(first.start, missing_name_msg(alias)));
-    }
-    let name_start = first.start;
-    let mut name_end = first.end;
-    let mut unterminated_ident = matches!(first.kind, TokenKind::Unterminated { ident: true });
-    cur.bump();
-    while let Some(t) = cur.peek() {
-        // A whitespace gap or a `(` / `;` symbol ends the name.
-        if t.start != name_end || matches!(t.kind, TokenKind::Symbol(b'(' | b';')) {
-            break;
-        }
-        if matches!(t.kind, TokenKind::Unterminated { ident: true }) {
-            unterminated_ident = true;
-        }
-        name_end = t.end;
-        cur.bump();
-    }
-    let table_name = &entry[name_start..name_end];
-
-    // Bare reserved keywords in the name slot surface the missing-name error
-    // (Phase 68 A1 / D-03) — `o AS PRIMARY KEY (id)` has no real table name.
-    if matches!(
-        table_name.to_ascii_uppercase().as_str(),
-        "PRIMARY" | "UNIQUE" | "FOREIGN" | "REFERENCES" | "NOT"
-    ) {
-        return Err(cur.err(name_start, missing_name_msg(alias)));
-    }
-    // An unterminated `"..."` in the name slot (Phase 68 A4). A doubled-quote
-    // `""` is an escape and stays balanced, so only a genuinely open quote trips
-    // this — the lexer already encoded that distinction in the token kind.
-    if unterminated_ident {
-        return Err(cur.err(
-            name_start,
-            format!(
-                "Unterminated quoted identifier in source-table name for alias '{alias}' in TABLES clause.",
-            ),
-        ));
-    }
+    // Step 3: the source-table name (see `take_source_table_name`).
+    let (table_name, name_end) = take_source_table_name(&mut cur, entry, alias)?;
 
     // Step 4: optional PRIMARY KEY. Its keyword pair may appear anywhere in the
     // remaining tokens; any token before it is text that does not belong
@@ -198,6 +151,66 @@ fn parse_single_table_entry(entry: &str, entry_offset: usize) -> Result<TableRef
         comment: annotations.comment,
         synonyms: annotations.synonyms,
     })
+}
+
+/// Capture the source-table name after `AS` — a maximal run of tokens with no
+/// whitespace gap, stopping before a `(` / `;` symbol. This reproduces
+/// `find_identifier_end`: a dotted / quoted FQN like `"my db"."sch"."t"` is
+/// contiguous and captured whole, while a following ` PRIMARY KEY` is separated
+/// by whitespace and left for the constraint parser. Returns the verbatim name
+/// slice and its end offset (in `entry`) for the caller's "between" check.
+fn take_source_table_name<'a>(
+    cur: &mut Cursor<'a>,
+    entry: &'a str,
+    alias: &str,
+) -> Result<(&'a str, usize), ParseError> {
+    let Some(first) = cur.peek() else {
+        return Err(cur.err(cur.byte_pos(), missing_name_msg(alias)));
+    };
+    if matches!(first.kind, TokenKind::Symbol(_)) {
+        // A leading `(` / `.` / `=` / etc. where the name should be. `find_identifier_end`
+        // returned 0 only for `(` / `;` / whitespace, but a leading `.foo` / `=x`
+        // is a non-name that is better rejected here than accepted as a bogus
+        // table name (pinned by `test_leading_symbol_in_name_slot_is_missing_name`).
+        return Err(cur.err(first.start, missing_name_msg(alias)));
+    }
+    let name_start = first.start;
+    let mut name_end = first.end;
+    let mut unterminated_ident = matches!(first.kind, TokenKind::Unterminated { ident: true });
+    cur.bump();
+    while let Some(t) = cur.peek() {
+        // A whitespace gap or a `(` / `;` symbol ends the name.
+        if t.start != name_end || matches!(t.kind, TokenKind::Symbol(b'(' | b';')) {
+            break;
+        }
+        if matches!(t.kind, TokenKind::Unterminated { ident: true }) {
+            unterminated_ident = true;
+        }
+        name_end = t.end;
+        cur.bump();
+    }
+    let table_name = &entry[name_start..name_end];
+
+    // Bare reserved keywords in the name slot surface the missing-name error
+    // (Phase 68 A1 / D-03) — `o AS PRIMARY KEY (id)` has no real table name.
+    if matches!(
+        table_name.to_ascii_uppercase().as_str(),
+        "PRIMARY" | "UNIQUE" | "FOREIGN" | "REFERENCES" | "NOT"
+    ) {
+        return Err(cur.err(name_start, missing_name_msg(alias)));
+    }
+    // An unterminated `"..."` in the name slot (Phase 68 A4). A doubled-quote
+    // `""` is an escape and stays balanced, so only a genuinely open quote trips
+    // this — the lexer already encoded that distinction in the token kind.
+    if unterminated_ident {
+        return Err(cur.err(
+            name_start,
+            format!(
+                "Unterminated quoted identifier in source-table name for alias '{alias}' in TABLES clause.",
+            ),
+        ));
+    }
+    Ok((table_name, name_end))
 }
 
 /// Consume the `(col, col, ...)` list that must follow a `PRIMARY KEY` /

--- a/src/body_parser/tables.rs
+++ b/src/body_parser/tables.rs
@@ -1,13 +1,22 @@
 //! TABLES clause parsing.
+//!
+//! §6.1 (code-review 2026-07-11): this is the first clause migrated onto the
+//! shared [`Cursor`]/lexer. Each entry is parsed by consuming tokens in order
+//! — alias, `AS`, source-table name, then the optional `PRIMARY KEY` / `UNIQUE`
+//! constraints — so "text between the name and a constraint" is a visible
+//! unexpected token rather than a region a `find_primary_key`-anywhere scan
+//! could silently slice past (the P-1 silent-discard hole). Quote-awareness is
+//! structural: a keyword inside a `"quoted"` name or a `'string'` COMMENT is a
+//! single token, never a matchable keyword.
+//!
+//! The trailing `COMMENT` / `WITH SYNONYMS` region is still handed as verbatim
+//! source to the shared [`parse_trailing_annotations`], which tiles it (P-2).
 
 use super::annotations::parse_trailing_annotations;
-use super::scan::{
-    extract_paren_content, find_primary_key, find_unique, is_ident_continuation,
-    is_quoting_balanced, split_first_token,
-};
+use super::cursor::Cursor;
+use super::lexer::TokenKind;
 use super::split_at_depth0_commas;
 use crate::errors::ParseError;
-use crate::ident::find_identifier_end;
 use crate::model::TableRef;
 
 /// Parse the content inside TABLES (...).
@@ -29,6 +38,13 @@ pub(crate) fn parse_tables_clause(
     Ok(result)
 }
 
+/// The "physical table name is missing" error is emitted from three guards
+/// (no name token, a bare reserved keyword in the name slot, ...) so the exact
+/// message stays single-sourced.
+fn missing_name_msg(alias: &str) -> String {
+    format!("Missing physical table name after AS for alias '{alias}' in TABLES clause.")
+}
+
 /// Parse a single TABLES clause entry.
 ///
 /// Supports:
@@ -37,215 +53,133 @@ pub(crate) fn parse_tables_clause(
 /// - `alias AS physical_table`                    (bare -- no PK, no UNIQUE)
 #[allow(clippy::too_many_lines)]
 fn parse_single_table_entry(entry: &str, entry_offset: usize) -> Result<TableRef, ParseError> {
-    // Step 1: get alias (first whitespace-delimited token)
     let entry = entry.trim();
-    let (alias, rest) = split_first_token(entry);
-    if alias.is_empty() {
-        return Err(ParseError {
-            message: "Expected table alias in TABLES entry.".to_string(),
-            position: Some(entry_offset),
-        });
-    }
-    let rest = rest.trim();
-    let rest_offset = entry_offset + entry.len() - rest.len();
+    let mut cur = Cursor::new(entry, entry_offset);
 
-    // Step 2: expect "AS" keyword, with a trailing word boundary —
-    // `ASschema.table` / `ASX` must not match (PR #50 review). Punctuation
-    // like `"` stays a legal boundary (`AS"my table"`).
-    let as_ok = rest.get(..2).is_some_and(|s| s.eq_ignore_ascii_case("AS"))
-        && (rest.len() == 2 || !is_ident_continuation(rest.as_bytes()[2]));
-    if !as_ok {
-        return Err(ParseError {
-            message: format!("Expected 'AS' after table alias '{alias}' in TABLES clause."),
-            position: Some(rest_offset),
-        });
-    }
-    let after_as = rest[2..].trim_start();
-    let after_as_offset = rest_offset + 2 + (rest[2..].len() - after_as.len());
-
-    // Step 3: capture the source-table name using identifier-aware tokenisation
-    // (Phase 67 Plan 02 / TECH-DEBT #24). `find_identifier_end` natively walks
-    // across dots while outside quoted regions (verified by the
-    // `fqn_with_quoted_parts_runs_to_whitespace` doctest in `src/ident.rs`), so
-    // a single call captures `schema.tbl`, `"my db"."schema"."col"`, etc. The
-    // earlier dot-rejoin loop arm was unreachable (Phase 68 A3 collapse).
-    // This MUST run before we look for the PRIMARY KEY / UNIQUE trailing
-    // keywords — otherwise the case-insensitive scan over the whole `after_as`
-    // slice can match a `PRIMARY KEY` substring INSIDE a quoted source-table
-    // name.
-    let name_end = find_identifier_end(after_as, /* allow_paren = */ true);
-    if name_end == 0 {
-        return Err(ParseError {
-            message: format!(
-                "Missing physical table name after AS for alias '{alias}' in TABLES clause.",
-            ),
-            position: Some(after_as_offset),
-        });
-    }
-    // Phase 68 A1 (D-03): reject bare reserved keywords captured as the
-    // source-table name. Without this guard `o AS PRIMARY KEY (id)` would
-    // succeed at `find_identifier_end` (capturing `PRIMARY` up to the
-    // following whitespace) and the downstream PRIMARY-KEY scan over
-    // `" KEY (id)"` would fail to find the keyword (already eaten), producing
-    // a confusing "table 'PRIMARY' does not exist" downstream. The literal
-    // pre-Phase-67 error message is the contract — see Phase 68 CONTEXT.md
-    // D-03 for the authoritative keyword set.
-    let captured = after_as[..name_end].trim();
-    let upper_captured = captured.to_ascii_uppercase();
-    if matches!(
-        upper_captured.as_str(),
-        "PRIMARY" | "UNIQUE" | "FOREIGN" | "REFERENCES" | "NOT"
-    ) {
-        return Err(ParseError {
-            message: format!(
-                "Missing physical table name after AS for alias '{alias}' in TABLES clause.",
-            ),
-            position: Some(after_as_offset),
-        });
-    }
-    let table_name = captured;
-    if table_name.is_empty() {
-        return Err(ParseError {
-            message: format!(
-                "Missing physical table name after AS for alias '{alias}' in TABLES clause.",
-            ),
-            position: Some(after_as_offset),
-        });
-    }
-    // Phase 68 A4: reject unterminated quoted source-table names. `find_identifier_end`
-    // saturates at input.len() on an unterminated quote rather than surfacing an
-    // error, so `o AS "unclosed` would otherwise pass through as `table_name =
-    // "\"unclosed"` and corrupt downstream catalog lookups. The doubled-quote
-    // escape `""` is balanced — mirror src/ident.rs::find_identifier_end's escape
-    // rule via the private `is_quoting_balanced` helper.
-    if !is_quoting_balanced(&after_as[..name_end]) {
-        return Err(ParseError {
-            message: format!(
-                "Unterminated quoted identifier in source-table name for alias '{alias}' in TABLES clause.",
-            ),
-            position: Some(after_as_offset),
-        });
-    }
-    let after_name = &after_as[name_end..];
-    let after_name_offset = after_as_offset + name_end;
-
-    // Step 3a: now search ONLY the post-name slice for the optional
-    // PRIMARY KEY / UNIQUE trailing clauses. `name_end` was computed via
-    // identifier-aware tokenisation so we can safely uppercase the rest.
-    let upper_after_name = after_name.to_ascii_uppercase();
-    let pk_pos = find_primary_key(&upper_after_name);
-
-    // P-1 (code-review 2026-07-11): reject text between the source-table
-    // name and PRIMARY KEY instead of silently discarding it. The keyword
-    // scan finds PRIMARY KEY anywhere in the post-name slice, so
-    // `o AS orders COMMENT = 'doc' PRIMARY KEY (id)` previously parsed
-    // "successfully" with the comment destroyed.
-    if let Some((pk_start, _)) = pk_pos {
-        let pre = &after_name[..pk_start];
-        if !pre.trim().is_empty() {
-            return Err(ParseError {
-                message: format!(
-                    "Unexpected text '{}' between source table name and PRIMARY KEY for alias '{alias}' in TABLES clause. Constraints must immediately follow the table name; COMMENT / WITH SYNONYMS come after constraints.",
-                    pre.trim()
-                ),
-                position: Some(after_name_offset + (pre.len() - pre.trim_start().len())),
-            });
-        }
-    }
-
-    // `after_pk_offset` tracks the absolute byte offset of `after_pk_text[0]`
-    // so the UNIQUE-loop guards below can point their carets at the actual
-    // offending token rather than the start of the entry (Copilot review,
-    // PR #71).
-    let (pk_columns, after_pk_text, after_pk_offset) = if let Some((_pk_start, pk_end)) = pk_pos {
-        let after_pk_raw = &after_name[pk_end..];
-        let after_pk = after_pk_raw.trim_start();
-        let after_pk_offset = after_name_offset + pk_end + (after_pk_raw.len() - after_pk.len());
-        if !after_pk.starts_with('(') {
-            return Err(ParseError {
-                message: "Expected '(' after PRIMARY KEY in TABLES clause.".to_string(),
-                position: Some(after_pk_offset),
-            });
-        }
-        let pk_body = extract_paren_content(after_pk).ok_or_else(|| ParseError {
-            message: "Unclosed '(' in PRIMARY KEY column list.".to_string(),
-            position: Some(after_pk_offset),
-        })?;
-        let pk_columns: Vec<String> = split_at_depth0_commas(pk_body)
-            .into_iter()
-            .map(|(_, entry)| entry.to_string())
-            .collect();
-        // extract_paren_content requires after_pk to start with '(' and is
-        // quote-aware, so the matching close is exactly one byte past the
-        // content — a naive find(')') would stop at a ')' inside a quoted
-        // column name (PA-6).
-        let close = 1 + pk_body.len();
-        let remainder = &after_pk[close + 1..];
-        (pk_columns, remainder, after_pk_offset + close + 1)
-    } else {
-        // No PRIMARY KEY -- fact table. Hand the whole post-name slice to
-        // the UNIQUE/annotation steps below. (Previously the bare no-PK /
-        // no-UNIQUE case hard-set the remainder to "" — silently dropping
-        // table-level COMMENT / WITH SYNONYMS annotations, PA-9.)
-        (vec![], after_name, after_name_offset)
+    // Step 1: alias — the first token.
+    let Some(alias_tok) = cur.bump() else {
+        return Err(cur.err(0, "Expected table alias in TABLES entry.".to_string()));
     };
+    let alias = cur.text(alias_tok);
 
-    // Step 4: parse zero or more UNIQUE constraints from after_pk_text
-    let mut unique_constraints: Vec<Vec<String>> = Vec::new();
-    let mut remaining = after_pk_text;
-    let mut remaining_offset = after_pk_offset;
-    loop {
-        let upper_remaining = remaining.to_ascii_uppercase();
-        if let Some((u_start, u_end)) = find_unique(&upper_remaining) {
-            // P-1 companion: text before a UNIQUE constraint is an error,
-            // not silently discarded (the same anywhere-scan hole as the
-            // PRIMARY KEY slot above).
-            let pre = &remaining[..u_start];
-            if !pre.trim().is_empty() {
-                return Err(ParseError {
-                    message: format!(
-                        "Unexpected text '{}' before UNIQUE for alias '{alias}' in TABLES clause. Constraints must immediately follow the table name or the preceding constraint; COMMENT / WITH SYNONYMS come after constraints.",
-                        pre.trim()
-                    ),
-                    // Caret on the junk token, not the entry start (skip
-                    // leading whitespace within `pre`).
-                    position: Some(remaining_offset + (pre.len() - pre.trim_start().len())),
-                });
-            }
-            let after_unique_raw = &remaining[u_end..];
-            let after_unique_kw = after_unique_raw.trim_start();
-            let after_unique_offset =
-                remaining_offset + u_end + (after_unique_raw.len() - after_unique_kw.len());
-            if !after_unique_kw.starts_with('(') {
-                return Err(ParseError {
-                    message: format!(
-                        "Expected '(' after UNIQUE keyword for table alias '{alias}'."
-                    ),
-                    position: Some(after_unique_offset),
-                });
-            }
-            let cols_str = extract_paren_content(after_unique_kw).ok_or_else(|| ParseError {
-                message: format!("Unclosed '(' in UNIQUE column list for table alias '{alias}'."),
-                position: Some(after_unique_offset),
-            })?;
-            let cols: Vec<String> = split_at_depth0_commas(cols_str)
-                .into_iter()
-                .map(|(_, entry)| entry.to_string())
-                .collect();
-            unique_constraints.push(cols);
-            // Quote-aware close (see the PRIMARY KEY branch above).
-            let close = 1 + cols_str.len();
-            remaining = &after_unique_kw[close + 1..];
-            remaining_offset = after_unique_offset + close + 1;
-        } else {
+    // Step 2: the `AS` keyword. Tokenization gives the word boundary for free —
+    // `ASorders` is a single bare token that is not `AS`, and `AS"my table"`
+    // splits into `AS` + the quoted name — so no manual boundary check is
+    // needed (the PR #50 review's `is_ident_continuation` guard).
+    match cur.peek() {
+        Some(t) if cur.is_kw(t, "AS") => {
+            cur.bump();
+        }
+        _ => {
+            let off = cur.byte_pos();
+            return Err(cur.err(
+                off,
+                format!("Expected 'AS' after table alias '{alias}' in TABLES clause."),
+            ));
+        }
+    }
+
+    // Step 3: the source-table name — a maximal run of tokens with no
+    // whitespace gap, stopping before `(` / `;`. This reproduces
+    // `find_identifier_end`: a dotted / quoted FQN like `"my db"."sch"."t"` is
+    // contiguous and captured whole, while a following ` PRIMARY KEY` is
+    // separated by whitespace and left for the constraint parser.
+    let Some(first) = cur.peek() else {
+        return Err(cur.err(cur.byte_pos(), missing_name_msg(alias)));
+    };
+    if matches!(first.kind, TokenKind::Symbol(_)) {
+        // A leading `(` / `.` / etc. where the name should be.
+        return Err(cur.err(first.start, missing_name_msg(alias)));
+    }
+    let name_start = first.start;
+    let mut name_end = first.end;
+    let mut unterminated_ident = matches!(first.kind, TokenKind::Unterminated { ident: true });
+    cur.bump();
+    while let Some(t) = cur.peek() {
+        // A whitespace gap or a `(` / `;` symbol ends the name.
+        if t.start != name_end || matches!(t.kind, TokenKind::Symbol(b'(' | b';')) {
             break;
         }
+        if matches!(t.kind, TokenKind::Unterminated { ident: true }) {
+            unterminated_ident = true;
+        }
+        name_end = t.end;
+        cur.bump();
+    }
+    let table_name = &entry[name_start..name_end];
+
+    // Bare reserved keywords in the name slot surface the missing-name error
+    // (Phase 68 A1 / D-03) — `o AS PRIMARY KEY (id)` has no real table name.
+    if matches!(
+        table_name.to_ascii_uppercase().as_str(),
+        "PRIMARY" | "UNIQUE" | "FOREIGN" | "REFERENCES" | "NOT"
+    ) {
+        return Err(cur.err(name_start, missing_name_msg(alias)));
+    }
+    // An unterminated `"..."` in the name slot (Phase 68 A4). A doubled-quote
+    // `""` is an escape and stays balanced, so only a genuinely open quote trips
+    // this — the lexer already encoded that distinction in the token kind.
+    if unterminated_ident {
+        return Err(cur.err(
+            name_start,
+            format!(
+                "Unterminated quoted identifier in source-table name for alias '{alias}' in TABLES clause.",
+            ),
+        ));
     }
 
-    // Phase 43: Parse trailing COMMENT / WITH SYNONYMS annotations after constraints.
-    // Any non-annotation text left over is an error rather than silently
-    // discarded (PA-9 companion: `o AS orders garbage COMMENT = 'x'`).
-    let (leftover, annotations) = parse_trailing_annotations(remaining)?;
+    // Step 4: optional PRIMARY KEY. Its keyword pair may appear anywhere in the
+    // remaining tokens; any token before it is text that does not belong
+    // between the name and the constraint (P-1).
+    let mut pk_columns: Vec<String> = Vec::new();
+    if let Some(pk_tok) = cur.find_kw_pair("PRIMARY", "KEY") {
+        let between = entry[name_end..pk_tok.start].trim();
+        if !between.is_empty() {
+            let off = cur.peek().map_or(name_end, |t| t.start);
+            return Err(cur.err(
+                off,
+                format!(
+                    "Unexpected text '{between}' between source table name and PRIMARY KEY for alias '{alias}' in TABLES clause. Constraints must immediately follow the table name; COMMENT / WITH SYNONYMS come after constraints.",
+                ),
+            ));
+        }
+        cur.bump(); // PRIMARY
+        cur.bump(); // KEY
+        pk_columns = take_columns(
+            &mut cur,
+            "Expected '(' after PRIMARY KEY in TABLES clause.".to_string(),
+            "Unclosed '(' in PRIMARY KEY column list.".to_string(),
+        )?;
+    }
+
+    // Step 5: zero or more UNIQUE constraints, each immediately following the
+    // previous constraint. Text before a UNIQUE keyword is rejected, not
+    // discarded (P-1 companion).
+    let mut unique_constraints: Vec<Vec<String>> = Vec::new();
+    while let Some(u_tok) = cur.find_kw("UNIQUE") {
+        let between = entry[cur.byte_pos()..u_tok.start].trim();
+        if !between.is_empty() {
+            let off = cur.peek().map_or(u_tok.start, |t| t.start);
+            return Err(cur.err(
+                off,
+                format!(
+                    "Unexpected text '{between}' before UNIQUE for alias '{alias}' in TABLES clause. Constraints must immediately follow the table name or the preceding constraint; COMMENT / WITH SYNONYMS come after constraints.",
+                ),
+            ));
+        }
+        cur.bump(); // UNIQUE
+        let cols = take_columns(
+            &mut cur,
+            format!("Expected '(' after UNIQUE keyword for table alias '{alias}'."),
+            format!("Unclosed '(' in UNIQUE column list for table alias '{alias}'."),
+        )?;
+        unique_constraints.push(cols);
+    }
+
+    // Step 6: trailing COMMENT / WITH SYNONYMS annotations. The shared parser
+    // tiles the region exactly; any non-annotation text left in front of it is
+    // reported here rather than silently dropped (PA-9 companion).
+    let (leftover, annotations) = parse_trailing_annotations(cur.rest())?;
     if !leftover.trim().is_empty() {
         return Err(ParseError {
             message: format!(
@@ -264,4 +198,26 @@ fn parse_single_table_entry(entry: &str, entry_offset: usize) -> Result<TableRef
         comment: annotations.comment,
         synonyms: annotations.synonyms,
     })
+}
+
+/// Consume the `(col, col, ...)` list that must follow a `PRIMARY KEY` /
+/// `UNIQUE` keyword. `expected_msg` fires when no `(` follows; `unclosed_msg`
+/// when the `(` never closes. Both carets point at where the `(` was expected.
+fn take_columns(
+    cur: &mut Cursor,
+    expected_msg: String,
+    unclosed_msg: String,
+) -> Result<Vec<String>, ParseError> {
+    let off = cur.byte_pos();
+    match cur.peek() {
+        Some(t) if t.kind == TokenKind::Symbol(b'(') => {}
+        _ => return Err(cur.err(off, expected_msg)),
+    }
+    let Some(inner) = cur.take_parens() else {
+        return Err(cur.err(off, unclosed_msg));
+    };
+    Ok(split_at_depth0_commas(inner)
+        .into_iter()
+        .map(|(_, col)| col.to_string())
+        .collect())
 }


### PR DESCRIPTION
First phase of the §6.1 parser-layer migration from the 2026-07-11 code review (`_notes/code-review-2026-07-11.md`, §6.1). The T-5 shared hostile-input generators are already on this branch (PR #72), so this phase is the first actual lexer migration, done **behaviour-preserving under that oracle** (roundtrip / create-front-door / parse proptests + sqllogictest). One clause per phase, TABLES first.

## What changed

- **`src/body_parser/lexer.rs`** (new) — a token stream producing `Token { kind, span }` over clause text. Kinds: `Ident { quoted }`, `String`, `Symbol(u8)`, `Unterminated { ident }`. Quote-awareness and UTF-8 safety are **structural**: a keyword inside a `"quoted"` name or a `'string'` is a single token, and every span lands on a char boundary (the PA-1/PA-2 mid-codepoint panic class becomes unrepresentable). The tiling / char-boundary invariant is checked **generatively** by proptests (hostile alphabet + arbitrary Unicode).
- **`src/body_parser/cursor.rs`** (new) — a forward token cursor (`peek` / `bump` / `is_kw` / `find_kw` / `find_kw_pair` / `take_parens` / `err`) whose error carets are real token offsets, not manufactured byte arithmetic (the P-4 caret-drift source). `take_parens` is nesting- and quote-aware for free — a `)` inside a string/quoted-ident is part of that one token, never a `Symbol`.
- **`src/body_parser/tables.rs`** — each entry is parsed by consuming tokens in order: alias → `AS` → source-table name → `PRIMARY KEY` / `UNIQUE` constraints. "Text between the name and a constraint" is now a visible unexpected token rather than a region a `find_primary_key`-anywhere scan could silently slice past (the **P-1 silent-discard hole**).
- **`src/body_parser/scan.rs`** — `find_primary_key` / `find_unique` **deleted**: TABLES was their only production caller, and constraint keywords are now recognised as tokens (inherently quote-aware / UTF-8-safe). Their word-boundary and non-ASCII guarantees are re-pinned as clause-level integration tests.
- **`src/body_parser/mod.rs`** — register the two modules; replace the two deleted-helper unit tests with equivalent `parse_tables_clause`-level tests.

### Behaviour preservation

Error messages and caret positions are preserved for every previously-tested / defined input. There is **one deliberate divergence**: a name slot beginning with a non-`(`/`;` symbol (`o AS .foo`, `o AS =x`, `o AS -1`) now errors at DDL-parse time with the missing-name message, whereas the old `find_identifier_end` folded a leading `.`/`=`/`-` into a bogus table name that only failed later at catalog resolution. This is an intentional, stricter improvement on input the old code left undefined-by-test, pinned by `test_leading_symbol_in_name_slot_is_missing_name`.

## Why

The review's finding #2: the parser layer has no lexer, so every remediated bug class (PA-2 mojibake, PA-5/9 silent discard, PA-10 whitespace) keeps re-emerging in new grammar slots because each slot re-hands the author a raw `&str`. A shared lexer + cursor eliminates the class structurally. This is the first, behaviour-preserving clause migration; later phases move the remaining clauses one at a time and eventually fold `blank_sql_comments` into the lexer.

## Verification (full local gate)

- `cargo test` — 240 body_parser tests (incl. lexer/cursor unit tests + generative tiling proptests) and all integration proptests: the T-5 oracle (`roundtrip_proptest`, `create_front_door_proptest`, `parse_proptest`).
- `cargo clippy -- -D warnings` (workspace `pedantic = deny`) + `cargo fmt --check`.
- `just build` + `just test-sql` — **71/71 sqllogictest files pass** (error-caret suites included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)