### PR TITLE
§6.1 (phase 3): migrate DIMENSIONS/FACTS entries onto the lexer/cursor

### DIFF
--- a/src/body_parser/cursor.rs
+++ b/src/body_parser/cursor.rs
@@ -98,6 +98,17 @@ impl<'a> Cursor<'a> {
             .find(|&t| self.is_kw(t, kw))
     }
 
+    /// The first `Symbol(b)` token at/after the cursor, without consuming.
+    /// Quote-aware by construction — a `b` inside a string/quoted-ident is part
+    /// of that one token, never a `Symbol`. Used to locate a structural
+    /// delimiter (e.g. the qualifier `.`) that a name run splits on.
+    pub(super) fn find_symbol(&self, b: u8) -> Option<Token> {
+        self.toks[self.idx..]
+            .iter()
+            .copied()
+            .find(|t| t.kind == TokenKind::Symbol(b))
+    }
+
     /// Is the next token `Symbol(b)`?
     pub(super) fn peek_is_symbol(&self, b: u8) -> bool {
         matches!(self.peek(), Some(t) if t.kind == TokenKind::Symbol(b))

--- a/src/body_parser/entries.rs
+++ b/src/body_parser/entries.rs
@@ -96,10 +96,13 @@ fn parse_single_qualified_entry(
         }
     }
 
-    // The cursor spans the post-access-modifier text. Its base is `entry_offset`
-    // (not the access-modifier offset within `entry`) so error carets reproduce
-    // the pre-migration formula exactly.
-    let mut cur = Cursor::new(entry_after_access, entry_offset);
+    // The cursor spans the post-access-modifier text. Its base includes the
+    // byte offset of `entry_after_access` within `entry` so error carets land at
+    // true positions — the pre-migration `entry_offset + dot_pos` formula was
+    // relative to `entry_after_access` and so drifted left into a stripped
+    // `PRIVATE `/`PUBLIC ` prefix on FACTS entries (PR #102 review).
+    let access_offset = crate::util::byte_offset_within(entry, entry_after_access);
+    let mut cur = Cursor::new(entry_after_access, entry_offset + access_offset);
 
     // Split `alias.name` at the first `.` SYMBOL token — quote-aware (PA-6): a
     // dot inside a quoted name (`"a.b"`) is part of that one token, not a

--- a/src/body_parser/entries.rs
+++ b/src/body_parser/entries.rs
@@ -1,7 +1,16 @@
 //! DIMENSIONS / FACTS qualified-entry parsing.
+//!
+//! §6.1 (phase 3, code-review 2026-07-11): the structural `alias.name AS`
+//! prefix is parsed on the shared [`Cursor`]/lexer — the qualifier `.` is the
+//! first `.` SYMBOL token (quote-aware: a dot inside a quoted `"a.b"` is inert,
+//! PA-6) and `AS` is the first keyword token after it. The leading access
+//! modifier, the unterminated-quote guard, and the trailing COMMENT / WITH
+//! SYNONYMS region continue to use their shared helpers (the annotation tail is
+//! handed the post-`AS` source verbatim, as TABLES does).
 
 use super::annotations::{parse_leading_access_modifier, parse_trailing_annotations};
-use super::scan::{find_keyword_ci, find_live_byte, unterminated_quote_error};
+use super::cursor::Cursor;
+use super::scan::unterminated_quote_error;
 use super::{split_at_depth0_commas, ParsedQualifiedEntry};
 use crate::errors::ParseError;
 use crate::model::AccessModifier;
@@ -87,47 +96,58 @@ fn parse_single_qualified_entry(
         }
     }
 
-    // Find first live '.' to split alias.bare_name — quote-aware (PA-6):
-    // a dot inside a quoted name (`"a.b"`) is not a qualifier separator.
-    let dot_pos = find_live_byte(entry_after_access, b'.').ok_or_else(|| ParseError {
-        message: format!(
-            "Expected 'alias.name' qualified identifier, got '{entry}'. Each dimension/metric entry must have the form 'alias.name AS expr'.",
-        ),
-        position: Some(entry_offset),
-    })?;
+    // The cursor spans the post-access-modifier text. Its base is `entry_offset`
+    // (not the access-modifier offset within `entry`) so error carets reproduce
+    // the pre-migration formula exactly.
+    let mut cur = Cursor::new(entry_after_access, entry_offset);
 
-    let source_alias = entry_after_access[..dot_pos].trim().to_string();
+    // Split `alias.name` at the first `.` SYMBOL token — quote-aware (PA-6): a
+    // dot inside a quoted name (`"a.b"`) is part of that one token, not a
+    // qualifier separator. `name` keeps the source-slice form because it may
+    // itself contain dots (`o.x.y` → alias `o`, name `x.y`).
+    let Some(dot_tok) = cur.find_symbol(b'.') else {
+        return Err(cur.err(
+            0,
+            format!(
+                "Expected 'alias.name' qualified identifier, got '{entry}'. Each dimension/metric entry must have the form 'alias.name AS expr'.",
+            ),
+        ));
+    };
+    let source_alias = entry_after_access[..dot_tok.start].trim().to_string();
     if source_alias.is_empty() {
-        return Err(ParseError {
-            message: format!("Source alias before '.' is empty in entry '{entry}'."),
-            position: Some(entry_offset),
-        });
+        return Err(cur.err(
+            0,
+            format!("Source alias before '.' is empty in entry '{entry}'."),
+        ));
     }
+    cur.advance_past_byte(dot_tok.end);
 
-    // Everything from dot+1 forward; find "AS" (case-insensitive, word boundary)
-    let after_dot = &entry_after_access[dot_pos + 1..];
-    let upper_after = after_dot.to_ascii_uppercase();
-    let as_pos = find_keyword_ci(&upper_after, "AS").ok_or_else(|| ParseError {
-        message: format!(
-            "Expected 'AS' keyword in dimension/metric entry '{entry}'. Form: 'alias.name AS expr'.",
-        ),
-        position: Some(entry_offset + dot_pos + 1),
-    })?;
-
-    let bare_name = after_dot[..as_pos].trim().to_string();
+    // `AS` is the first keyword token after the qualifier dot; `name` is the
+    // text between them.
+    let Some(as_tok) = cur.find_kw("AS") else {
+        return Err(cur.err(
+            dot_tok.end,
+            format!(
+                "Expected 'AS' keyword in dimension/metric entry '{entry}'. Form: 'alias.name AS expr'.",
+            ),
+        ));
+    };
+    let bare_name = entry_after_access[dot_tok.end..as_tok.start]
+        .trim()
+        .to_string();
     if bare_name.is_empty() {
-        return Err(ParseError {
-            message: format!("Missing bare name between '.' and 'AS' in entry '{entry}'."),
-            position: Some(entry_offset + dot_pos + 1),
-        });
+        return Err(cur.err(
+            dot_tok.end,
+            format!("Missing bare name between '.' and 'AS' in entry '{entry}'."),
+        ));
     }
 
-    let raw_expr = after_dot[as_pos + 2..].trim();
+    let raw_expr = entry_after_access[as_tok.end..].trim();
     if raw_expr.is_empty() {
-        return Err(ParseError {
-            message: format!("Missing expression after 'AS' in entry '{entry}'."),
-            position: Some(entry_offset + dot_pos + 1 + as_pos + 2),
-        });
+        return Err(cur.err(
+            as_tok.end,
+            format!("Missing expression after 'AS' in entry '{entry}'."),
+        ));
     }
 
     // Phase 43: Parse trailing annotations from expression

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -1268,6 +1268,20 @@ mod tests {
     }
 
     #[test]
+    fn test_private_fact_structural_error_caret_after_modifier() {
+        // §6.1 (phase 3, PR #102 review): the cursor base accounts for the
+        // stripped PRIVATE/PUBLIC modifier, so a structural-error caret lands in
+        // the alias.name region, not inside "PRIVATE ". `PRIVATE o.x` has no AS.
+        let entry = "PRIVATE o.x";
+        let err = parse_qualified_entries(entry, 0, true, "facts").unwrap_err();
+        let pos = err.position.expect("caret");
+        assert!(
+            pos >= entry.find("o.x").unwrap(),
+            "caret {pos} drifted into the access modifier of {entry:?}"
+        );
+    }
+
+    #[test]
     fn test_quoted_dot_in_alias_not_a_qualifier() {
         // §6.1 (phase 3): the qualifier `.` is the first `.` SYMBOL token, so a
         // dot inside a QUOTED alias is inert — the split happens at the dot

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -1268,6 +1268,18 @@ mod tests {
     }
 
     #[test]
+    fn test_quoted_dot_in_alias_not_a_qualifier() {
+        // §6.1 (phase 3): the qualifier `.` is the first `.` SYMBOL token, so a
+        // dot inside a QUOTED alias is inert — the split happens at the dot
+        // AFTER the closing quote. (Quote-aware already, now token-structural.)
+        let entries = parse_qualified_entries("\"a.b\".name AS 1", 0, false, "dimensions").unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].source_alias, "\"a.b\"");
+        assert_eq!(entries[0].name, "name");
+        assert_eq!(entries[0].expr, "1");
+    }
+
+    #[test]
     fn test_keyword_not_matched_before_non_ascii_continuation() {
         // PR #50 review: keyword boundary checks treated non-ASCII bytes as
         // boundaries, so COMMENT matched inside the identifier `commenté`


### PR DESCRIPTION
Third clause onto the shared token cursor (phase 1 TABLES #100, phase 2 RELATIONSHIPS #101). Behaviour-preserving under the same oracle (roundtrip / create-front-door / parse proptests + sqllogictest); one clause per phase.

## What changed

`src/body_parser/entries.rs` — the `[PRIVATE|PUBLIC] alias.name AS expr [COMMENT = '...'] [WITH SYNONYMS = ('...')]` prefix is now parsed on the cursor:

- The `alias.name` qualifier split is the **first `.` `Symbol` token** (replacing `find_live_byte`) and `AS` is the **first keyword token after it** (replacing `find_keyword_ci`) — both quote-aware by construction (a dot or `AS` inside a `"quoted"`/`'string'` token is inert). `name` is kept as a source slice because it may itself contain dots (`o.x.y` → alias `o`, name `x.y`), so it is not forced to a single token.
- The **leading access modifier**, the **unterminated-quote guard**, and the **trailing annotation region** keep their existing shared helpers — the annotation tail is handed the post-`AS` source verbatim, exactly as TABLES does. Migrating the shared annotation parser itself is a later phase.

### Behaviour preservation (+ one intentional fix)

For the common (non-access-modifier) path, every error message and caret offset is **byte-identical** to the pre-migration `entry_offset + dot_pos + …` arithmetic (verified for all of: dot-missing, empty-alias, AS-missing, empty-name, empty-expr). The quote-aware qualifier split is pinned token-structurally by `test_quoted_dot_in_alias_not_a_qualifier` (`"a.b".name` → alias `"a.b"`, not split at the in-quote dot).

There is **one intentional behaviour change** (commit dc739d9, from PR review): for `PRIVATE`/`PUBLIC` FACTS entries the cursor base now includes the stripped modifier's byte offset (`access_offset = byte_offset_within(entry, entry_after_access)`). This **fixes** a latent caret-drift bug — the old `entry_offset + dot_pos` carets (with `dot_pos` relative to the post-modifier slice) landed *inside* the `PRIVATE `/`PUBLIC ` prefix. Non-modifier entries have `access_offset == 0`, so the common path is unaffected. Pinned by `test_private_fact_structural_error_caret_after_modifier`.

No `scan.rs` helpers were deleted — `find_live_byte` / `find_keyword_ci` are still used by the not-yet-migrated METRICS/window clauses. The `find_symbol` cursor helper is used again here (the qualifier-dot split).

## Verification (full local gate)

- `cargo test` — 245 body_parser tests (incl. the quote-aware split test and the caret-fix regression test) + all integration proptests.
- `cargo clippy -- -D warnings` + `cargo fmt --check`.
- `just build` + `just test-sql` — **71/71 sqllogictest files pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)