### PR TITLE
§6.1 (phase 5): migrate window OVER-clause parser onto the lexer/cursor

### DIFF
--- a/src/body_parser/cursor.rs
+++ b/src/body_parser/cursor.rs
@@ -143,14 +143,16 @@ impl<'a> Cursor<'a> {
     }
 
     /// The first bare keyword `kw` token at/after the cursor that sits at
-    /// paren-depth 0 (not inside any `(...)` group). Used for `OVER`, which must
-    /// be outside the window-function call's own parentheses.
+    /// bracket-depth 0 (not inside any `(...)`, `[...]`, or `{...}` group). Used
+    /// for `OVER`, which must be outside the window-function call's own
+    /// parentheses. All three bracket kinds count as nesting, matching
+    /// [`super::split_at_depth0_commas`] and the retired `find_depth0_keyword`.
     pub(super) fn find_kw_depth0(&self, kw: &str) -> Option<Token> {
         let mut depth = 0i32;
         for &t in &self.toks[self.idx..] {
             match t.kind {
-                TokenKind::Symbol(b'(') => depth += 1,
-                TokenKind::Symbol(b')') => depth -= 1,
+                TokenKind::Symbol(b'(' | b'[' | b'{') => depth += 1,
+                TokenKind::Symbol(b')' | b']' | b'}') => depth -= 1,
                 _ if depth == 0 && self.is_kw(t, kw) => return Some(t),
                 _ => {}
             }

--- a/src/body_parser/cursor.rs
+++ b/src/body_parser/cursor.rs
@@ -142,6 +142,32 @@ impl<'a> Cursor<'a> {
             .map(|w| w[0])
     }
 
+    /// The first bare keyword `kw` token at/after the cursor that sits at
+    /// paren-depth 0 (not inside any `(...)` group). Used for `OVER`, which must
+    /// be outside the window-function call's own parentheses.
+    pub(super) fn find_kw_depth0(&self, kw: &str) -> Option<Token> {
+        let mut depth = 0i32;
+        for &t in &self.toks[self.idx..] {
+            match t.kind {
+                TokenKind::Symbol(b'(') => depth += 1,
+                TokenKind::Symbol(b')') => depth -= 1,
+                _ if depth == 0 && self.is_kw(t, kw) => return Some(t),
+                _ => {}
+            }
+        }
+        None
+    }
+
+    /// The first token at/after the cursor that is a bare keyword equal to ANY
+    /// of `kws`. Used to locate the earliest of several possible boundary
+    /// keywords (e.g. `ORDER` / `ROWS` / `RANGE` / `GROUPS`).
+    pub(super) fn find_any_kw(&self, kws: &[&str]) -> Option<Token> {
+        self.toks[self.idx..]
+            .iter()
+            .copied()
+            .find(|&t| kws.iter().any(|kw| self.is_kw(t, kw)))
+    }
+
     /// The first run of consecutive bare keyword tokens matching `kws` in order
     /// (only whitespace between them, since that is all that separates adjacent
     /// tokens). Returns `(first_token, last_token)`. Used for multi-word

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -401,7 +401,6 @@ pub fn parse_keyword_body(text: &str, base_offset: usize) -> Result<KeywordBody,
 #[cfg(test)]
 mod tests {
     use super::annotations::parse_trailing_annotations;
-    use super::scan::find_keyword_ci;
     use super::*;
     use crate::model::{Cardinality, NullsOrder, SortOrder};
 
@@ -1009,13 +1008,15 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_find_keyword_ci_non_ascii_no_panic() {
-        // `é` uppercases to `É` (both 2 bytes); scanning must not panic and
-        // must still find the keyword after the multi-byte run.
-        let upper = "ÉÉÉ AS x".to_string();
-        assert_eq!(find_keyword_ci(&upper, "AS"), Some(7));
-        // No match at all — pure multi-byte text.
-        assert_eq!(find_keyword_ci("東京東京", "AS"), None);
+    fn test_keyword_scan_over_non_ascii_no_panic() {
+        // PA-1/PA-2: keyword scanning over non-ASCII input must not panic and
+        // must still find a keyword after a multi-byte run. This is now
+        // structural — the lexer consumes each multi-byte codepoint whole and
+        // the cursor matches keywords by token — so it is exercised via the
+        // cursor (replacing the retired `find_keyword_ci` scan test).
+        use super::cursor::Cursor;
+        assert!(Cursor::new("ÉÉÉ AS x", 0).find_kw("AS").is_some());
+        assert!(Cursor::new("東京東京", 0).find_kw("AS").is_none());
     }
 
     #[test]

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -1547,6 +1547,34 @@ mod tests {
         assert_eq!(ws.order_by[0].expr, "d");
     }
 
+    #[test]
+    fn test_over_partition_dim_named_like_frame_keyword() {
+        // §6.1 (phase 5, PR #104 review): a PARTITION/EXCLUDING dim named like a
+        // frame keyword (`groups`/`rows`/`range`) followed by ORDER BY stays a
+        // dim — the dims boundary prefers ORDER over frame keywords, matching
+        // the pre-migration `find_keyword_ci("ORDER").or_else(find_frame_start)`.
+        // (Neither the old nor the new suite covered this boundary before.)
+        let result = parse_metrics_clause(
+            "s.r AS SUM(qty) OVER (PARTITION BY EXCLUDING region, groups ORDER BY d)",
+            0,
+        )
+        .unwrap();
+        let ws = result[0].window_spec.as_ref().expect("window spec");
+        assert_eq!(ws.excluding_dims, vec!["region", "groups"]);
+        assert_eq!(ws.order_by.len(), 1);
+        assert_eq!(ws.order_by[0].expr, "d");
+        // Plain PARTITION BY with a frame-keyword-named dim + ORDER BY.
+        let result = parse_metrics_clause(
+            "s.r AS SUM(qty) OVER (PARTITION BY region, rows ORDER BY d)",
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            result[0].window_spec.as_ref().unwrap().partition_dims,
+            vec!["region", "rows"]
+        );
+    }
+
     // -----------------------------------------------------------------------
     // P-3 (code-review 2026-07-11): the OVER-clause parser must not silently
     // degrade malformed content. `ORDER` without an adjacent `BY` previously

--- a/src/body_parser/scan.rs
+++ b/src/body_parser/scan.rs
@@ -277,83 +277,12 @@ pub(super) fn extract_paren_prefix(s: &str) -> Option<(&str, usize)> {
     None
 }
 
-/// Requires the keyword to be preceded by whitespace (or be at start) and
-/// followed by whitespace or end-of-string. Returns byte offset into `upper_text`.
-///
-/// Quote-aware (PA-3/PA-6): keyword text inside `'...'` string literals or
-/// `"..."` quoted identifiers does not match.
-pub(super) fn find_keyword_ci(upper_text: &str, keyword: &str) -> Option<usize> {
-    let kw_len = keyword.len();
-    let text_len = upper_text.len();
-    if text_len < kw_len {
-        return None;
-    }
-    let kw_bytes = keyword.as_bytes();
-    let text_bytes = upper_text.as_bytes();
-    let mut st = QuoteState::default();
-    let mut i = 0;
-    while i < text_len {
-        let (next, live) = st.step(text_bytes, i);
-        // Byte comparison — `i` advances one byte at a time, so a string
-        // slice here panics mid-codepoint on non-ASCII input (PA-1).
-        if live && i + kw_len <= text_len && &text_bytes[i..i + kw_len] == kw_bytes {
-            // Check boundary: preceded by non-identifier char (or start), followed by non-identifier char (or end).
-            // Underscore is a valid identifier character, so it must NOT count as a word boundary.
-            let before_ok = i == 0 || !is_ident_continuation(text_bytes[i - 1]);
-            let after_ok = i + kw_len == text_len || !is_ident_continuation(text_bytes[i + kw_len]);
-            if before_ok && after_ok {
-                return Some(i);
-            }
-        }
-        i = next;
-    }
-    None
-}
-
-/// Find a keyword at depth-0 in a string (not inside parens or string literals).
-/// Returns byte offset of the keyword start.
-pub(super) fn find_depth0_keyword(
-    upper_text: &str,
-    raw_text: &str,
-    keyword: &str,
-) -> Option<usize> {
-    let bytes = upper_text.as_bytes();
-    let kw_len = keyword.len();
-    if bytes.len() < kw_len {
-        return None;
-    }
-    let raw_bytes = raw_text.as_bytes();
-    let mut depth: i32 = 0;
-    let mut st = QuoteState::default();
-    let mut i = 0;
-    while i < bytes.len() {
-        // Quote state tracks the RAW text (quotes live at identical offsets
-        // in the uppercased copy, but scan the original for clarity).
-        let (next, live) = st.step(raw_bytes, i);
-        if live {
-            match raw_bytes[i] {
-                b'(' | b'[' | b'{' => depth += 1,
-                b')' | b']' | b'}' => depth -= 1,
-                _ => {}
-            }
-            if depth == 0
-                && i + kw_len <= bytes.len()
-                // Byte comparison — `i` advances one byte at a time, so a string
-                // slice here panics mid-codepoint on non-ASCII input (PA-1).
-                && &bytes[i..i + kw_len] == keyword.as_bytes()
-            {
-                let before_ok = i == 0 || !is_ident_continuation(bytes[i - 1]);
-                let after_ok =
-                    i + kw_len == bytes.len() || !is_ident_continuation(bytes[i + kw_len]);
-                if before_ok && after_ok {
-                    return Some(i);
-                }
-            }
-        }
-        i = next;
-    }
-    None
-}
+// `find_keyword_ci` (case-insensitive, quote-aware, word-boundaried keyword
+// search) and `find_depth0_keyword` (its paren-depth-0 variant, used for OVER)
+// were retired in the §6.1 migration: clause parsers now recognize keywords as
+// bare-identifier TOKENS via `super::cursor::Cursor` (`find_kw` / `find_kw_seq`
+// / `find_kw_depth0`), which are inherently quote-aware and UTF-8-safe
+// (code-review 2026-07-11).
 
 // `find_primary_key` / `find_unique` (the case-insensitive, quote-aware
 // "find this constraint keyword anywhere in the post-name slice and slice from

--- a/src/body_parser/window.rs
+++ b/src/body_parser/window.rs
@@ -192,8 +192,15 @@ fn parse_over_content(content: &str, base_offset: usize) -> Result<OverContent, 
             cur.advance_past_byte(ex_end);
         }
         let dims_start = cur.byte_pos();
-        // Dims run up to ORDER or a frame keyword (whichever is first), else end.
-        let boundary = cur.find_any_kw(&["ORDER", "ROWS", "RANGE", "GROUPS"]);
+        // Dims run up to ORDER BY, else a frame keyword, else end. ORDER is
+        // PREFERRED over frame keywords (matching the old
+        // `find_keyword_ci("ORDER").or_else(find_frame_start)`), so a dim named
+        // like a frame keyword (`groups`/`rows`/`range`) followed by ORDER BY
+        // stays a dim rather than being taken as the frame boundary (PR #104
+        // review).
+        let boundary = cur
+            .find_kw("ORDER")
+            .or_else(|| cur.find_any_kw(&FRAME_KEYWORDS));
         let dims_end = boundary.map_or(content.len(), |t| t.start);
         let dims = split_dim_list(content[dims_start..dims_end].trim());
         if excluding {

--- a/src/body_parser/window.rs
+++ b/src/body_parser/window.rs
@@ -1,64 +1,73 @@
 //! Window-metric OVER clause parsing and the shared ORDER-BY modifier loop.
 
-use super::scan::{
-    extract_paren_content, find_depth0_keyword, find_keyword_ci, is_ident_continuation,
-    is_quoting_balanced,
-};
+use super::cursor::Cursor;
+use super::scan::{is_ident_continuation, is_quoting_balanced};
 use super::split_at_depth0_commas;
 use crate::errors::ParseError;
 use crate::ident::find_identifier_end;
 use crate::model::{NullsOrder, SortOrder, WindowOrderBy, WindowSpec};
+
+/// The frame-clause lead keywords (`ROWS` / `RANGE` / `GROUPS`).
+const FRAME_KEYWORDS: [&str; 3] = ["ROWS", "RANGE", "GROUPS"];
 
 /// Parse a window function OVER clause from the expression text.
 ///
 /// Detects `FUNC(metric[, args...]) OVER (PARTITION BY EXCLUDING d1, d2 [ORDER BY ...] [frame])`.
 /// Returns the raw expression and an optional parsed `WindowSpec`.
 ///
-/// The OVER keyword must be at depth-0 (not inside parens or string literals) and at a word
-/// boundary. If found, the function call part is parsed into `window_function`, `inner_metric`,
-/// and `extra_args`, and the OVER clause content is parsed for EXCLUDING dims, ORDER BY entries,
-/// and a frame clause.
+/// §6.1 (phase 5): parsed on the shared [`Cursor`]/lexer. `OVER` is the first
+/// depth-0 keyword token (outside the function-call parens); the function-call
+/// and OVER-body parentheses are consumed with `take_parens`; and the OVER
+/// content's `PARTITION BY [EXCLUDING]` / `ORDER BY` / frame boundaries are
+/// keyword tokens. The P-3 hardening (ORDER-must-be-adjacent-BY, no silent
+/// frame, frame-keyword-name rejection) is preserved exactly.
 pub(super) fn parse_window_over_clause(
     expr: &str,
     base_offset: usize,
 ) -> Result<(String, Option<WindowSpec>), ParseError> {
     let expr = expr.trim();
-    let upper = expr.to_ascii_uppercase();
+    let mut cur = Cursor::new(expr, base_offset);
 
-    // Scan for OVER keyword at depth-0 with word boundaries
-    let Some(over_pos) = find_depth0_keyword(&upper, expr, "OVER") else {
+    // OVER keyword at depth-0 (outside the window-function call's parentheses).
+    let Some(over_tok) = cur.find_kw_depth0("OVER") else {
         return Ok((expr.to_string(), None));
     };
+    let func_part = expr[..over_tok.start].trim();
 
-    // The part before OVER is the function call: e.g., "AVG(total_qty)" or "LAG(total_qty, 30)"
-    let func_part = expr[..over_pos].trim();
-    let after_over = expr[over_pos + 4..].trim();
-
-    // Extract the OVER clause's parenthesized content
-    if !after_over.starts_with('(') {
+    // The OVER body: `(...)` immediately after OVER.
+    cur.advance_past_byte(over_tok.end);
+    if !cur.peek_is_symbol(b'(') {
         return Err(ParseError {
             message: format!("Expected '(' after OVER in expression '{expr}'."),
-            position: Some(base_offset + over_pos + 4),
+            position: Some(base_offset + over_tok.end),
         });
     }
-    let over_content = extract_paren_content(after_over).ok_or_else(|| ParseError {
-        message: format!("Unclosed '(' after OVER in expression '{expr}'."),
-        position: Some(base_offset + over_pos + 4),
-    })?;
+    let Some(over_content) = cur.take_parens() else {
+        return Err(ParseError {
+            message: format!("Unclosed '(' after OVER in expression '{expr}'."),
+            position: Some(base_offset + over_tok.end),
+        });
+    };
 
-    // Parse function call part: FUNC(inner_metric[, extra_args...])
-    let paren_start = func_part.find('(').ok_or_else(|| ParseError {
-        message: format!(
-            "Window function before OVER must have parenthesized arguments: '{func_part}'."
-        ),
-        position: Some(base_offset),
-    })?;
-    let window_function = func_part[..paren_start].trim().to_string();
-    let func_args_content =
-        extract_paren_content(&func_part[paren_start..]).ok_or_else(|| ParseError {
+    // The function call before OVER: `FUNC(inner_metric[, extra_args...])`.
+    let mut fcur = Cursor::new(func_part, base_offset);
+    let Some(fparen) = fcur.find_symbol(b'(') else {
+        return Err(ParseError {
+            message: format!(
+                "Window function before OVER must have parenthesized arguments: '{func_part}'."
+            ),
+            position: Some(base_offset),
+        });
+    };
+    let window_function = func_part[..fparen.start].trim().to_string();
+    let paren_start = fparen.start;
+    fcur.advance_past_byte(paren_start);
+    let Some(func_args_content) = fcur.take_parens() else {
+        return Err(ParseError {
             message: format!("Unclosed '(' in window function call '{func_part}'."),
             position: Some(base_offset + paren_start),
-        })?;
+        });
+    };
 
     // Split function arguments: first is inner_metric, rest are extra_args
     let func_args: Vec<&str> = split_at_depth0_commas(func_args_content)
@@ -79,9 +88,8 @@ pub(super) fn parse_window_over_clause(
         .collect();
 
     // Parse OVER clause content: PARTITION BY [EXCLUDING] ..., ORDER BY ..., frame clause
-    let over_upper = over_content.to_ascii_uppercase();
     let (excluding_dims, partition_dims, order_by, frame_clause) =
-        parse_over_content(over_content, &over_upper, base_offset + over_pos)?;
+        parse_over_content(over_content, base_offset + over_tok.start)?;
 
     Ok((
         expr.to_string(),
@@ -101,198 +109,160 @@ pub(super) fn parse_window_over_clause(
 /// (`excluding_dims`, `partition_dims`, `order_by`, `frame_clause`)
 type OverContent = (Vec<String>, Vec<String>, Vec<WindowOrderBy>, Option<String>);
 
-/// Parse the content inside the OVER (...) clause.
-/// Returns (`excluding_dims`, `order_by`, `frame_clause`).
-#[allow(clippy::too_many_lines)]
-fn parse_over_content(
-    content: &str,
-    upper_content: &str,
-    base_offset: usize,
-) -> Result<OverContent, ParseError> {
-    let content = content.trim();
-    let upper_content = upper_content.trim();
+/// Split a comma-separated dimension list (already sliced from the source),
+/// trimming and dropping empties.
+fn split_dim_list(text: &str) -> Vec<String> {
+    split_at_depth0_commas(text)
+        .into_iter()
+        .map(|(_, s)| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
 
+/// Parse the comma-separated `dim [ASC|DESC] [NULLS FIRST|LAST]` entries of an
+/// OVER `ORDER BY`. `dim` is captured identifier-aware (quoted / dotted names
+/// survive); the modifier suffix is whitespace-tokenised and resolved by the
+/// shared [`parse_order_by_modifiers`]. Entry errors anchor at
+/// `base_offset + <entry offset>`.
+fn parse_order_by_entries(
+    order_text: &str,
+    base_offset: usize,
+) -> Result<Vec<WindowOrderBy>, ParseError> {
+    let mut order_by = Vec::new();
+    for (start, entry_text) in split_at_depth0_commas(order_text) {
+        let entry_text = entry_text.trim();
+        if entry_text.is_empty() {
+            continue;
+        }
+        let name_end = find_identifier_end(entry_text, /* allow_paren = */ false);
+        if name_end == 0 {
+            continue;
+        }
+        if !is_quoting_balanced(&entry_text[..name_end]) {
+            return Err(ParseError {
+                message: format!(
+                    "Unterminated quoted identifier in OVER ORDER BY entry '{entry_text}'."
+                ),
+                position: Some(base_offset + start),
+            });
+        }
+        let dim_name = entry_text[..name_end].trim().to_string();
+        let suffix = entry_text[name_end..].trim();
+        let parts: Vec<&str> = suffix.split_whitespace().collect();
+        let (sort, nulls) = parse_order_by_modifiers(
+            &parts,
+            OrderModifierContext::OverOrderBy { entry_text },
+            base_offset + start,
+        )?;
+        order_by.push(WindowOrderBy {
+            expr: dim_name,
+            order: sort,
+            nulls,
+        });
+    }
+    Ok(order_by)
+}
+
+/// Parse the content inside the OVER (...) clause:
+/// `[PARTITION BY [EXCLUDING] dims] [ORDER BY entries] [frame]`.
+///
+/// All boundaries are keyword tokens on a [`Cursor`] scoped to `content`. The
+/// P-3 diagnostics anchor at `base_offset` (as before); ORDER BY entry errors
+/// at `base_offset + <entry offset>`.
+fn parse_over_content(content: &str, base_offset: usize) -> Result<OverContent, ParseError> {
+    let content = content.trim();
     if content.is_empty() {
         return Ok((vec![], vec![], vec![], None));
     }
 
-    // Look for PARTITION BY EXCLUDING or plain PARTITION BY at the start
+    let mut cur = Cursor::new(content, base_offset);
     let mut excluding_dims: Vec<String> = Vec::new();
     let mut partition_dims: Vec<String> = Vec::new();
-    let mut remaining = content;
-    let mut remaining_upper = upper_content;
 
-    if let Some(pbe_pos) = find_partition_by_excluding(upper_content) {
-        let after_pbe = &content[pbe_pos..];
-        let after_pbe_upper = &upper_content[pbe_pos..];
+    // `tail_start` is where the post-PARTITION-BY region begins in `content`
+    // (0 when there is no PARTITION BY).
+    let mut tail_start = 0usize;
 
-        // Find end of EXCLUDING dims list: either ORDER BY, or a frame keyword, or end of string
-        let end_of_dims =
-            find_keyword_ci(after_pbe_upper, "ORDER").or_else(|| find_frame_start(after_pbe_upper));
-        let dims_text = match end_of_dims {
-            Some(end) => after_pbe[..end].trim(),
-            None => after_pbe.trim(),
-        };
-
-        // Parse comma-separated dimension names
-        excluding_dims = split_at_depth0_commas(dims_text)
-            .into_iter()
-            .map(|(_, s)| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect();
-
-        // Slice BOTH content and its ASCII-uppercased twin (identical byte
-        // offsets) from the same absolute bounds. Deriving the start via
-        // `content.len() - remaining.len()` assumed `remaining` was a strict
-        // suffix; `.trim()` also strips trailing whitespace, so that start
-        // would skip the remainder's leading bytes if any trailing
-        // whitespace were present. Today `content` is pre-trimmed so no live
-        // bug, but offset-based slicing is correct independent of that
-        // invariant (PR #50 review).
-        let (rem_start, rem_end) = match end_of_dims {
-            Some(end) => trimmed_bounds(content, pbe_pos + end),
-            None => (content.len(), content.len()),
-        };
-        remaining = &content[rem_start..rem_end];
-        remaining_upper = &upper_content[rem_start..rem_end];
-    } else if let Some(pb_pos) = find_partition_by(upper_content) {
-        // Plain PARTITION BY (without EXCLUDING)
-        let after_pb = &content[pb_pos..];
-        let after_pb_upper = &upper_content[pb_pos..];
-
-        let end_of_dims =
-            find_keyword_ci(after_pb_upper, "ORDER").or_else(|| find_frame_start(after_pb_upper));
-        let dims_text = match end_of_dims {
-            Some(end) => after_pb[..end].trim(),
-            None => after_pb.trim(),
-        };
-
-        partition_dims = split_at_depth0_commas(dims_text)
-            .into_iter()
-            .map(|(_, s)| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect();
-
-        // Offset-based slicing (see the EXCLUDING branch above).
-        let (rem_start, rem_end) = match end_of_dims {
-            Some(end) => trimmed_bounds(content, pb_pos + end),
-            None => (content.len(), content.len()),
-        };
-        remaining = &content[rem_start..rem_end];
-        remaining_upper = &upper_content[rem_start..rem_end];
+    if let Some((_partition, by_tok)) = cur.find_kw_seq(&["PARTITION", "BY"]) {
+        cur.advance_past_byte(by_tok.end);
+        // Optional EXCLUDING.
+        let excluding = cur.peek().is_some_and(|t| cur.is_kw(t, "EXCLUDING"));
+        if excluding {
+            let ex_end = cur.peek().map_or(by_tok.end, |t| t.end);
+            cur.advance_past_byte(ex_end);
+        }
+        let dims_start = cur.byte_pos();
+        // Dims run up to ORDER or a frame keyword (whichever is first), else end.
+        let boundary = cur.find_any_kw(&["ORDER", "ROWS", "RANGE", "GROUPS"]);
+        let dims_end = boundary.map_or(content.len(), |t| t.start);
+        let dims = split_dim_list(content[dims_start..dims_end].trim());
+        if excluding {
+            excluding_dims = dims;
+        } else {
+            partition_dims = dims;
+        }
+        cur.advance_past_byte(dims_end);
+        tail_start = dims_end;
     }
 
-    // Look for ORDER BY
+    // ORDER BY, then the frame region.
     let mut order_by: Vec<WindowOrderBy> = Vec::new();
-    let order_pos = find_keyword_ci(remaining_upper, "ORDER");
-    if let Some(opos) = order_pos {
-        // P-3 (code-review 2026-07-11): text before ORDER at this point is
-        // not valid OVER-clause content — it was previously skipped silently.
-        if !remaining[..opos].trim().is_empty() {
+    let frame_region: &str = if let Some(order_tok) = cur.find_kw("ORDER") {
+        // P-3: no stray text between the dims/start and ORDER.
+        let before = content[tail_start..order_tok.start].trim();
+        if !before.is_empty() {
+            return Err(ParseError {
+                message: format!("Unexpected text '{before}' before ORDER BY in OVER clause."),
+                position: Some(base_offset),
+            });
+        }
+        // P-3: ORDER must be immediately followed by BY (no junk between, and
+        // absent-BY is an error rather than a silent frame clause).
+        cur.advance_past_byte(order_tok.end);
+        let by_tok = match cur.peek() {
+            Some(t) if cur.is_kw(t, "BY") => t,
+            _ => {
+                return Err(ParseError {
+                    message: "Expected BY immediately after ORDER in OVER clause.".to_string(),
+                    position: Some(base_offset),
+                });
+            }
+        };
+        cur.advance_past_byte(by_tok.end);
+
+        // ORDER BY entries run up to a frame keyword (or end).
+        let frame_tok = cur.find_any_kw(&FRAME_KEYWORDS);
+        let order_end = frame_tok.map_or(content.len(), |t| t.start);
+        let order_text = content[by_tok.end..order_end].trim();
+        order_by = parse_order_by_entries(order_text, base_offset)?;
+
+        // P-3: ORDER BY must yield at least one parsed entry (an unquoted
+        // reference named like a frame keyword otherwise leaves zero entries
+        // and a bogus frame with no diagnostics).
+        if order_by.is_empty() {
+            let after_order_by = content[by_tok.end..].trim();
             return Err(ParseError {
                 message: format!(
-                    "Unexpected text '{}' before ORDER BY in OVER clause.",
-                    remaining[..opos].trim()
+                    "Expected column reference after ORDER BY in OVER clause, found '{after_order_by}'. (Quote the reference if it is named like a frame keyword.)"
                 ),
                 position: Some(base_offset),
             });
         }
-        let after_order = &remaining[opos + 5..];
-        let after_order_upper = &remaining_upper[opos + 5..];
-        // P-3: ORDER must be immediately followed by BY. Previously BY was
-        // searched for ANYWHERE after ORDER (junk between them was skipped),
-        // and when BY was absent the whole tail fell through silently and
-        // `ORDER d` was stored as the frame clause — accepted with no
-        // ordering applied.
-        let ws_len = after_order.len() - after_order.trim_start().len();
-        let at_by = &after_order_upper.as_bytes()[ws_len..];
-        let by_ok =
-            at_by.starts_with(b"BY") && (at_by.len() == 2 || !is_ident_continuation(at_by[2]));
-        if !by_ok {
-            return Err(ParseError {
-                message: "Expected BY immediately after ORDER in OVER clause.".to_string(),
-                position: Some(base_offset),
-            });
-        }
-        {
-            let after_order_by = after_order[ws_len + 2..].trim();
-            let after_order_by_upper = after_order_upper[ws_len + 2..].trim();
 
-            // Find end of ORDER BY: frame clause or end of string
-            let frame_start = find_frame_start(after_order_by_upper);
-            let order_text = match frame_start {
-                Some(fpos) => after_order_by[..fpos].trim(),
-                None => after_order_by.trim(),
-            };
+        frame_tok.map_or("", |t| content[t.start..].trim())
+    } else {
+        // No ORDER BY: the tail is the frame clause (or junk).
+        content[tail_start..].trim()
+    };
 
-            // Parse ORDER BY entries using same pattern as non_additive_by
-            // Phase 68 Plan 03 (B2) / TECH-DEBT #25: identifier-aware
-            // tokenisation of the column-reference slot. The post-port
-            // contract narrows the slot from "any expression" to
-            // "identifier (possibly quoted, possibly dotted)" — RESEARCH §B2
-            // confirmed no existing fixture uses function-call expressions
-            // here, so this is a defense-in-depth narrowing, not a regression.
-            let entries = split_at_depth0_commas(order_text);
-            for (start, entry_text) in entries {
-                let entry_text = entry_text.trim();
-                if entry_text.is_empty() {
-                    continue;
-                }
-                let name_end = find_identifier_end(entry_text, /* allow_paren = */ false);
-                if name_end == 0 {
-                    continue;
-                }
-                if !is_quoting_balanced(&entry_text[..name_end]) {
-                    return Err(ParseError {
-                        message: format!(
-                            "Unterminated quoted identifier in OVER ORDER BY entry '{entry_text}'."
-                        ),
-                        position: Some(base_offset + start),
-                    });
-                }
-                let dim_name = entry_text[..name_end].trim().to_string();
-                let suffix = entry_text[name_end..].trim();
-                let parts: Vec<&str> = suffix.split_whitespace().collect();
-                let (sort, nulls) = parse_order_by_modifiers(
-                    &parts,
-                    OrderModifierContext::OverOrderBy { entry_text },
-                    base_offset + start,
-                )?;
-                order_by.push(WindowOrderBy {
-                    expr: dim_name,
-                    order: sort,
-                    nulls,
-                });
-            }
-
-            // P-3: ORDER BY must yield at least one parsed entry. Without
-            // this, an unquoted reference named `range`/`rows`/`groups` was
-            // claimed by `find_frame_start`, leaving zero entries and a
-            // bogus frame clause with no diagnostics.
-            if order_by.is_empty() {
-                return Err(ParseError {
-                    message: format!(
-                        "Expected column reference after ORDER BY in OVER clause, found '{after_order_by}'. (Quote the reference if it is named like a frame keyword.)"
-                    ),
-                    position: Some(base_offset),
-                });
-            }
-
-            // Frame clause is everything after ORDER BY entries
-            remaining = match frame_start {
-                Some(fpos) => after_order_by[fpos..].trim(),
-                None => "",
-            };
-        }
-    }
-
-    // Whatever is left is the frame clause. P-3: validate it actually IS one
-    // — previously any residue was stored verbatim as `frame_clause`.
-    let frame_clause = if remaining.is_empty() {
+    // P-3: validate the frame region actually starts with a frame keyword —
+    // previously any residue was stored verbatim as `frame_clause`.
+    let frame_clause = if frame_region.is_empty() {
         None
     } else {
-        let upper_rem = remaining.to_ascii_uppercase();
-        let is_frame = [&b"ROWS"[..], b"RANGE", b"GROUPS"].iter().any(|kw| {
+        let upper_rem = frame_region.to_ascii_uppercase();
+        let is_frame = FRAME_KEYWORDS.iter().any(|kw| {
+            let kw = kw.as_bytes();
             upper_rem.as_bytes().starts_with(kw)
                 && (upper_rem.len() == kw.len()
                     || !is_ident_continuation(upper_rem.as_bytes()[kw.len()]))
@@ -300,102 +270,15 @@ fn parse_over_content(
         if !is_frame {
             return Err(ParseError {
                 message: format!(
-                    "Expected frame clause starting with ROWS, RANGE, or GROUPS in OVER clause, found '{remaining}'."
+                    "Expected frame clause starting with ROWS, RANGE, or GROUPS in OVER clause, found '{frame_region}'."
                 ),
                 position: Some(base_offset),
             });
         }
-        Some(remaining.to_string())
+        Some(frame_region.to_string())
     };
 
     Ok((excluding_dims, partition_dims, order_by, frame_clause))
-}
-
-/// Absolute `[start, end)` byte offsets of `s[base..].trim()` within `s`.
-///
-/// Lets a caller slice `s` and its ASCII-uppercased twin (identical byte
-/// offsets) from the same bounds, avoiding the `len()`-subtraction pitfall:
-/// `trim()` strips both ends, so `s.len() - s[base..].trim().len()` skips
-/// the remainder's leading bytes whenever trailing whitespace is present.
-fn trimmed_bounds(s: &str, base: usize) -> (usize, usize) {
-    let raw = &s[base..];
-    let start = base + (raw.len() - raw.trim_start().len());
-    let end = start + raw.trim().len();
-    (start, end)
-}
-
-/// Find "PARTITION BY" (without EXCLUDING) in uppercase text.
-/// Returns byte offset past "BY" (the start of the dims list).
-/// Only matches if NOT followed by EXCLUDING.
-fn find_partition_by(upper_text: &str) -> Option<usize> {
-    let mut search_from = 0;
-    while let Some(pos) = find_keyword_ci(&upper_text[search_from..], "PARTITION") {
-        let abs_pos = search_from + pos;
-        let after_partition = upper_text[abs_pos + 9..].trim_start();
-        if let Some(rest) = after_partition.strip_prefix("BY") {
-            // Word boundary after BY: `_` and non-ASCII bytes continue an
-            // identifier (BY_foo is not the keyword BY).
-            if rest.is_empty() || !is_ident_continuation(rest.as_bytes()[0]) {
-                let rest = rest.trim_start();
-                // Make sure this is NOT PARTITION BY EXCLUDING
-                if rest.starts_with("EXCLUDING")
-                    && (rest.len() == 9 || !is_ident_continuation(rest.as_bytes()[9]))
-                {
-                    // This is PARTITION BY EXCLUDING, skip
-                    search_from = abs_pos + 9;
-                    continue;
-                }
-                // Return offset past "BY"
-                let by_end = upper_text.len() - rest.len();
-                return Some(by_end);
-            }
-        }
-        search_from = abs_pos + 9;
-    }
-    None
-}
-
-/// Find "PARTITION BY EXCLUDING" in uppercase text.
-/// Returns byte offset past "EXCLUDING" (the start of the dims list).
-fn find_partition_by_excluding(upper_text: &str) -> Option<usize> {
-    let mut search_from = 0;
-    while let Some(pos) = find_keyword_ci(&upper_text[search_from..], "PARTITION") {
-        let abs_pos = search_from + pos;
-        let after_partition = upper_text[abs_pos + 9..].trim_start();
-        if let Some(rest) = after_partition.strip_prefix("BY") {
-            // Word boundary after BY / EXCLUDING: `_` and non-ASCII bytes
-            // continue an identifier.
-            if rest.is_empty() || !is_ident_continuation(rest.as_bytes()[0]) {
-                let rest = rest.trim_start();
-                if let Some(rest2) = rest.strip_prefix("EXCLUDING") {
-                    if rest2.is_empty() || !is_ident_continuation(rest2.as_bytes()[0]) {
-                        // Return offset past EXCLUDING
-                        let excluding_end = upper_text.len() - rest2.len();
-                        return Some(excluding_end);
-                    }
-                }
-            }
-        }
-        search_from = abs_pos + 9;
-    }
-    None
-}
-
-/// Find the start of a frame clause keyword (ROWS, RANGE, GROUPS) in uppercase text.
-fn find_frame_start(upper_text: &str) -> Option<usize> {
-    // Try each frame keyword
-    let frame_keywords = ["ROWS", "RANGE", "GROUPS"];
-    let mut earliest: Option<usize> = None;
-    for kw in &frame_keywords {
-        if let Some(pos) = find_keyword_ci(upper_text, kw) {
-            match earliest {
-                None => earliest = Some(pos),
-                Some(e) if pos < e => earliest = Some(pos),
-                _ => {}
-            }
-        }
-    }
-    earliest
 }
 
 /// Sort-modifier parsing context: which clause the `ASC|DESC|NULLS FIRST|LAST`
@@ -528,38 +411,7 @@ pub(super) fn parse_order_by_modifiers(
     Ok((order, nulls))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::trimmed_bounds;
-
-    #[test]
-    fn trimmed_bounds_no_whitespace() {
-        let s = "ORDER BY d";
-        assert_eq!(trimmed_bounds(s, 0), (0, s.len()));
-    }
-
-    #[test]
-    fn trimmed_bounds_leading_only() {
-        // base points before "   ORDER BY d"; start skips the 3 leading
-        // spaces, end is the full string length (no trailing ws).
-        let s = "xyz   ORDER BY d";
-        let (start, end) = trimmed_bounds(s, 3);
-        assert_eq!(&s[start..end], "ORDER BY d");
-    }
-
-    #[test]
-    fn trimmed_bounds_leading_and_trailing() {
-        // The old `len() - remaining.len()` start computation skipped the
-        // two trailing spaces' worth of leading bytes here (PR #50 review).
-        let s = "xyz  ORDER BY d  ";
-        let (start, end) = trimmed_bounds(s, 3);
-        assert_eq!(&s[start..end], "ORDER BY d");
-    }
-
-    #[test]
-    fn trimmed_bounds_all_whitespace_suffix() {
-        let s = "abc   ";
-        let (start, end) = trimmed_bounds(s, 3);
-        assert_eq!(start, end, "empty trimmed remainder -> zero-length span");
-    }
-}
+// The `trimmed_bounds` helper and its tests were retired with the §6.1 OVER
+// migration: dims/order regions are now sliced between keyword TOKEN offsets
+// (`content[dims_start..dims_end]`), which are exact by construction, so the
+// uppercase-twin offset bookkeeping the helper served is gone.


### PR DESCRIPTION
Fifth clause onto the shared token cursor (TABLES #100, RELATIONSHIPS #101, DIMENSIONS/FACTS entries #102, METRICS #103). Behaviour-preserving under the same oracle; one clause per phase.

Note: the P-3 OVER-clause correctness hardening (ORDER-without-adjacent-BY, silent frame, frame-keyword-name) already landed in the earlier correctness PR — so this phase is a pure **structural** migration of `window.rs`, not a bug fix. The P-3 guards are preserved exactly.

## What changed

`src/body_parser/window.rs` — the OVER-clause parser is now token-sequential:

- `OVER` is the first **depth-0** keyword token (new cursor helper `find_kw_depth0`, so an `OVER` inside the window function's own parentheses is inert). The function-call and OVER-body parentheses are consumed with `take_parens`.
- Inside the OVER body, the `PARTITION BY [EXCLUDING]` / `ORDER BY` / frame boundaries are keyword tokens: `find_kw_seq` for `PARTITION BY`, and a new `find_any_kw` helper for the earliest of `ORDER` / `ROWS` / `RANGE` / `GROUPS`. The dim and ORDER-BY regions are sliced between token offsets — which is exact by construction, so the uppercase-twin offset bookkeeping and the `trimmed_bounds` / `find_partition_by` / `find_partition_by_excluding` / `find_frame_start` helpers are all deleted.
- The **P-3 hardening is preserved exactly**: `ORDER` must be immediately followed by `BY`, no stray text before `ORDER`, `ORDER BY` must yield ≥1 entry, and the frame region must start with `ROWS`/`RANGE`/`GROUPS`. All OVER error messages and carets — including the pinned `Expected '(' after OVER` position (byte 18 in `test_over_clause_error_position_is_expression_relative`) — are unchanged. The identifier-aware ORDER-BY entry loop is extracted into `parse_order_by_entries` (keeps `parse_over_content` under the 100-line clippy limit; `parse_order_by_modifiers` / `OrderModifierContext` are unchanged).

`find_keyword_ci` and `find_depth0_keyword` were the window layer's last callers and are **deleted** from `scan.rs`. Net −193 lines.

## Verification (full local gate)

- `cargo test` — body_parser tests + parse / roundtrip / create-front-door / **output** proptests (the window/semi-additive output oracle) all pass.
- `cargo clippy -- -D warnings` + `cargo fmt --check`.
- `just build` + `just test-sql` — **71/71 sqllogictest files pass** (incl. `phase48_window_metrics`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCukus8YB1Qf853dXguuia)_