### PR TITLE
§6.1 (phase 6): migrate MATERIALIZATIONS clause onto the lexer/cursor

### DIFF
--- a/src/body_parser/cursor.rs
+++ b/src/body_parser/cursor.rs
@@ -160,6 +160,28 @@ impl<'a> Cursor<'a> {
         None
     }
 
+    /// Every bare keyword token at/after the cursor that equals ANY of `kws`
+    /// AND sits at bracket-depth 0, in source order. The depth-0 tiling variant
+    /// of [`Cursor::find_any_kw`]: it locates a fixed set of sub-clause
+    /// keywords (`TABLE` / `DIMENSIONS` / `METRICS`) that partition a body, so a
+    /// keyword-like name nested inside one of their `(...)` lists is inert.
+    /// Replaces the ad-hoc quote+depth `find_sub_keyword_positions` scan
+    /// (code-review 2026-07-11). All three bracket kinds count as nesting,
+    /// matching [`Cursor::find_kw_depth0`].
+    pub(super) fn find_all_kw_depth0(&self, kws: &[&str]) -> Vec<Token> {
+        let mut depth = 0i32;
+        let mut out = Vec::new();
+        for &t in &self.toks[self.idx..] {
+            match t.kind {
+                TokenKind::Symbol(b'(' | b'[' | b'{') => depth += 1,
+                TokenKind::Symbol(b')' | b']' | b'}') => depth -= 1,
+                _ if depth == 0 && kws.iter().any(|kw| self.is_kw(t, kw)) => out.push(t),
+                _ => {}
+            }
+        }
+        out
+    }
+
     /// The first token at/after the cursor that is a bare keyword equal to ANY
     /// of `kws`. Used to locate the earliest of several possible boundary
     /// keywords (e.g. `ORDER` / `ROWS` / `RANGE` / `GROUPS`).
@@ -280,6 +302,21 @@ mod tests {
         assert!(Cursor::new("\"NON\" ADDITIVE BY", 0)
             .find_kw_seq(&["NON", "ADDITIVE", "BY"])
             .is_none());
+    }
+
+    #[test]
+    fn find_all_kw_depth0_tiles_and_ignores_nested_and_quoted() {
+        // TABLE / DIMENSIONS / METRICS at depth 0 are found in order; a
+        // keyword-like *name* nested inside a (...) list (`METRICS` as a dim
+        // name at depth 1) or hidden inside a quoted ident is inert.
+        let c = Cursor::new(
+            "TABLE t, DIMENSIONS (metrics, \"TABLE\"), METRICS (total)",
+            0,
+        );
+        let kws = c.find_all_kw_depth0(&["TABLE", "DIMENSIONS", "METRICS"]);
+        let texts: Vec<&str> = kws.iter().map(|&t| c.text(t)).collect();
+        // The depth-0 `metrics` name and the quoted `"TABLE"` do not appear.
+        assert_eq!(texts, vec!["TABLE", "DIMENSIONS", "METRICS"]);
     }
 
     #[test]

--- a/src/body_parser/cursor.rs
+++ b/src/body_parser/cursor.rs
@@ -315,7 +315,7 @@ mod tests {
         );
         let kws = c.find_all_kw_depth0(&["TABLE", "DIMENSIONS", "METRICS"]);
         let texts: Vec<&str> = kws.iter().map(|&t| c.text(t)).collect();
-        // The depth-0 `metrics` name and the quoted `"TABLE"` do not appear.
+        // The nested (depth-1) `metrics` name and the quoted `"TABLE"` do not appear.
         assert_eq!(texts, vec!["TABLE", "DIMENSIONS", "METRICS"]);
     }
 

--- a/src/body_parser/materializations.rs
+++ b/src/body_parser/materializations.rs
@@ -13,6 +13,7 @@
 //! [`split_at_depth0_commas`] unchanged.
 
 use super::cursor::Cursor;
+use super::lexer::TokenKind;
 use super::split_at_depth0_commas;
 use crate::errors::ParseError;
 use crate::model::Materialization;
@@ -62,6 +63,24 @@ fn parse_single_materialization_entry(
         });
     }
     let name_tok = cur.bump().expect("peek_is_value guaranteed a token");
+
+    // An unterminated `"..."` / `'...'` lexes as a single token spanning the
+    // rest of the entry, so without this guard it would be swallowed as the
+    // `name` and surface a misleading "Expected 'AS' after name '<whole entry>'"
+    // error. Reject it up front — matching how every sibling clause (TABLES via
+    // the token kind, entries/metrics via `unterminated_quote_error`) handles an
+    // orphan quote (PR #105 review).
+    if let TokenKind::Unterminated { ident } = name_tok.kind {
+        let noun = if ident {
+            "Unterminated quoted identifier"
+        } else {
+            "Unterminated string literal"
+        };
+        return Err(cur.err(
+            name_tok.start,
+            format!("{noun} in materialization entry '{entry}'."),
+        ));
+    }
     let name = cur.text(name_tok);
 
     // Expect `AS` immediately after the name (only whitespace between the two

--- a/src/body_parser/materializations.rs
+++ b/src/body_parser/materializations.rs
@@ -43,9 +43,12 @@ fn parse_single_materialization_entry(
     let entry = entry.trim();
     let mut cur = Cursor::new(entry, entry_offset);
 
-    // The name is the first token, which must be an identifier (bare or
-    // quoted) — not punctuation. A quoted name keeps its quotes and may contain
-    // whitespace (`"my mat"`), since it is one token now rather than a
+    // The name is the first token, which must be a value token — a bare or
+    // quoted identifier, or a string literal (`peek_is_value`) — rather than
+    // punctuation. This mirrors the retired first-whitespace scan, which also
+    // took a leading `'string'` verbatim as the name; only a leading symbol is
+    // rejected here as "missing name". A quoted name keeps its quotes and may
+    // contain whitespace (`"my mat"`), since it is one token now rather than a
     // first-whitespace split.
     if !cur.peek_is_value() {
         let message = if cur.peek().is_none() {

--- a/src/body_parser/materializations.rs
+++ b/src/body_parser/materializations.rs
@@ -1,6 +1,18 @@
 //! MATERIALIZATIONS clause parsing.
+//!
+//! §6.1 (phase 6, code-review 2026-07-11): the entry structure — the `name`,
+//! the `AS`, the parenthesized sub-body, and the depth-0 TABLE / DIMENSIONS /
+//! METRICS keyword scan — is parsed on the shared [`Cursor`]/lexer. Keyword,
+//! `AS`-boundary, and paren detection are now quote- and depth-aware by
+//! construction: a `TABLE`/`METRICS`/`(`/`)` inside a `"quoted"` / `'string'`
+//! token is inert, a keyword-like name nested inside a DIMENSIONS/METRICS list
+//! (depth > 0) does not split the sub-body, and `ASx` is a single ident token
+//! (never the `AS` keyword). This replaces the `split_first_token` /
+//! `extract_paren_content` / local `find_sub_keyword_positions` byte scans. The
+//! comma-split into entries and into per-list names is delegated to the shared
+//! [`split_at_depth0_commas`] unchanged.
 
-use super::scan::{extract_paren_content, is_ident_continuation, split_first_token, QuoteState};
+use super::cursor::Cursor;
 use super::split_at_depth0_commas;
 use crate::errors::ParseError;
 use crate::model::Materialization;
@@ -29,90 +41,92 @@ fn parse_single_materialization_entry(
     entry_offset: usize,
 ) -> Result<Materialization, ParseError> {
     let entry = entry.trim();
-    if entry.is_empty() {
+    let mut cur = Cursor::new(entry, entry_offset);
+
+    // The name is the first token, which must be an identifier (bare or
+    // quoted) — not punctuation. A quoted name keeps its quotes and may contain
+    // whitespace (`"my mat"`), since it is one token now rather than a
+    // first-whitespace split.
+    if !cur.peek_is_value() {
+        let message = if cur.peek().is_none() {
+            "Empty entry in MATERIALIZATIONS clause.".to_string()
+        } else {
+            "Expected materialization name in MATERIALIZATIONS entry.".to_string()
+        };
         return Err(ParseError {
-            message: "Empty entry in MATERIALIZATIONS clause.".to_string(),
+            message,
             position: Some(entry_offset),
         });
     }
+    let name_tok = cur.bump().expect("peek_is_value guaranteed a token");
+    let name = cur.text(name_tok);
 
-    // Extract name before "AS"
-    let (name, rest) = split_first_token(entry);
-    if name.is_empty() {
-        return Err(ParseError {
-            message: "Expected materialization name in MATERIALIZATIONS entry.".to_string(),
-            position: Some(entry_offset),
-        });
-    }
-    let rest = rest.trim();
-
-    // Expect "AS", with a trailing word boundary — `AS(...)` is legal
-    // (punctuation boundary) but `ASx` is not (PR #50 review).
-    let as_ok = rest.get(..2).is_some_and(|s| s.eq_ignore_ascii_case("AS"))
-        && (rest.len() == 2 || !is_ident_continuation(rest.as_bytes()[2]));
+    // Expect `AS` immediately after the name (only whitespace between the two
+    // tokens). `AS(...)` is legal — `(` is a separate token — while `ASx` is a
+    // single `ASx` ident token that is not the `AS` keyword (PR #50 review).
+    let as_ok = cur.peek().is_some_and(|t| cur.is_kw(t, "AS"));
     if !as_ok {
-        return Err(ParseError {
-            message: format!(
+        return Err(cur.err(
+            name_tok.end,
+            format!(
                 "Expected 'AS' after materialization name '{name}' in MATERIALIZATIONS clause."
             ),
-            position: Some(entry_offset + name.len()),
-        });
+        ));
     }
-    let after_as = rest[2..].trim();
+    cur.bump(); // consume AS
 
-    // Expect parenthesized sub-body: (TABLE ..., DIMENSIONS (...), METRICS (...))
-    if !after_as.starts_with('(') {
+    // Expect the parenthesized sub-body: (TABLE ..., DIMENSIONS (...), METRICS (...)).
+    if !cur.peek_is_symbol(b'(') {
         return Err(ParseError {
             message: format!("Expected '(' after 'AS' for materialization '{name}'."),
             position: None,
         });
     }
-    // Find matching closing paren — via the shared quote-aware extractor, so
-    // a ')' inside a quoted identifier or string cannot close the sub-body
-    // early (PA-6).
-    let sub_body = extract_paren_content(after_as).ok_or_else(|| ParseError {
-        message: format!("Unclosed '(' for materialization '{name}'."),
-        position: None,
-    })?;
+    // A `)` inside a quoted identifier or string is part of that one token, so
+    // it cannot close the sub-body early (PA-6).
+    let Some(sub_body) = cur.take_parens() else {
+        return Err(ParseError {
+            message: format!("Unclosed '(' for materialization '{name}'."),
+            position: None,
+        });
+    };
 
-    // Parse sub-body keywords: TABLE, DIMENSIONS, METRICS
+    // Locate the TABLE / DIMENSIONS / METRICS sub-keywords at depth 0 (outside
+    // any nested `(...)` list) and outside quotes, in order. Each keyword's
+    // content runs from just past it to the start of the next keyword (or the
+    // end of the sub-body) — the same tiling the retired
+    // `find_sub_keyword_positions` produced, now quote-aware by construction.
+    let sub = Cursor::new(sub_body, 0);
+    let kw_toks = sub.find_all_kw_depth0(&["TABLE", "DIMENSIONS", "METRICS"]);
+
     let mut table_name: Option<String> = None;
     let mut dim_names: Vec<String> = Vec::new();
     let mut met_names: Vec<String> = Vec::new();
 
-    // Scan for keyword positions (case-insensitive)
-    let sub_upper = sub_body.to_ascii_uppercase();
-    let kw_positions = find_sub_keyword_positions(&sub_upper);
-
-    for (i, &(kw, start)) in kw_positions.iter().enumerate() {
-        let end = if i + 1 < kw_positions.len() {
-            kw_positions[i + 1].1
+    for (i, &kw_tok) in kw_toks.iter().enumerate() {
+        let end = if i + 1 < kw_toks.len() {
+            kw_toks[i + 1].start
         } else {
             sub_body.len()
         };
-        let content = sub_body[start + kw.len()..end].trim();
-        // Strip trailing comma
+        let content = sub_body[kw_tok.end..end].trim();
+        // Strip a single trailing comma (the separator to the next sub-clause).
         let content = content.strip_suffix(',').unwrap_or(content).trim();
 
-        match kw {
-            "TABLE" => {
-                if content.is_empty() {
-                    return Err(ParseError {
-                        message: format!(
-                            "Materialization '{name}': TABLE sub-clause has no table name."
-                        ),
-                        position: None,
-                    });
-                }
-                table_name = Some(content.to_string());
+        if sub.is_kw(kw_tok, "TABLE") {
+            if content.is_empty() {
+                return Err(ParseError {
+                    message: format!(
+                        "Materialization '{name}': TABLE sub-clause has no table name."
+                    ),
+                    position: None,
+                });
             }
-            "DIMENSIONS" => {
-                dim_names = extract_paren_list(content)?;
-            }
-            "METRICS" => {
-                met_names = extract_paren_list(content)?;
-            }
-            _ => {}
+            table_name = Some(content.to_string());
+        } else if sub.is_kw(kw_tok, "DIMENSIONS") {
+            dim_names = extract_paren_list(content)?;
+        } else if sub.is_kw(kw_tok, "METRICS") {
+            met_names = extract_paren_list(content)?;
         }
     }
 
@@ -138,59 +152,20 @@ fn parse_single_materialization_entry(
     })
 }
 
-/// Find positions of TABLE, DIMENSIONS, METRICS keywords in the uppercased
-/// sub-body. Returns (keyword, `byte_offset`) pairs sorted by position.
-///
-/// Matches only at depth 0 and outside quoted regions (PA-6): a
-/// dimension/metric name inside a nested `(...)` list, or keyword text
-/// inside `'...'` / `"..."`, must not split the sub-body. The uppercased
-/// copy has identical byte offsets to the raw text (ASCII-only fold), so
-/// quote tracking over it is sound.
-fn find_sub_keyword_positions(upper: &str) -> Vec<(&'static str, usize)> {
-    let keywords: &[&str] = &["TABLE", "DIMENSIONS", "METRICS"];
-    let bytes = upper.as_bytes();
-    let mut positions = Vec::new();
-    let mut st = QuoteState::default();
-    let mut depth: i32 = 0;
-    let mut i = 0;
-    while i < bytes.len() {
-        let (next, live) = st.step(bytes, i);
-        if live {
-            match bytes[i] {
-                b'(' | b'[' | b'{' => depth += 1,
-                b')' | b']' | b'}' => depth -= 1,
-                _ => {}
-            }
-            if depth == 0 {
-                for &kw in keywords {
-                    let kb = kw.as_bytes();
-                    if i + kb.len() <= bytes.len() && &bytes[i..i + kb.len()] == kb {
-                        let before_ok = i == 0 || !is_ident_continuation(bytes[i - 1]);
-                        let after_pos = i + kb.len();
-                        let after_ok =
-                            after_pos >= bytes.len() || !is_ident_continuation(bytes[after_pos]);
-                        if before_ok && after_ok {
-                            positions.push((kw, i));
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        i = next;
-    }
-    positions
-}
-
 /// Extract a parenthesized comma-separated name list: `(name1, name2, ...)`.
-/// Strips whitespace from each name.
+/// Strips whitespace from each name. A bare, unparenthesized `content` is
+/// treated as a single-element list (unchanged tolerance from the pre-cursor
+/// scanner).
 fn extract_paren_list(content: &str) -> Result<Vec<String>, ParseError> {
     let content = content.trim();
     if content.is_empty() {
         return Ok(Vec::new());
     }
     let inner = if content.starts_with('(') {
-        extract_paren_content(content).ok_or_else(|| ParseError {
+        // Quote-aware balanced `(...)`: a `)` inside a string / quoted ident
+        // cannot close the list early (PA-6).
+        let mut c = Cursor::new(content, 0);
+        c.take_parens().ok_or_else(|| ParseError {
             message: "Unclosed parenthesis in MATERIALIZATIONS sub-clause.".to_string(),
             position: None,
         })?

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -1848,6 +1848,49 @@ mod tests {
     }
 
     #[test]
+    fn parse_materializations_unquoted_keyword_name_nested_not_a_subkeyword() {
+        // §6.1 phase 6: a *bare* dimension named like a sub-keyword (`metrics`)
+        // sits at bracket-depth 1 inside DIMENSIONS (...), so the depth-0
+        // TABLE/DIMENSIONS/METRICS scan must not treat it as the METRICS
+        // sub-clause and split the sub-body there.
+        let result =
+            parse_materializations_clause("m1 AS (TABLE t, DIMENSIONS (metrics, region))", 0)
+                .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].table, "t");
+        assert_eq!(result[0].dimensions, vec!["metrics", "region"]);
+        assert!(
+            result[0].metrics.is_empty(),
+            "the nested `metrics` name must not become a METRICS sub-clause"
+        );
+    }
+
+    #[test]
+    fn parse_materializations_quoted_name_with_space() {
+        // §6.1 phase 6: the name is the first TOKEN, so a double-quoted name
+        // containing whitespace stays whole (`"my mat"`) instead of splitting
+        // at the interior space the way the old first-whitespace scan did.
+        let result =
+            parse_materializations_clause("\"my mat\" AS (TABLE t, DIMENSIONS (region))", 0)
+                .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "\"my mat\"");
+        assert_eq!(result[0].table, "t");
+        assert_eq!(result[0].dimensions, vec!["region"]);
+    }
+
+    #[test]
+    fn parse_materializations_leading_symbol_is_missing_name() {
+        // §6.1 phase 6: an entry whose first token is punctuation has no name.
+        let err = parse_materializations_clause("(TABLE t, DIMENSIONS (region))", 0).unwrap_err();
+        assert!(
+            err.message.contains("Expected materialization name"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
     fn parse_relationships_error_missing_name() {
         // Entry starts with "AS" — no preceding relationship name
         let result = parse_relationships_clause("AS o(customer_id) REFERENCES c", 0);

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -1891,6 +1891,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_materializations_unterminated_name_rejected_cleanly() {
+        // PR #105 review: an unterminated quoted-identifier name lexes as one
+        // token spanning the whole entry; reject it up front (like every sibling
+        // clause) instead of embedding the entry in an "Expected 'AS'" error.
+        let err = parse_materializations_clause("\"unclosed AS (TABLE t, DIMENSIONS (r))", 0)
+            .unwrap_err();
+        assert!(
+            err.message.contains("Unterminated quoted identifier"),
+            "got: {}",
+            err.message
+        );
+        // An unterminated string literal in the name slot is distinguished.
+        let err =
+            parse_materializations_clause("'unclosed AS (TABLE t, DIMENSIONS (r))", 0).unwrap_err();
+        assert!(
+            err.message.contains("Unterminated string literal"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
     fn parse_relationships_error_missing_name() {
         // Entry starts with "AS" — no preceding relationship name
         let result = parse_relationships_clause("AS o(customer_id) REFERENCES c", 0);

--- a/src/body_parser/scan.rs
+++ b/src/body_parser/scan.rs
@@ -134,15 +134,11 @@ pub(crate) fn split_at_depth0_commas(body: &str) -> Vec<(usize, &str)> {
     entries
 }
 
-/// Split `s` at the first ASCII whitespace, returning `(first_token, rest)`.
-/// If no whitespace found, returns `(s, "")`.
-pub(super) fn split_first_token(s: &str) -> (&str, &str) {
-    if let Some(pos) = s.find(|c: char| c.is_ascii_whitespace()) {
-        (&s[..pos], &s[pos..])
-    } else {
-        (s, "")
-    }
-}
+// `split_first_token` (first-whitespace split for the MATERIALIZATIONS name)
+// was retired in the §6.1 MATERIALIZATIONS migration: the name is now the first
+// TOKEN via `super::cursor::Cursor`, so a quoted name containing whitespace
+// (`"my mat"`) stays one identifier instead of splitting mid-quote
+// (code-review 2026-07-11).
 
 /// Phase 68 B1 (D-08): split a qualified identifier at the FIRST dot that
 /// falls OUTSIDE a double-quoted region. Returns
@@ -233,17 +229,17 @@ pub(super) fn is_quoting_balanced(s: &str) -> bool {
     !in_quote
 }
 
-/// Extract content inside the outermost `(...)` of `s` (which must start with `(`).
-/// Returns the content between the first `(` and its matching `)`, or `None` if unbalanced.
-/// Quote-aware: brackets inside `'...'` string literals and `"..."` quoted
-/// identifiers are inert (PA-6).
-pub(super) fn extract_paren_content(s: &str) -> Option<&str> {
-    extract_paren_prefix(s).map(|(inner, _)| inner)
-}
+// `extract_paren_content` (content between the first `(` and its matching `)`)
+// was retired in the §6.1 MATERIALIZATIONS migration: the sub-body and each
+// DIMENSIONS/METRICS list are now consumed with `super::cursor::Cursor`'s
+// quote-aware `take_parens` (code-review 2026-07-11). `extract_paren_prefix`
+// stays — the trailing-annotation parser still needs the consumed-byte count.
 
-/// Like [`extract_paren_content`], but also returns the number of bytes consumed
-/// through the matching closing `)` (so a caller can advance past the whole
-/// `(...)` group and inspect what follows). `s` must start with `(`.
+/// Returns the content inside the outermost `(...)` of `s` (which must start
+/// with `(`) plus the number of bytes consumed through the matching closing `)`
+/// (so a caller can advance past the whole `(...)` group and inspect what
+/// follows). Quote-aware: brackets inside `'...'` string literals and `"..."`
+/// quoted identifiers are inert (PA-6). Returns `None` if unbalanced.
 pub(super) fn extract_paren_prefix(s: &str) -> Option<(&str, usize)> {
     let bytes = s.as_bytes();
     if bytes.is_empty() || bytes[0] != b'(' {


### PR DESCRIPTION
## Summary

Phase 6 of the §6.1 incremental lexer + cursor migration (Task #26). Parses each `MATERIALIZATIONS` entry — the name, the `AS`, the parenthesized sub-body, and the depth-0 `TABLE` / `DIMENSIONS` / `METRICS` keyword scan — on the shared `Cursor`/lexer instead of the ad-hoc byte scanners (`split_first_token`, `extract_paren_content`, and the local `find_sub_keyword_positions`).

Keyword, `AS`-boundary, and paren detection are now quote- and depth-aware **by construction**:

- **name is the first token** — a double-quoted name with interior whitespace (`"my mat"`) stays whole instead of splitting mid-quote the way the old first-whitespace scan did;
- **`ASx` is a single ident token**, never the `AS` keyword (no `is_ident_continuation` boundary probe needed);
- a **`)` inside a quoted identifier / string** cannot close the sub-body early (PA-6);
- a **bare dimension/metric named like a sub-keyword** (e.g. `metrics`) nested inside a `DIMENSIONS`/`METRICS` list (depth > 0) no longer splits the sub-body.

## Changes

- **`cursor.rs`**: add `find_all_kw_depth0(&[&str]) -> Vec<Token>` — the depth-0 tiling variant of `find_kw_depth0` that collects every matching keyword token in source order. Replaces the local quote+depth `find_sub_keyword_positions` scan. Unit-tested for the depth-0 + quote-aware guarantee.
- **`materializations.rs`**: rewritten onto the cursor. Entry comma-splitting and per-list name splitting stay on the shared `split_at_depth0_commas`.
- **`scan.rs`**: retire the now-dead `split_first_token` and `extract_paren_content` (both were used only by this clause). `extract_paren_prefix` stays — the trailing-annotation parser still needs its consumed-byte count.
- **`mod.rs`**: new regression tests — quote-aware name with a space, leading-symbol missing-name, unquoted nested keyword-like name.

## Behaviour preservation

All existing `MATERIALIZATIONS` unit tests and sqllogictest coverage are unchanged. The parser-level proptests don't generate `MATERIALIZATIONS`, so the contract is the unit tests + sqllogictest, which all pass. The quote/depth-awareness wins are structural (the lexer makes them free). The only behaviour *changes* are on previously-malformed input (quoted-name-with-space now accepted; leading-symbol / nested-keyword edge cases get cleaner handling), each covered by a new regression test.

## Local gate (all green)

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (1186 unit tests + all integration/proptests)
- `make debug` (extension build) ✅
- `make test_debug` (sqllogictest) ✅ — 71 tests run, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCukus8YB1Qf853dXguuia)_