### PR TITLE
fix(build): stop Windows fmt patch3 hard-failing on the removed stdext block

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -472,21 +472,35 @@ fn patch_duckdb_cpp_for_windows() -> String {
     let patch3_before = "#ifdef _SECURE_SCL\n// Make a checked iterator to avoid MSVC warnings.\ntemplate <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;";
     let patch3_after = "#if 0 // semantic-views patch: stdext::checked_array_iterator removed from modern MSVC STL — force fmt's portable raw-pointer path\n// Make a checked iterator to avoid MSVC warnings.\ntemplate <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;";
 
-    // AR-9: like patch 2, a patch-3 miss is a HARD error. Without it, MSVC
-    // takes fmt's `stdext::checked_array_iterator` branch — removed from modern
-    // MSVC STL — and fails with `error C2653: 'stdext' is not a namespace`.
-    // Fail loudly at the patch site rather than deep in the fmt headers.
+    // AR-9: a patch-3 miss is a HARD error ONLY when the dangerous reference is
+    // still present but has drifted out of `patch3_before`'s exact shape — that
+    // is the case #60 cared about (a silently-unapplied patch shipping a broken
+    // MSVC build). But DuckDB's bundled fmt no longer emits the
+    // `stdext::checked_array_iterator` block at all (it is absent as of the
+    // v1.5.4 amalgamation — `grep` finds zero occurrences of `stdext`), so the
+    // original unconditional hard-fail was a false positive that has kept every
+    // Windows build red since the marker disappeared. Distinguish the two:
+    //   - `patch3_before` present            -> apply the guard flip;
+    //   - `stdext::checked_array_iterator` present but not in that shape
+    //                                        -> the patch drifted: fail loudly;
+    //   - neither present                    -> nothing to neutralize, MSVC
+    //                                           already compiles fmt's portable
+    //                                           `checked_ptr = T*` path: skip.
     let content = if content.contains(patch3_before) {
         content.replace(patch3_before, patch3_after)
-    } else {
+    } else if content.contains("stdext::checked_array_iterator") {
         panic!(
-            "duckdb.cpp Win32 patch 3 FAILED: expected _SECURE_SCL marker not found. The \
-             bundled DuckDB/fmt amalgamation changed shape (most likely a version bump), so \
-             this Windows-only fmt patch no longer applies. Left unpatched, MSVC selects \
-             fmt's removed `stdext::checked_array_iterator` and fails with `error C2653: \
-             'stdext' is not a class or namespace name`. Update `patch3_before` in \
+            "duckdb.cpp Win32 patch 3 FAILED: `stdext::checked_array_iterator` is present but \
+             not in the exact form `patch3_before` matches, so the guard flip was silently \
+             dropped. Left unpatched, MSVC selects fmt's removed \
+             `stdext::checked_array_iterator` and fails with `error C2653: 'stdext' is not a \
+             class or namespace name`. Update `patch3_before` in \
              build.rs::patch_duckdb_cpp_for_windows to match the new amalgamation."
         );
+    } else {
+        // fmt's MSVC checked-iterator block was removed upstream; there is no
+        // `stdext` reference for MSVC to reject. Nothing to patch.
+        content
     };
 
     std::fs::write(&patched, content).expect("failed to write duckdb_patched.cpp to OUT_DIR");


### PR DESCRIPTION
## Problem

`BuildAll.yml` (the full platform matrix that runs on push to `main`) has failed on the **Windows** job for every merge going back to at least 2026-07-12 — 30+ consecutive red runs, long predating the §6.1 parser work. The failure is in `build.rs::patch_duckdb_cpp_for_windows`, "patch 3":

```
build.rs panicked: duckdb.cpp Win32 patch 3 FAILED: expected _SECURE_SCL marker not found.
```

Patch 3 rewrites fmt's MSVC checked-iterator guard so MSVC takes fmt's portable `checked_ptr = T*` path instead of the removed `stdext::checked_array_iterator`. #60 made a patch-3 *miss* a hard panic so a silently-unapplied patch could never ship a broken MSVC build.

## Root cause

DuckDB's bundled fmt in the **v1.5.4** amalgamation (`FMT_VERSION 60102`) no longer emits that block at all. Verified against the pinned amalgamation:

| probe | in `cpp/include/duckdb.cpp` |
|---|---|
| `patch2_before` | present ✅ (patch 2 succeeds) |
| `patch3_before` | absent ❌ |
| `stdext::checked_array_iterator` | **absent entirely** |
| `stdext` / `_SECURE_SCL` / `checked_ptr` | absent |

So the unconditional hard-fail fires on code that was **already removed upstream**. Since `stdext` appears nowhere, there is no `C2653` for MSVC to hit — the unpatched build compiles fmt's portable path directly. That the panic surfaces at patch 3 (not patch 2, whose marker is still present) confirms CI's release amalgamation matches the pinned one. This is what has kept Windows red since `.duckdb-version` moved to v1.5.4 (#48) and #60 turned the now-always-missing marker into a hard error.

## Fix

Distinguish "the patch drifted" (the case #60 cared about) from "there is nothing to patch":

- `patch3_before` present → apply the guard flip, exactly as before;
- `stdext::checked_array_iterator` present but **not** in `patch3_before`'s shape → the patch drifted: **hard-fail** (preserves #60's intent);
- neither present → the block is gone, no `stdext` reference for MSVC to reject → **skip cleanly**.

Windows-only `build.rs` logic; Linux/macOS builds are unaffected.

## Validation note

⚠️ This fix **cannot be validated by this PR's CI**. PR branches run `BuildQuick.yml`, which is Linux-x86_64 only (`exclude_archs` drops `windows_amd64` — "the full matrix runs on main"). The MSVC path is only exercised by `BuildAll.yml` **after merge to `main`**. Confidence here rests on the amalgamation analysis above (the `stdext` block is verifiably absent, so the skipped patch leaves nothing that fails to compile). `build.rs` itself was compile-checked locally via the `SV_SKIP_CPP_BUILD` analysis-only path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCukus8YB1Qf853dXguuia)_