### PR TITLE
§6.1 follow-up: depth-0 keyword scan for metrics AS / USING / NON ADDITIVE BY

### DIFF
--- a/src/body_parser/cursor.rs
+++ b/src/body_parser/cursor.rs
@@ -210,6 +210,37 @@ impl<'a> Cursor<'a> {
             .map(|w| (toks[w], toks[w + kws.len() - 1]))
     }
 
+    /// Like [`Cursor::find_kw_seq`], but only matches a run that starts at
+    /// bracket-depth 0 (not inside any `(...)`/`[...]`/`{...}` group). The
+    /// consecutive keyword tokens have no bracket tokens between them, so if the
+    /// first is at depth 0 the whole run is. Used for `NON ADDITIVE BY`, which
+    /// must be the metric entry's own tail keyword — not a like-named run nested
+    /// inside a preceding `USING (...)` list.
+    pub(super) fn find_kw_seq_depth0(&self, kws: &[&str]) -> Option<(Token, Token)> {
+        let toks = &self.toks[self.idx..];
+        let n = kws.len();
+        if n == 0 || toks.len() < n {
+            return None;
+        }
+        let mut depth = 0i32;
+        for w in 0..=toks.len() - n {
+            if depth == 0
+                && kws
+                    .iter()
+                    .enumerate()
+                    .all(|(k, kw)| self.is_kw(toks[w + k], kw))
+            {
+                return Some((toks[w], toks[w + n - 1]));
+            }
+            match toks[w].kind {
+                TokenKind::Symbol(b'(' | b'[' | b'{') => depth += 1,
+                TokenKind::Symbol(b')' | b']' | b'}') => depth -= 1,
+                _ => {}
+            }
+        }
+        None
+    }
+
     /// If the token stream ends in an unterminated `"`/`'` region, return
     /// `Some(true)` for a quoted identifier (`"..."`) or `Some(false)` for a
     /// string literal (`'...'`). The lexer emits at most one
@@ -332,6 +363,24 @@ mod tests {
         let texts: Vec<&str> = kws.iter().map(|&t| c.text(t)).collect();
         // The nested (depth-1) `metrics` name and the quoted `"TABLE"` do not appear.
         assert_eq!(texts, vec!["TABLE", "DIMENSIONS", "METRICS"]);
+    }
+
+    #[test]
+    fn find_kw_seq_depth0_ignores_nested_run() {
+        // A `NON ADDITIVE BY` run nested inside a preceding `(...)` is inert;
+        // the depth-0 run at the tail is the match.
+        let c = Cursor::new("m USING (NON ADDITIVE BY) NON ADDITIVE BY (d)", 0);
+        let (first, last) = c.find_kw_seq_depth0(&["NON", "ADDITIVE", "BY"]).unwrap();
+        // The match is the depth-0 run, which starts after the `)` at byte 26.
+        assert_eq!(first.start, 26);
+        assert_eq!(c.text(first), "NON");
+        assert_eq!(c.text(last), "BY");
+        // With ONLY a nested run, there is no depth-0 match.
+        let c2 = Cursor::new("m USING (NON ADDITIVE BY)", 0);
+        assert!(c2.find_kw_seq_depth0(&["NON", "ADDITIVE", "BY"]).is_none());
+        // A plain depth-0 run still matches (parity with find_kw_seq).
+        let c3 = Cursor::new("revenue NON ADDITIVE BY date", 0);
+        assert!(c3.find_kw_seq_depth0(&["NON", "ADDITIVE", "BY"]).is_some());
     }
 
     #[test]

--- a/src/body_parser/metrics.rs
+++ b/src/body_parser/metrics.rs
@@ -135,8 +135,10 @@ fn parse_single_metric_entry(entry: &str, entry_offset: usize) -> Result<ParsedM
         entry_offset + byte_offset_within(entry, entry_after_access),
     );
 
-    // Split the entry at the first `AS` keyword token.
-    let Some(as_tok) = cur.find_kw("AS") else {
+    // Split the entry at the first `AS` keyword token AT DEPTH 0 — an `AS`
+    // nested inside a preceding `USING (a AS b)` list is inert, so the split
+    // lands on the structural `AS` before the expression (#103 review).
+    let Some(as_tok) = cur.find_kw_depth0("AS") else {
         return Err(ParseError {
             message: format!(
                 "Expected 'AS' keyword in metric entry '{entry}'. Form: 'alias.name AS expr' or 'name AS expr'.",
@@ -182,7 +184,7 @@ fn parse_single_metric_entry(entry: &str, entry_offset: usize) -> Result<ParsedM
     let mut non_additive_by: Vec<NonAdditiveDim> = Vec::new();
     let before_na = {
         let mut nab_cur = Cursor::new(before_as, before_base);
-        if let Some((na_first, na_last)) = nab_cur.find_kw_seq(&["NON", "ADDITIVE", "BY"]) {
+        if let Some((na_first, na_last)) = nab_cur.find_kw_seq_depth0(&["NON", "ADDITIVE", "BY"]) {
             nab_cur.advance_past_byte(na_last.end);
             // The token where `(` is expected; caret recovered from it (P-4).
             let after_na_abs = nab_cur.abs(nab_cur.byte_pos());
@@ -228,7 +230,7 @@ fn parse_single_metric_entry(entry: &str, entry_offset: usize) -> Result<ParsedM
     let final_name_portion = {
         let na_base = entry_offset + byte_offset_within(entry, before_na);
         let mut using_cur = Cursor::new(before_na, na_base);
-        if let Some(using_tok) = using_cur.find_kw("USING") {
+        if let Some(using_tok) = using_cur.find_kw_depth0("USING") {
             using_cur.advance_past_byte(using_tok.end);
             let after_using_abs = using_cur.abs(using_cur.byte_pos());
             if !using_cur.peek_is_symbol(b'(') {

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -1380,6 +1380,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_metrics_using_nested_as_splits_at_structural_as() {
+        // #103 review follow-up: an `AS` token nested inside the `USING (...)`
+        // list must not be mistaken for the structural `AS`. The split now
+        // lands on the depth-0 `AS`, so the expression is the whole `SUM(v)`,
+        // not `b) AS SUM(v)`, and the USING list is `a AS b` verbatim.
+        let result = parse_metrics_clause("s.m USING (a AS b) AS SUM(v)", 0).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].source_alias.as_deref(), Some("s"));
+        assert_eq!(result[0].name, "m");
+        assert_eq!(result[0].expr, "SUM(v)");
+        assert_eq!(result[0].using_relationships, vec!["a AS b"]);
+    }
+
+    #[test]
     fn test_parse_non_additive_dims_dotted_path() {
         // Dotted-path dim_name (D-08 contract extension): `o."my dim"` must be
         // captured as a single identifier including the dot. Two-entry clause


### PR DESCRIPTION
## Summary

Follow-up to the §6.1 lexer/cursor migration (tracked from the PR #103 review). Switches the metric-entry structural keyword searches to **depth-0** so a keyword nested inside a preceding `USING (...)` list can't hijack the split. Previously the scans matched keywords at any paren depth, which meant an `AS`/`USING`/`NON ADDITIVE BY` sitting inside a `USING (...)` argument list could be mistaken for the structural separator and mis-split the metric entry.

## What changed

- **cursor.rs**: added `find_kw_seq_depth0` (+ unit test)
- **metrics.rs**: `AS` and `USING` now use `find_kw_depth0`; `NON ADDITIVE BY` uses `find_kw_seq_depth0`
- **mod.rs**: regression test — `s.m USING (a AS b) AS SUM(v)` now splits at the structural `AS` instead of erroring on a dangling `(a`

## Behaviour preservation

Behaviour-preserving for all well-formed metrics: the structural `AS` / `USING` / `NON ADDITIVE BY` that delimit a metric entry always live at depth 0, so restricting the scan to depth 0 changes results only for inputs where a keyword was previously matched inside a nested paren group — i.e. exactly the mis-split case this fixes.

## Gate

Full local gate passed:

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `make debug`
- `make test_debug` (71/0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013CgqTTZ7oBHT5QZ46woc4e)_