### PR TITLE
test(concurrent-ddl): force transaction overlap to de-flake the CREATE IF NOT EXISTS race

### DIFF
--- a/test/integration/test_concurrent_ddl.py
+++ b/test/integration/test_concurrent_ddl.py
@@ -111,18 +111,6 @@ def worker(thread_conn, sql: str, result: WorkerResult, staged: threading.Barrie
         result.ok = True
     except Exception as exc:  # noqa: BLE001 - we want every error type
         result.error = exc
-        # If we failed before reaching the barrier — e.g. the PK conflict
-        # surfaced at INSERT-time rather than the expected COMMIT-time (a shape
-        # the write-race suite documents) — abort the barrier so a peer that
-        # already staged unblocks immediately instead of waiting out the full
-        # timeout. abort() on an already-released barrier is a harmless no-op,
-        # so the normal one-loser-at-COMMIT path is unaffected. Then roll back
-        # so no aborted/open transaction lingers on this connection.
-        staged.abort()
-        try:
-            thread_conn.execute("ROLLBACK")
-        except Exception:  # noqa: BLE001 - txn already aborted / none active
-            pass
 
 
 def test_concurrent_create_serializes() -> bool:

--- a/test/integration/test_concurrent_ddl.py
+++ b/test/integration/test_concurrent_ddl.py
@@ -111,6 +111,18 @@ def worker(thread_conn, sql: str, result: WorkerResult, staged: threading.Barrie
         result.ok = True
     except Exception as exc:  # noqa: BLE001 - we want every error type
         result.error = exc
+        # If we failed before reaching the barrier — e.g. the PK conflict
+        # surfaced at INSERT-time rather than the expected COMMIT-time (a shape
+        # the write-race suite documents) — abort the barrier so a peer that
+        # already staged unblocks immediately instead of waiting out the full
+        # timeout. abort() on an already-released barrier is a harmless no-op,
+        # so the normal one-loser-at-COMMIT path is unaffected. Then roll back
+        # so no aborted/open transaction lingers on this connection.
+        staged.abort()
+        try:
+            thread_conn.execute("ROLLBACK")
+        except Exception:  # noqa: BLE001 - txn already aborted / none active
+            pass
 
 
 def test_concurrent_create_serializes() -> bool:

--- a/test/integration/test_concurrent_ddl.py
+++ b/test/integration/test_concurrent_ddl.py
@@ -81,18 +81,33 @@ class WorkerResult:
         self.error: Exception | None = None
 
 
-def worker(thread_conn, sql: str, result: WorkerResult, gate: threading.Event) -> None:
-    # Both threads block at the gate before issuing their statement so they
-    # race the PK constraint check. The thread-local DuckDB connection
-    # (obtained via .cursor()) shares the underlying database instance
-    # with the master and the other worker, so both inserts hit the same
-    # `semantic_layer._definitions` table simultaneously. The PK constraint
-    # serializes them: one wins, the other gets a constraint-violation
-    # error (plain CREATE) or silently no-ops (CREATE IF NOT EXISTS via
-    # INSERT OR IGNORE).
-    gate.wait()
+def worker(thread_conn, sql: str, result: WorkerResult, staged: threading.Barrier) -> None:
+    # Force the two transactions to OVERLAP deterministically rather than
+    # leaving it to thread-scheduling luck.
+    #
+    # Each worker opens an explicit transaction, issues its CREATE (which
+    # parser_override rewrites to an INSERT [OR IGNORE] against
+    # `semantic_layer._definitions`), and only THEN waits on the shared
+    # barrier. Both transactions take their MVCC snapshot at BEGIN — before
+    # either has committed — so both see the target name absent and both stage
+    # the INSERT. The barrier holds every worker at the post-INSERT point until
+    # all have staged, so no COMMIT can land before the other's snapshot is
+    # fixed: the first COMMIT wins and the second necessarily hits DuckDB's
+    # primary-key write-write conflict. That makes "exactly one success, one
+    # failure" deterministic.
+    #
+    # The previous autocommit form (no BEGIN, a plain Event gate) could let the
+    # threads serialize cleanly — one CREATE fully committing before the other
+    # took its snapshot. Plain CREATE still errored then (its committed-state
+    # guard saw the row), but CREATE IF NOT EXISTS silently no-opped
+    # (INSERT OR IGNORE saw the row) → two successes, and the test flaked.
     try:
+        thread_conn.execute("BEGIN TRANSACTION")
         thread_conn.execute(sql)
+        # INSERT is now staged in this transaction's snapshot; release only
+        # once the other worker has staged its INSERT too, so the commits race.
+        staged.wait(timeout=20)
+        thread_conn.execute("COMMIT")
         result.ok = True
     except Exception as exc:  # noqa: BLE001 - we want every error type
         result.error = exc
@@ -111,13 +126,12 @@ def test_concurrent_create_serializes() -> bool:
         c1 = master.cursor()
         c2 = master.cursor()
 
-        gate = threading.Event()
+        staged = threading.Barrier(2)
         r1, r2 = WorkerResult(1), WorkerResult(2)
-        t1 = threading.Thread(target=worker, args=(c1, CREATE_SQL, r1, gate))
-        t2 = threading.Thread(target=worker, args=(c2, CREATE_SQL, r2, gate))
+        t1 = threading.Thread(target=worker, args=(c1, CREATE_SQL, r1, staged))
+        t2 = threading.Thread(target=worker, args=(c2, CREATE_SQL, r2, staged))
         t1.start()
         t2.start()
-        gate.set()
         t1.join(timeout=30)
         t2.join(timeout=30)
         if t1.is_alive() or t2.is_alive():
@@ -183,17 +197,12 @@ def test_concurrent_create_if_not_exists_serializes() -> bool:
         c1 = master.cursor()
         c2 = master.cursor()
 
-        gate = threading.Event()
+        staged = threading.Barrier(2)
         r1, r2 = WorkerResult(1), WorkerResult(2)
-        t1 = threading.Thread(
-            target=worker, args=(c1, CREATE_IF_NOT_EXISTS_SQL, r1, gate)
-        )
-        t2 = threading.Thread(
-            target=worker, args=(c2, CREATE_IF_NOT_EXISTS_SQL, r2, gate)
-        )
+        t1 = threading.Thread(target=worker, args=(c1, CREATE_IF_NOT_EXISTS_SQL, r1, staged))
+        t2 = threading.Thread(target=worker, args=(c2, CREATE_IF_NOT_EXISTS_SQL, r2, staged))
         t1.start()
         t2.start()
-        gate.set()
         t1.join(timeout=30)
         t2.join(timeout=30)
         if t1.is_alive() or t2.is_alive():


### PR DESCRIPTION
## Summary

Follow-up to #108. On that PR's build, the `Python integration suites` job failed intermittently in `test/integration/test_concurrent_ddl.py` with `expected exactly 1 success, got 2`. The failure was **unrelated to the #108 parser change** (a re-run on the same commit went green), so #108 was merged and this fixes the underlying flaky test separately.

## Root cause

`test_concurrent_create_if_not_exists_serializes` wants to prove that two concurrent `CREATE SEMANTIC VIEW IF NOT EXISTS` on the same name serialize on the `_definitions(name)` PK → exactly **1 success + 1 failure**.

But the two worker threads issued their CREATE under **autocommit** (no explicit `BEGIN`), and a plain `threading.Event` only released them together — it did **not** force their transactions to *overlap*. When the scheduler let one worker fully commit before the other took its MVCC snapshot, the second `CREATE IF NOT EXISTS` saw the row present and its `INSERT OR IGNORE` cleanly no-opped (a *correct* outcome) → **two successes**, tripping the `len(successes) != 1` assertion. The catalog still held exactly one row; only the success/failure-*count* assertion over-specified one particular interleaving.

The module docstring already claimed the workers *"BEGIN a transaction"* — the code just never did. That mismatch was the bug.

## Fix

Make the code match its own contract. The shared `worker` now opens an explicit transaction, issues its CREATE, and only **then** waits on a `threading.Barrier`. Both transactions snapshot the name as absent before either commits, so the first `COMMIT` wins and the second necessarily hits DuckDB's primary-key write-write conflict — deterministically one success, one failure. The barrier backs both the plain-CREATE and IF-NOT-EXISTS tests, so both now genuinely exercise the concurrent-overlap path. **Assertions are unchanged.**

## Verification

A controlled diagnostic against the debug extension pins each interleaving deterministically:

```
[Case A: SERIALIZED]  w1=ok w2=ok  successes=2
    -> old autocommit test would see 2 successes here (FLAKE: trips exactly-1 assertion)
[Case B: FORCED OVERLAP] w1=err w2=ok  successes=1
    -> loser error: TransactionContext Error: Failed to commit: PRIMARY KEY or UNIQUE
       constraint violation: duplicate key "ine_view"
    -> catalog rows for ine_view: 1  (invariant: exactly 1)
```

The loser's message contains both `ine_view` and `constraint`, so the existing assertion holds; it also matches the commit-time race shape already documented in `test_concurrent_writes_per_call_conn.py`'s `categorise()`. The de-flaked test then passed **50/50** local runs. (On this runner the old form happened to pass 60/60 — the flake is scheduling-dependent, which is why CI, not local looping, was the authoritative repro.)

## Related audit

Swept the other concurrency/timing integration tests for the same over-specified-interleaving pattern:

- **`test_concurrent_writes_per_call_conn.py`** — robust by design: buckets outcomes into documented categories and only fails on `unknown_error`; final-state uses a subset invariant (explicitly avoids exact-interleaving over-specification).
- **`test_concurrent_reads_per_call_conn.py`** — outcome assertions are deterministic (no concurrent writers → identical snapshots); only a 30 s wall-budget serialization guard is timing-sensitive, with generous margin.
- **`test_readonly_load.py`** — daemon-thread watchdog is a hang detector, not an interleaving assertion.
- **`test_multi_db_isolation.py`** (RSS bound) — deliberately loose 500 MB threshold; **`test_chunk_boundary.py`** — timing used for reporting only; **`test_differential.py`** — fixed-seed RNG (deterministic).

No other test shared this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013CgqTTZ7oBHT5QZ46woc4e)_