### PR TITLE
docs(§6.1): record phase 8 decision — blank_sql_comments stays the top-level pre-pass

### DIFF
--- a/src/body_parser/lexer.rs
+++ b/src/body_parser/lexer.rs
@@ -11,17 +11,29 @@
 //! tokens in order, so "text between the name and the constraint" becomes a
 //! visible unexpected token rather than a region silently skipped over.
 //!
-//! ## Scope (grows per phase)
+//! ## Scope
 //!
 //! The token kinds are exactly what the migrated clauses need today:
 //! double-quoted / bare identifiers, single-quoted string literals, and
-//! single-byte symbols. Comment handling still lives upstream in
-//! [`crate::util::blank_sql_comments`] (length-preserving, so byte offsets and
-//! carets stay valid); folding it into the lexer is a later phase, once every
-//! clause parser reads its input through this tokenizer. Numeric and
-//! dollar-quoted literals get their own kinds when a consumer first needs them
-//! distinguished (numbers currently tokenize as bare identifiers, which is
-//! harmless for the identifier-only clauses migrated so far).
+//! single-byte symbols. Comment handling deliberately stays upstream in
+//! [`crate::util::blank_sql_comments`] — §6.1 phase 8 (2026-07-15) evaluated
+//! folding it into this lexer and declined. Blanking is a whole-query,
+//! length-preserving pre-pass shared by statement detection
+//! (`parse::detect`) and the CREATE front door (`parse::rewrite`), neither of
+//! which tokenizes through this lexer, so a fold would not remove the
+//! pre-pass; and this lexer only ever receives already-blanked text, so
+//! comment handling here would be dead code on its own path. Length
+//! preservation is also load-bearing: stored expressions are re-sliced from
+//! raw source and error carets are computed on the blanked text, so offsets
+//! must map 1:1 onto the original bytes (pinned by
+//! `caret_after_in_body_comment_is_honest`) — a lexer that merely skipped
+//! comment tokens would let raw slices re-absorb comment bytes. Revisit only
+//! as part of a universal-front-door refactor in which detect/rewrite also
+//! tokenize through this lexer and every raw-slice consumer reads via a
+//! comment-aware token layer. Numeric and dollar-quoted literals get their
+//! own kinds when a consumer first needs them distinguished (numbers
+//! currently tokenize as bare identifiers, which is harmless for the
+//! identifier-only clauses migrated so far).
 //!
 //! ## UTF-8 safety
 //!

--- a/src/util.rs
+++ b/src/util.rs
@@ -346,6 +346,10 @@ pub fn read_dollar_tag_len(bytes: &[u8], start: usize) -> Option<usize> {
 /// every downstream scanner comment-immune, stops trailing comments being
 /// absorbed into stored expressions (`ALTER ... RENAME TO x -- oops` renamed
 /// to `x -- oops`), and fixes non-nesting block-comment handling (PA-10).
+///
+/// This pre-pass is the settled design, not a stopgap: §6.1 phase 8
+/// (2026-07-15) evaluated folding it into the body-parser lexer and declined
+/// — see the decision record in `crate::body_parser::lexer`'s module docs.
 #[must_use]
 #[allow(clippy::too_many_lines)]
 pub fn blank_sql_comments(input: &str) -> std::borrow::Cow<'_, str> {


### PR DESCRIPTION
Phase 8 ("fold comment handling into the lexer") is resolved as: do not fold.
The lexer.rs module doc promised the fold "once every clause parser reads its
input through this tokenizer", but that precondition can never discharge the
pre-pass: blank_sql_comments is a whole-query, length-preserving pass shared
by parse::detect (statement detection) and parse::rewrite (the CREATE front
door), neither of which is lexer-based, and the lexer itself only ever
receives already-blanked text. Length preservation is load-bearing for
raw-source expression slicing and error-caret offsets (pinned by
caret_after_in_body_comment_is_honest), which a comment-skipping token
stream cannot provide to raw-slice consumers.

This replaces the stale "later phase" promise in the lexer module docs with
the decision rationale, and cross-references it from blank_sql_comments so
the pre-pass reads as settled design rather than a stopgap. §6.1 is complete
with phases 1-7; a universal-front-door refactor (detect/rewrite tokenizing
through the lexer) would be a separately scoped architectural change.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hy5RByfXiPK5w4qwevxsYT