### PR TITLE
Code-review 2026-07-11: §6.1 phase-8 decision + §3 residual cleanup sweep

### DIFF
--- a/src/body_parser/lexer.rs
+++ b/src/body_parser/lexer.rs
@@ -11,17 +11,29 @@
 //! tokens in order, so "text between the name and the constraint" becomes a
 //! visible unexpected token rather than a region silently skipped over.
 //!
-//! ## Scope (grows per phase)
+//! ## Scope
 //!
 //! The token kinds are exactly what the migrated clauses need today:
 //! double-quoted / bare identifiers, single-quoted string literals, and
-//! single-byte symbols. Comment handling still lives upstream in
-//! [`crate::util::blank_sql_comments`] (length-preserving, so byte offsets and
-//! carets stay valid); folding it into the lexer is a later phase, once every
-//! clause parser reads its input through this tokenizer. Numeric and
-//! dollar-quoted literals get their own kinds when a consumer first needs them
-//! distinguished (numbers currently tokenize as bare identifiers, which is
-//! harmless for the identifier-only clauses migrated so far).
+//! single-byte symbols. Comment handling deliberately stays upstream in
+//! [`crate::util::blank_sql_comments`] — §6.1 phase 8 (2026-07-15) evaluated
+//! folding it into this lexer and declined. Blanking is a whole-query,
+//! length-preserving pre-pass shared by statement detection
+//! (`parse::detect`) and the CREATE front door (`parse::rewrite`), neither of
+//! which tokenizes through this lexer, so a fold would not remove the
+//! pre-pass; and this lexer only ever receives already-blanked text, so
+//! comment handling here would be dead code on its own path. Length
+//! preservation is also load-bearing: stored expressions are re-sliced from
+//! raw source and error carets are computed on the blanked text, so offsets
+//! must map 1:1 onto the original bytes (pinned by
+//! `caret_after_in_body_comment_is_honest`) — a lexer that merely skipped
+//! comment tokens would let raw slices re-absorb comment bytes. Revisit only
+//! as part of a universal-front-door refactor in which detect/rewrite also
+//! tokenize through this lexer and every raw-slice consumer reads via a
+//! comment-aware token layer. Numeric and dollar-quoted literals get their
+//! own kinds when a consumer first needs them distinguished (numbers
+//! currently tokenize as bare identifiers, which is harmless for the
+//! identifier-only clauses migrated so far).
 //!
 //! ## UTF-8 safety
 //!

--- a/src/expand/join_resolver.rs
+++ b/src/expand/join_resolver.rs
@@ -6,6 +6,17 @@ use crate::model::{Join, SemanticViewDefinition, TableRef};
 use super::facts::{collect_derived_metric_source_tables, collect_derived_metric_using};
 use super::resolution::{qualify_and_quote_table_ref, quote_ident};
 
+/// Build a role-playing scoped alias in the documented `{table}__{rel}` format.
+///
+/// Both parts must already be lowercased by the caller (aliases and relationship
+/// names are matched case-insensitively via lowercasing at the call sites). This
+/// is the single source of the format so the two producers — this module's
+/// USING-relationship join synthesis and `role_playing::scoped_alias_for` — can
+/// never drift (E-10, code-review 2026-07-11).
+pub(super) fn scoped_join_alias(table_lower: &str, rel_lower: &str) -> String {
+    format!("{table_lower}__{rel_lower}")
+}
+
 /// Synthesize an ON clause from PK/FK column declarations (Phase 26).
 ///
 /// Zips `join.fk_columns` with the referenced table's `pk_columns` to produce
@@ -227,7 +238,7 @@ pub(super) fn resolve_joins_pkfk<'a>(
                 .is_some_and(|n| n.to_ascii_lowercase() == using_rel_lower)
         }) {
             let to_alias = join.table.to_ascii_lowercase();
-            let scoped = format!("{to_alias}__{using_rel_lower}");
+            let scoped = scoped_join_alias(&to_alias, &using_rel_lower);
             if !scoped_joins.iter().any(|(s, _)| *s == scoped) {
                 scoped_joins.push((scoped, join));
             }

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -58,7 +58,8 @@ mod tests_role_playing;
 pub use resolution::{quote_ident, quote_ident_if_needed, quote_table_ref};
 pub use sql_gen::expand;
 pub use types::{
-    DimensionName, ExpandError, FanTrapError, MetricFanTrapError, MetricName, QueryRequest,
+    DimensionName, ExpandError, FactName, FanTrapError, MetricFanTrapError, MetricName,
+    QueryRequest,
 };
 
 // Crate-internal API (used by ddl/show_dims_for_metric.rs under extension feature)

--- a/src/expand/role_playing.rs
+++ b/src/expand/role_playing.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use crate::model::SemanticViewDefinition;
 
 use super::facts::collect_derived_metric_using;
+use super::join_resolver::scoped_join_alias;
 use super::types::ExpandError;
 
 /// Determine which relationships point to a given table alias in the definition.
@@ -119,7 +120,7 @@ pub(super) fn find_using_context(
 
     if using_rels_for_table.len() == 1 {
         // Exactly one USING path disambiguates -> return scoped alias
-        let scoped = format!("{dim_table_lower}__{}", using_rels_for_table[0]);
+        let scoped = scoped_join_alias(&dim_table_lower, &using_rels_for_table[0]);
         Ok(Some(scoped))
     } else if using_rels_for_table.is_empty() && !is_role_playing_target(def, &dim_table_lower) {
         // Multiple inbound relationships but each from a DIFFERENT source

--- a/src/expand/tests_fact_query.rs
+++ b/src/expand/tests_fact_query.rs
@@ -24,7 +24,7 @@ fn multi_table_def() -> SemanticViewDefinition {
 fn test_fact_query_basic() {
     let def = multi_table_def();
     let req = QueryRequest {
-        facts: vec!["net_price".to_string()],
+        facts: vec![FactName::new("net_price")],
         dimensions: vec![DimensionName::new("region")],
         metrics: vec![],
     };
@@ -46,7 +46,7 @@ fn test_fact_query_basic() {
 fn test_fact_query_no_dimensions() {
     let def = multi_table_def();
     let req = QueryRequest {
-        facts: vec!["net_price".to_string()],
+        facts: vec![FactName::new("net_price")],
         dimensions: vec![],
         metrics: vec![],
     };
@@ -75,7 +75,7 @@ fn test_fact_query_inline_facts() {
         .with_fact("line_total", "net_price * li.quantity", "li")
         .with_pkfk_join("li_to_o", "li", "o", &["order_id"], &["id"]);
     let req = QueryRequest {
-        facts: vec!["line_total".to_string()],
+        facts: vec![FactName::new("line_total")],
         dimensions: vec![],
         metrics: vec![],
     };
@@ -91,7 +91,7 @@ fn test_fact_query_inline_facts() {
 fn test_fact_query_unknown_fact() {
     let def = multi_table_def();
     let req = QueryRequest {
-        facts: vec!["nonexistent".to_string()],
+        facts: vec![FactName::new("nonexistent")],
         dimensions: vec![],
         metrics: vec![],
     };
@@ -108,7 +108,7 @@ fn test_fact_query_unknown_fact() {
 fn test_fact_query_duplicate_fact() {
     let def = multi_table_def();
     let req = QueryRequest {
-        facts: vec!["net_price".to_string(), "net_price".to_string()],
+        facts: vec![FactName::new("net_price"), FactName::new("net_price")],
         dimensions: vec![],
         metrics: vec![],
     };
@@ -125,7 +125,7 @@ fn test_fact_query_duplicate_fact() {
 fn test_fact_query_private_fact() {
     let def = multi_table_def().with_private_fact("raw_price", "li.price", "li");
     let req = QueryRequest {
-        facts: vec!["raw_price".to_string()],
+        facts: vec![FactName::new("raw_price")],
         dimensions: vec![],
         metrics: vec![],
     };
@@ -151,7 +151,7 @@ fn test_fact_path_violation() {
         .with_pkfk_join("li_to_o", "li", "o", &["order_id"], &["id"])
         .with_pkfk_join("p_to_o", "p", "o", &["order_id"], &["id"]);
     let req = QueryRequest {
-        facts: vec!["net_price".to_string()],
+        facts: vec![FactName::new("net_price")],
         dimensions: vec![DimensionName::new("pay_status")],
         metrics: vec![],
     };
@@ -177,7 +177,7 @@ fn test_fact_path_valid_linear() {
         .with_pkfk_join("li_to_o", "li", "o", &["order_id"], &["id"])
         .with_pkfk_join("d_to_li", "d", "li", &["line_id"], &["id"]);
     let req = QueryRequest {
-        facts: vec!["detail_val".to_string()],
+        facts: vec![FactName::new("detail_val")],
         dimensions: vec![DimensionName::new("region")],
         metrics: vec![],
     };
@@ -190,7 +190,7 @@ fn test_fact_query_with_output_type() {
     let mut def = multi_table_def();
     def.facts[0].output_type = Some("DECIMAL(10,2)".to_string());
     let req = QueryRequest {
-        facts: vec!["net_price".to_string()],
+        facts: vec![FactName::new("net_price")],
         dimensions: vec![],
         metrics: vec![],
     };

--- a/src/expand/tests_facts_awareness.rs
+++ b/src/expand/tests_facts_awareness.rs
@@ -11,7 +11,7 @@ use crate::expand::test_helpers::{orders_view, TestFixtureExt};
 fn test_facts_metrics_mutual_exclusion() {
     let def = orders_view().with_fact("line_total", "quantity * price", "orders");
     let req = QueryRequest {
-        facts: vec!["line_total".to_string()],
+        facts: vec![FactName::new("line_total")],
         dimensions: vec![],
         metrics: vec![MetricName::new("total_revenue")],
     };
@@ -33,7 +33,7 @@ fn test_facts_metrics_mutual_exclusion() {
 fn test_empty_request_with_facts_is_not_empty() {
     let def = orders_view().with_fact("line_total", "quantity * price", "orders");
     let req = QueryRequest {
-        facts: vec!["line_total".to_string()],
+        facts: vec![FactName::new("line_total")],
         dimensions: vec![],
         metrics: vec![],
     };

--- a/src/expand/tests_facts_path_role_playing.rs
+++ b/src/expand/tests_facts_path_role_playing.rs
@@ -31,7 +31,7 @@ fn test_facts_path_role_playing_dimension_raises_ambiguous_path() {
     // arbitrary edge.
     let def = role_playing_facts_def(true);
     let req = QueryRequest {
-        facts: vec!["order_note".to_string()],
+        facts: vec![FactName::new("order_note")],
         dimensions: vec![DimensionName::new("city")],
         metrics: vec![],
     };
@@ -59,7 +59,7 @@ fn test_facts_path_role_playing_dimension_raises_ambiguous_path() {
 fn test_facts_path_single_relationship_dimension_ok() {
     let def = role_playing_facts_def(false);
     let req = QueryRequest {
-        facts: vec!["order_note".to_string()],
+        facts: vec![FactName::new("order_note")],
         dimensions: vec![DimensionName::new("city")],
         metrics: vec![],
     };
@@ -90,7 +90,7 @@ fn test_facts_path_convergent_parent_dimension_not_ambiguous() {
         .with_pkfk_join("li_to_o", "li", "orders", &["order_id"], &["id"])
         .with_pkfk_join("pay_to_o", "pay", "orders", &["order_id"], &["id"]);
     let req = QueryRequest {
-        facts: vec!["net_price".to_string()],
+        facts: vec![FactName::new("net_price")],
         dimensions: vec![DimensionName::new("region")],
         metrics: vec![],
     };

--- a/src/expand/tests_join_emission_regression.rs
+++ b/src/expand/tests_join_emission_regression.rs
@@ -136,7 +136,7 @@ GROUP BY
 #[test]
 fn sg10_fact_source_chain_includes_intermediate_join() {
     let req = QueryRequest {
-        facts: vec!["detail_amount".to_string()],
+        facts: vec![FactName::new("detail_amount")],
         dimensions: vec![],
         metrics: vec![],
     };

--- a/src/expand/types.rs
+++ b/src/expand/types.rs
@@ -98,11 +98,17 @@ pub enum DimensionKind {}
 /// Kind marker for [`MetricName`]; never constructed.
 pub enum MetricKind {}
 
+/// Kind marker for [`FactName`]; never constructed.
+pub enum FactKind {}
+
 /// A dimension name with case-insensitive equality and hashing (see [`CiName`]).
 pub type DimensionName = CiName<DimensionKind>;
 
 /// A metric name with case-insensitive equality and hashing (see [`CiName`]).
 pub type MetricName = CiName<MetricKind>;
+
+/// A fact name with case-insensitive equality and hashing (see [`CiName`]).
+pub type FactName = CiName<FactKind>;
 
 /// A request to expand a semantic view into SQL.
 ///
@@ -116,7 +122,7 @@ pub type MetricName = CiName<MetricKind>;
 pub struct QueryRequest {
     pub dimensions: Vec<DimensionName>,
     pub metrics: Vec<MetricName>,
-    pub facts: Vec<String>,
+    pub facts: Vec<FactName>,
 }
 
 /// A resolved dimension paired with its role-playing scoped alias, if any.
@@ -211,6 +217,14 @@ mod tests {
         assert_eq!(met, MetricName::new("total_revenue"));
         assert_eq!(&*met.clone(), "Total_Revenue");
         assert_eq!(met.as_ref() as &str, "Total_Revenue");
+
+        // Facts share the same case-insensitive impl (R-7 follow-up: the third
+        // `CiName<K>` type the original change omitted, replacing the former
+        // stringly `facts: Vec<String>`).
+        let fact = FactName::new("Line_Total");
+        assert_eq!(fact, FactName::new("line_total"));
+        assert_eq!(&*fact.clone(), "Line_Total");
+        assert_eq!(fact.as_ref() as &str, "Line_Total");
     }
 
     #[test]

--- a/src/parse/create_body.rs
+++ b/src/parse/create_body.rs
@@ -48,37 +48,26 @@ pub(crate) fn extract_view_comment(text: &str) -> Result<(Option<String>, &str),
                 position: None,
             });
         }
-        // Extract the quoted string handling '' escaping.
-        //
-        // Phase 65.1 WR-04: walk as `char` stream (UTF-8 scalar values)
-        // rather than raw bytes — the previous `bytes[i] as char` cast
-        // silently mangled non-ASCII characters in the comment body.
-        // We skip the opening quote (one ASCII byte) and iterate from
-        // byte offset 1 via `char_indices()` against `&after_eq[1..]`,
-        // adjusting reported offsets back to `after_eq` space.
-        let mut chars = after_eq[1..].char_indices();
-        let mut value = String::new();
-        while let Some((rel_i, ch)) = chars.next() {
-            if ch == '\'' {
-                let mut peek = chars.clone();
-                if matches!(peek.next(), Some((_, '\''))) {
-                    value.push('\'');
-                    chars = peek;
-                    continue;
+        // Extract the '...'-quoted comment (with '' escaping) via the shared
+        // single-quote extractor. This used to re-inline the exact `char`-stream
+        // loop `util::extract_single_quoted_prefix` already provides — the ST-4
+        // consolidation whose doc says "do not re-inline this logic" (P-8,
+        // code-review 2026-07-11). `after_eq` is known to start with `'` (checked
+        // above), so `NotQuoted` is unreachable; the only real failure is an
+        // unterminated literal. `consumed` counts both delimiter quotes, so the
+        // remaining slice starts right after the closing quote.
+        let (value, consumed) = extract_single_quoted_prefix(after_eq).map_err(|e| ParseError {
+            message: match e {
+                SingleQuoteError::Unterminated => {
+                    "Unclosed single-quoted string in view-level COMMENT.".to_string()
                 }
-                // Closing quote found. `rel_i` is offset into `after_eq[1..]`;
-                // absolute offset of the closing quote in `after_eq` is
-                // `rel_i + 1`; the slice after the closing quote starts at
-                // `rel_i + 2` (closing quote is one ASCII byte).
-                let remaining = &after_eq[rel_i + 2..];
-                return Ok((Some(value), remaining));
-            }
-            value.push(ch);
-        }
-        Err(ParseError {
-            message: "Unclosed single-quoted string in view-level COMMENT.".to_string(),
+                SingleQuoteError::NotQuoted => {
+                    "Expected single-quoted string after COMMENT =.".to_string()
+                }
+            },
             position: None,
-        })
+        })?;
+        Ok((Some(value), &after_eq[consumed..]))
     } else {
         Ok((None, text))
     }
@@ -86,7 +75,6 @@ pub(crate) fn extract_view_comment(text: &str) -> Result<(Option<String>, &str),
 
 /// Validate a CREATE-with-body DDL statement and rewrite it if valid.
 pub(crate) fn validate_create_body(
-    _query: &str,
     trimmed_no_semi: &str,
     trim_offset: usize,
     plen: usize,

--- a/src/parse/detect.rs
+++ b/src/parse/detect.rs
@@ -3,7 +3,7 @@
 //! Extracted from `parse` (AR-1). Everything here answers "is this one of our
 //! statements, and if so which kind?" without rewriting anything: keyword
 //! prefix matching ([`match_keyword_prefix`]), comment/whitespace skipping
-//! ([`skip_leading_whitespace_and_comments`]), the longest-first prefix table
+//! ([`skip_leading_whitespace`]), the longest-first prefix table
 //! ([`detect_ddl_prefix`]), the public detection entry points
 //! ([`detect_ddl_kind`], [`detect_semantic_view_ddl`]), and fuzzy near-miss
 //! suggestion ([`detect_near_miss`]).
@@ -68,54 +68,25 @@ pub(crate) fn match_keyword_prefix(input: &[u8], keywords: &[&[u8]]) -> Option<u
     Some(pos)
 }
 
-/// Return the byte offset of the first character that is neither ASCII whitespace
-/// nor part of a SQL comment. Recognises:
-///   - `-- ... \n` line comments (terminated by newline or end-of-input)
-///   - `/* ... */` block comments (NOT nested -- matches PostgreSQL/DuckDB behaviour)
+/// Return the byte offset of the first non-whitespace character in `input`.
 ///
-/// Designed for prefix-matching: never errors. An unterminated `/* ...` consumes to
-/// end of input (so the keyword match below it will simply fail and fall through
-/// to `PARSE_NOT_OURS`, matching today's behaviour for malformed queries).
+/// Every caller runs [`crate::util::blank_sql_comments`] first, which replaces
+/// each comment byte with a space (byte-length-preserving), so by the time input
+/// reaches here `-- ...` and `/* ... */` comments are already whitespace. This
+/// therefore only needs to skip leading ASCII whitespace — it formerly
+/// re-implemented comment scanning inline, but that branch was dead (comments
+/// were already blanked) *and* wrong: it treated `/* */` as non-nesting, the
+/// opposite of the nesting semantics `blank_sql_comments` (and PostgreSQL/DuckDB)
+/// actually apply (P-5, code-review 2026-07-11).
 ///
-/// Returns the byte offset where real SQL begins, in the *original* slice. Callers
-/// substitute this for the `query.len() - query.trim_start().len()` whitespace
-/// offset so that v0.5.1 error-caret positions continue to reference the original
-/// query string after a leading comment is consumed.
-///
-/// Quick task 260430-vdz: fixes parser hook compatibility with dbt-duckdb (and
-/// any other tool that prepends a query annotation comment).
-pub(crate) fn skip_leading_whitespace_and_comments(input: &str) -> usize {
-    let bytes = input.as_bytes();
-    let mut i = 0;
-    loop {
-        // ASCII whitespace
-        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-            i += 1;
-        }
-        // Line comment: -- ... \n
-        if i + 1 < bytes.len() && bytes[i] == b'-' && bytes[i + 1] == b'-' {
-            i += 2;
-            while i < bytes.len() && bytes[i] != b'\n' {
-                i += 1;
-            }
-            continue; // re-enter loop to consume more whitespace/comments
-        }
-        // Block comment: /* ... */ (non-nesting, Postgres semantics)
-        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
-            i += 2;
-            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                i += 1;
-            }
-            if i + 1 < bytes.len() {
-                i += 2; // consume "*/"
-            } else {
-                i = bytes.len(); // unterminated -- consume to end
-            }
-            continue;
-        }
-        break;
-    }
-    i
+/// The returned offset is into the *original* (blanked, length-preserving)
+/// slice, so v0.5.1 error-caret positions continue to reference the original
+/// query string after leading whitespace/comments are consumed. This is what
+/// keeps parser-hook compatibility with dbt-duckdb (and any other tool that
+/// prepends a query annotation comment): the comment is blanked upstream, then
+/// skipped here as whitespace.
+pub(crate) fn skip_leading_whitespace(input: &str) -> usize {
+    input.bytes().take_while(u8::is_ascii_whitespace).count()
 }
 
 /// Detect the DDL kind and consumed prefix byte count from a query string.
@@ -213,7 +184,7 @@ pub fn detect_ddl_kind(query: &str) -> Option<DdlKind> {
     // prefix keywords (`CREATE /* x */ SEMANTIC VIEW`).
     let blanked = crate::util::blank_sql_comments(query);
     let query = blanked.as_ref();
-    let lead = skip_leading_whitespace_and_comments(query);
+    let lead = skip_leading_whitespace(query);
     let trimmed = query[lead..].trim_end().trim_end_matches(';').trim();
     detect_ddl_prefix(trimmed).map(|(kind, _)| kind)
 }
@@ -262,7 +233,7 @@ pub fn detect_near_miss(query: &str) -> Option<ParseError> {
     // PA-7: comment-blind near-miss detection.
     let blanked = crate::util::blank_sql_comments(query);
     let query = blanked.as_ref();
-    let lead = skip_leading_whitespace_and_comments(query);
+    let lead = skip_leading_whitespace(query);
     let trimmed = query[lead..].trim_end();
     let trimmed_no_semi = trimmed.trim_end_matches(';').trim();
     let lower = trimmed_no_semi.to_ascii_lowercase();

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -24,9 +24,7 @@ pub(crate) use create_body::{
 
 mod detect;
 pub use detect::{detect_ddl_kind, detect_near_miss, detect_semantic_view_ddl};
-pub(crate) use detect::{
-    detect_ddl_prefix, match_keyword_prefix, skip_leading_whitespace_and_comments,
-};
+pub(crate) use detect::{detect_ddl_prefix, match_keyword_prefix, skip_leading_whitespace};
 
 mod ffi;
 #[cfg(feature = "extension")]

--- a/src/parse/rewrite.rs
+++ b/src/parse/rewrite.rs
@@ -15,7 +15,7 @@ use crate::util::{
 
 use super::{
     build_filter_suffix, detect_ddl_prefix, match_keyword_prefix, parse_show_filter_clauses,
-    skip_leading_whitespace_and_comments, validate_create_body, DdlKind,
+    skip_leading_whitespace, validate_create_body, DdlKind,
 };
 
 // Used by the `write_error_to_buffer_*` unit tests (which reference it as
@@ -319,7 +319,7 @@ fn plan_ddl(query: &str) -> Result<RewriteAction, ParseError> {
     // blanked; only allocates when comments are present).
     let blanked = crate::util::blank_sql_comments(query);
     let query = blanked.as_ref();
-    let lead = skip_leading_whitespace_and_comments(query);
+    let lead = skip_leading_whitespace(query);
     let trimmed = query[lead..].trim_end();
     let trimmed = trimmed.trim_end_matches(';').trim();
     // `trimmed` starts at absolute byte offset `lead` in the (length-preserving
@@ -437,7 +437,7 @@ pub fn extract_ddl_name(query: &str) -> Result<Option<String>, ParseError> {
     // PA-7: comment-blind name extraction.
     let blanked = crate::util::blank_sql_comments(query);
     let query = blanked.as_ref();
-    let lead = skip_leading_whitespace_and_comments(query);
+    let lead = skip_leading_whitespace(query);
     let trimmed = query[lead..].trim_end();
     let trimmed = trimmed.trim_end_matches(';').trim();
     let trim_base = lead;
@@ -623,7 +623,7 @@ pub fn plan_rewrite(query: &str) -> Result<Option<RewriteAction>, ParseError> {
     // expression or rename target.
     let blanked = crate::util::blank_sql_comments(query);
     let query = blanked.as_ref();
-    let lead = skip_leading_whitespace_and_comments(query);
+    let lead = skip_leading_whitespace(query);
     let trimmed = query[lead..].trim_end();
     let trimmed_no_semi = trimmed.trim_end_matches(';').trim();
     let trim_offset = lead;
@@ -641,7 +641,7 @@ pub fn plan_rewrite(query: &str) -> Result<Option<RewriteAction>, ParseError> {
     // every inner fault — are gone: `plan_ddl` is the single grammar.
     match kind {
         DdlKind::Create | DdlKind::CreateOrReplace | DdlKind::CreateIfNotExists => {
-            validate_create_body(query, trimmed_no_semi, trim_offset, plen, kind)
+            validate_create_body(trimmed_no_semi, trim_offset, plen, kind)
         }
         _ => plan_ddl(query).map(Some),
     }
@@ -3268,65 +3268,41 @@ $$"#;
     }
 
     // ===================================================================
-    // Quick task 260430-vdz: leading-comment skipping
+    // `skip_leading_whitespace` — leading-whitespace offset.
     //
-    // Failing-test-first: these reference `skip_leading_whitespace_and_comments`
-    // and rely on the helper being applied at five trimming sites. They will
-    // not compile/pass until the fix lands in the next commit.
+    // Comment handling is upstream in `blank_sql_comments` (P-5, code-review
+    // 2026-07-11): callers blank first, so by the time input reaches this
+    // helper comments are already spaces. The former inline comment-scanning
+    // branches were dead and are gone; end-to-end leading-comment skipping is
+    // covered by `detect_create_with_leading_block_comment` and the
+    // `detect_semantic_view_ddl` comment cases below (which go through the
+    // blank-then-skip pipeline).
     // ===================================================================
 
     #[test]
     fn skip_lws_empty() {
-        assert_eq!(skip_leading_whitespace_and_comments(""), 0);
+        assert_eq!(skip_leading_whitespace(""), 0);
     }
 
     #[test]
     fn skip_lws_only_whitespace() {
-        assert_eq!(skip_leading_whitespace_and_comments("   \n\t"), 5);
-    }
-
-    #[test]
-    fn skip_lws_line_comment() {
-        let q = "-- hi\nCREATE";
-        assert_eq!(&q[skip_leading_whitespace_and_comments(q)..], "CREATE");
-    }
-
-    #[test]
-    fn skip_lws_block_comment() {
-        let q = "/* hi */ CREATE";
-        assert_eq!(&q[skip_leading_whitespace_and_comments(q)..], "CREATE");
-    }
-
-    #[test]
-    fn skip_lws_multiple_comments_and_ws() {
-        let q = "-- a\n  /* b */\n\t-- c\n/*d*/CREATE";
-        assert_eq!(&q[skip_leading_whitespace_and_comments(q)..], "CREATE");
-    }
-
-    #[test]
-    fn skip_lws_block_does_not_nest() {
-        // Outer ends at first */, leaving "trailing */ CREATE"
-        let q = "/* outer /* inner */ trailing */ CREATE";
-        let rest = &q[skip_leading_whitespace_and_comments(q)..];
-        assert!(rest.starts_with("trailing"), "got: {rest:?}");
-    }
-
-    #[test]
-    fn skip_lws_unterminated_block_consumes_to_eof() {
-        let q = "/* never ends";
-        assert_eq!(skip_leading_whitespace_and_comments(q), q.len());
+        assert_eq!(skip_leading_whitespace("   \n\t"), 5);
     }
 
     #[test]
     fn skip_lws_no_leading_match() {
-        // No comments and no whitespace -> offset 0
-        assert_eq!(skip_leading_whitespace_and_comments("CREATE"), 0);
+        // No leading whitespace -> offset 0.
+        assert_eq!(skip_leading_whitespace("CREATE"), 0);
     }
 
     #[test]
-    fn skip_lws_dash_dash_at_eof() {
-        let q = "-- no newline at end";
-        assert_eq!(skip_leading_whitespace_and_comments(q), q.len());
+    fn skip_lws_blanked_comment_is_whitespace() {
+        // Mirrors production: a leading comment is blanked to spaces upstream,
+        // then this helper skips it as whitespace. (A raw `-- hi\n` would NOT
+        // be skipped — comment handling deliberately no longer lives here.)
+        let raw = "-- hi\nCREATE";
+        let blanked = crate::util::blank_sql_comments(raw);
+        assert_eq!(&blanked[skip_leading_whitespace(&blanked)..], "CREATE");
     }
 
     #[test]

--- a/src/parse/show_clauses.rs
+++ b/src/parse/show_clauses.rs
@@ -125,11 +125,7 @@ fn parse_in_scope(
 ///
 /// Returns `(remaining_text, metric_name)`. `base` is the absolute byte offset
 /// of `rest[0]` in the original query (R-2).
-fn parse_for_metric<'a>(
-    rest: &'a str,
-    _entity: &str,
-    base: usize,
-) -> Result<(&'a str, &'a str), ParseError> {
+fn parse_for_metric(rest: &str, base: usize) -> Result<(&str, &str), ParseError> {
     let after_for = rest[3..].trim_start();
     // Word boundary after METRIC: `FOR METRICS x` must not parse as the
     // METRIC keyword followed by a metric named `s x` (PR #50 review).
@@ -245,7 +241,7 @@ pub(crate) fn parse_show_filter_clauses<'a>(
                 position: Some(abs(rest)),
             });
         }
-        let (remaining, metric_name) = parse_for_metric(rest, entity, abs(rest))?;
+        let (remaining, metric_name) = parse_for_metric(rest, abs(rest))?;
         rest = remaining;
         for_metric = Some(metric_name);
     }

--- a/src/query/explain.rs
+++ b/src/query/explain.rs
@@ -228,7 +228,10 @@ unsafe fn explain_semantic_view_bind_body(
             .iter()
             .map(|s| crate::expand::MetricName::new(s.clone()))
             .collect(),
-        facts: facts.clone(),
+        facts: facts
+            .iter()
+            .map(|s| crate::expand::FactName::new(s.clone()))
+            .collect(),
     };
     let expanded_sql =
         expand(&view_name, &def, &req).map_err(|e| QueryError::from(e).to_string())?;

--- a/src/query/table_function.rs
+++ b/src/query/table_function.rs
@@ -193,7 +193,10 @@ unsafe fn semantic_view_bind_body(
             .iter()
             .map(|s| crate::expand::MetricName::new(s.clone()))
             .collect(),
-        facts: facts.clone(),
+        facts: facts
+            .iter()
+            .map(|s| crate::expand::FactName::new(s.clone()))
+            .collect(),
     };
     let expanded_sql =
         expand(&view_name, &def, &req).map_err(|e| QueryError::from(e).to_string())?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -346,6 +346,10 @@ pub fn read_dollar_tag_len(bytes: &[u8], start: usize) -> Option<usize> {
 /// every downstream scanner comment-immune, stops trailing comments being
 /// absorbed into stored expressions (`ALTER ... RENAME TO x -- oops` renamed
 /// to `x -- oops`), and fixes non-nesting block-comment handling (PA-10).
+///
+/// This pre-pass is the settled design, not a stopgap: §6.1 phase 8
+/// (2026-07-15) evaluated folding it into the body-parser lexer and declined
+/// — see the decision record in `crate::body_parser::lexer`'s module docs.
 #[must_use]
 #[allow(clippy::too_many_lines)]
 pub fn blank_sql_comments(input: &str) -> std::borrow::Cow<'_, str> {


### PR DESCRIPTION
## Summary

Closes out the last loose ends from the 2026-07-11 code review after a full audit confirmed every §2 confirmed-bug and §4 test-gap was already remediated. This branch adds:

1. **§6.1 phase-8 decision (doc-only)** — records that `blank_sql_comments` stays the top-level, length-preserving pre-pass rather than being folded into the body-parser lexer. The fold can't discharge the pre-pass (statement detection and the CREATE front door don't tokenize through the lexer, and the lexer only ever receives already-blanked text), and length-preservation is load-bearing for raw-source slicing and error carets. Replaces the stale "later phase" promise in `lexer.rs` with the rationale and cross-references it from `blank_sql_comments`.

2. **§3 residual cleanup sweep** — the mechanical, behaviour-preserving cleanups the earlier remediation rounds left behind:

| Finding | Change |
|---|---|
| **R-7** | Add the third `CiName<K>` type (`FactName`) and migrate `QueryRequest.facts` from `Vec<String>` to `Vec<FactName>`. The original R-7 unified the dimension/metric twins but left facts stringly-typed. Behaviour-neutral: the sole consumer `resolve_names::<Fact, _>` takes `N: AsRef<str>`, which `CiName<K>` implements. |
| **E-10** | Single `scoped_join_alias(table, rel)` helper for the `{table}__{rel}` role-playing alias, replacing two independent `format!` sites that could drift. |
| **P-5** | `skip_leading_whitespace_and_comments` re-implemented comment scanning inline, but all five callers `blank_sql_comments` first — the branches were dead, and the inline `/* */` scan was non-nesting while the doc claimed that "matches PostgreSQL" (it doesn't; Postgres/DuckDB nest). Simplified to a whitespace-only `skip_leading_whitespace`, doc corrected, dead-branch tests dropped (leading-comment skipping stays covered end-to-end via the blank-then-skip pipeline). |
| **P-8** | `extract_view_comment` re-inlined the single-quote scan that `util::extract_single_quoted_prefix` already owns (ST-4, "do not re-inline"). Delegates to it; identical `char`-stream / `''`-escape semantics. |
| **§3.5** | Drop the unused `_query` param from `validate_create_body` and `_entity` from `parse_for_metric`. |

## Deliberately excluded (with reasons)

The audit found three review items that under-characterized live code — excluded to keep this a genuinely low-risk mechanical sweep:

- **E-8** (13 `fk_columns.is_empty()` guards) — not "defensive scar tissue": they implement backward-compat tolerance for legacy (pre-Phase-24) stored catalogs, entangled with the `has_incomplete_relationships` read gate and pinned by `legacy_empty_fk_columns_skips_validation` / `upgrade_stamps_complete_rows_and_skips_incomplete`. Removing them is a behavioural change needing a proven reachability argument.
- **`sv_count_parser_extensions`** — not a dead grep-test hook: it's the live FFI symbol `test/integration/test_load_extension_twice_idempotent.py` uses to verify idempotent extension loading (D-21).
- **`extract_ddl_name` / `detect_semantic_view_ddl`** — dead in production, but their ~90 tests are the deliberate cargo-test proxy for CREATE name-normalization / DDL-detection coverage (the FFI path needs the extension feature). Removing them properly means migrating that coverage onto `plan_rewrite`/`detect_ddl_kind` first — a separate, non-mechanical change.

The larger structural items (**C-6** wire-format, **C-7** C++ registration) remain deferred per the review's own §6.3 sequencing (a separate structural PR).

## Verification

- `cargo test` — 1185+ tests pass, 0 failed
- `cargo clippy -- -D warnings` — clean
- `make test_debug` (sqllogictest) — 71/71 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hy5RByfXiPK5w4qwevxsYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hy5RByfXiPK5w4qwevxsYT)_