### PR TITLE
Code-review 2026-07-11 R-1: route SHOW/DESCRIBE SQL escaping through SqlLit

### DIFF
--- a/src/parse/rewrite.rs
+++ b/src/parse/rewrite.rs
@@ -9,6 +9,7 @@
 
 use crate::errors::ParseError;
 use crate::ident::{find_identifier_end, normalize_view_name};
+use crate::sql_lit::SqlLit;
 use crate::util::{
     byte_offset_within, extract_single_quoted_prefix, starts_with_keyword_ci, SingleQuoteError,
 };
@@ -359,7 +360,7 @@ fn plan_ddl(query: &str) -> Result<RewriteAction, ParseError> {
         // SQL text on the read side.
         DdlKind::Describe | DdlKind::ShowColumns => {
             let name = extract_raw_name_only(trimmed, plen, Trailing::Reject, trim_base)?;
-            let safe_name = name.replace('\'', "''");
+            let safe_name = SqlLit::escape(&name);
             let fn_name = read_function_name(kind);
             Ok(RewriteAction::Passthrough(format!(
                 "SELECT * FROM {fn_name}('{safe_name}')"
@@ -386,9 +387,9 @@ fn plan_ddl(query: &str) -> Result<RewriteAction, ParseError> {
 
             // Build base SELECT
             let base = if let Some(view_name) = clauses.in_view {
-                let safe_name = view_name.replace('\'', "''");
+                let safe_name = SqlLit::escape(view_name);
                 if let Some(metric_name) = clauses.for_metric {
-                    let safe_metric = metric_name.replace('\'', "''");
+                    let safe_metric = SqlLit::escape(metric_name);
                     format!(
                         "SELECT * FROM show_semantic_dimensions_for_metric('{safe_name}', '{safe_metric}')"
                     )

--- a/src/parse/show_clauses.rs
+++ b/src/parse/show_clauses.rs
@@ -16,6 +16,7 @@
 use super::extract_quoted_string;
 use super::DdlKind;
 use crate::errors::ParseError;
+use crate::sql_lit::SqlLit;
 use crate::util::{byte_offset_within, is_ident_byte, starts_with_keyword_ci};
 
 /// Build optional WHERE and LIMIT suffix for a SHOW rewrite.
@@ -34,19 +35,19 @@ pub(crate) fn build_filter_suffix(
 ) -> String {
     let mut parts = Vec::new();
     if let Some(pattern) = like_pattern {
-        let escaped = pattern.replace('\'', "''");
+        let escaped = SqlLit::escape(pattern);
         parts.push(format!("name ILIKE '{escaped}'"));
     }
     if let Some(prefix) = starts_with {
-        let escaped = prefix.replace('\'', "''");
+        let escaped = SqlLit::escape(prefix);
         parts.push(format!("name LIKE '{escaped}%'"));
     }
     if let Some(schema) = in_schema {
-        let escaped = schema.replace('\'', "''");
+        let escaped = SqlLit::escape(schema);
         parts.push(format!("schema_name = '{escaped}'"));
     }
     if let Some(db) = in_database {
-        let escaped = db.replace('\'', "''");
+        let escaped = SqlLit::escape(db);
         parts.push(format!("database_name = '{escaped}'"));
     }
     let mut suffix = String::new();
@@ -319,4 +320,39 @@ pub(crate) fn parse_show_filter_clauses<'a>(
         starts_with,
         limit,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_filter_suffix;
+
+    // R-1 (code-review 2026-07-11): every user-supplied filter value is
+    // embedded in a single-quoted SQL literal via `SqlLit`, so `'` doubles to
+    // `''` and no lone quote can break out of the literal. These assertions
+    // pin the escaped output the manual `.replace('\'', "''")` used to produce,
+    // now routed through the single escaping boundary.
+    #[test]
+    fn filter_suffix_escapes_single_quotes() {
+        assert_eq!(
+            build_filter_suffix(Some("O'Brien"), None, None, None, None),
+            " WHERE name ILIKE 'O''Brien'"
+        );
+        assert_eq!(
+            build_filter_suffix(None, Some("O'Br"), None, None, None),
+            " WHERE name LIKE 'O''Br%'"
+        );
+        assert_eq!(
+            build_filter_suffix(None, None, None, Some("sch'ema"), Some("d'b")),
+            " WHERE schema_name = 'sch''ema' AND database_name = 'd''b'"
+        );
+    }
+
+    #[test]
+    fn filter_suffix_plain_values_and_limit_unchanged() {
+        assert_eq!(
+            build_filter_suffix(Some("cust%"), None, Some(10), None, None),
+            " WHERE name ILIKE 'cust%' LIMIT 10"
+        );
+        assert_eq!(build_filter_suffix(None, None, None, None, None), "");
+    }
 }

--- a/src/sql_lit.rs
+++ b/src/sql_lit.rs
@@ -7,14 +7,15 @@
 //! &str`) with a free `escape_sql_arg` / `unescape_sql_arg` pair, so nothing
 //! at the type level distinguished a raw value from an escaped one.
 //!
-//! This newtype makes the raw-vs-escaped distinction type-enforced and
-//! centralizes escaping at one boundary: the emission helpers take `&SqlLit`,
-//! so a raw `&str` no longer type-checks (the accidental "forgot to escape →
-//! injection" footgun is a compile error), and the only way to obtain a
-//! `SqlLit` is [`SqlLit::escape`], so escaping happens once, at each
-//! SQL-emission boundary: `rewrite_to_native_sql` for the write-DDL path, and
-//! the SHOW/DESCRIBE read-rewrite in `parse::rewrite` / `build_filter_suffix`
-//! for the read path. It does NOT make double-escaping
+//! This newtype makes the raw-vs-escaped distinction type-enforced and routes
+//! all escaping through a single constructor: the emission helpers take
+//! `&SqlLit`, so a raw `&str` no longer type-checks (the accidental "forgot to
+//! escape → injection" footgun is a compile error), and the only way to obtain
+//! a `SqlLit` is [`SqlLit::escape`] — so the `'` → `''` doubling logic lives in
+//! exactly one place, applied once at each SQL-emission boundary that uses it:
+//! `rewrite_to_native_sql` for the write-DDL path, and the SHOW/DESCRIBE
+//! read-rewrite in `parse::rewrite` / `build_filter_suffix` for the read path.
+//! It does NOT make double-escaping
 //! impossible — a caller could deliberately round-trip through `Display`
 //! (`SqlLit::escape(&lit.to_string())`) — but that is an intentional act, not
 //! an accidental one, and there is no such call site.

--- a/src/sql_lit.rs
+++ b/src/sql_lit.rs
@@ -11,17 +11,13 @@
 //! centralizes escaping at one boundary: the emission helpers take `&SqlLit`,
 //! so a raw `&str` no longer type-checks (the accidental "forgot to escape →
 //! injection" footgun is a compile error), and the only way to obtain a
-//! `SqlLit` is [`SqlLit::escape`], so escaping happens once, at the
-//! `rewrite_to_native_sql` boundary. It does NOT make double-escaping
+//! `SqlLit` is [`SqlLit::escape`], so escaping happens once, at each
+//! SQL-emission boundary: `rewrite_to_native_sql` for the write-DDL path, and
+//! the SHOW/DESCRIBE read-rewrite in `parse::rewrite` / `build_filter_suffix`
+//! for the read path. It does NOT make double-escaping
 //! impossible — a caller could deliberately round-trip through `Display`
 //! (`SqlLit::escape(&lit.to_string())`) — but that is an intentional act, not
 //! an accidental one, and there is no such call site.
-
-// The only non-test constructor call sites are the `extension`-gated write
-// emitters (`crate::parse::native_sql`); under a default, non-test build the
-// type is unused (the guard builders that consume it are themselves
-// `allow(dead_code)` there). Mirror the escaping helpers this replaced.
-#![cfg_attr(not(any(feature = "extension", test)), allow(dead_code))]
 
 /// A string with single quotes already SQL-doubled (`'` → `''`), ready to be
 /// embedded **between** the quotes of a single-quoted SQL string literal


### PR DESCRIPTION
## Summary

Finishes the **R-1** migration (code-review 2026-07-11). The `SqlLit` newtype
already centralized single-quote escaping for the write-DDL path
(`native_sql` + `catalog/writes`), but a full audit found the migration was
only partial: **seven executed-SQL sites still hand-rolled
`.replace('\'', "''")` by naming convention** — the exact "escaped-vs-raw
distinguished only by a variable name" footgun R-1 set out to eliminate, and
precisely the kind of half-migration the review's meta-lesson warns leaves the
next round's divergences behind.

| Site | Count | What it builds |
|---|---|---|
| `parse/rewrite.rs` | 3 | `DESCRIBE` / `SHOW COLUMNS` passthrough and `SHOW … FOR METRIC` → `SELECT * FROM fn('{name}')` |
| `parse/show_clauses.rs` | 4 | `build_filter_suffix`'s `LIKE` / `STARTS WITH` / `IN SCHEMA` / `IN DATABASE` `WHERE`-clause literals |

All seven now escape via the single `SqlLit::escape` boundary, with `Display`
rendering the escaped text — **output is byte-identical** (pinned by new
`build_filter_suffix` unit tests over `'`-bearing values). With `SqlLit` now
consumed by the always-compiled parser, the obsolete
`#[cfg_attr(not(any(feature = "extension", test)), allow(dead_code))]` is
removed and the module doc records the read-path boundary.

`render_ddl`'s named `escape_single_quote` helper (display DDL reconstruction,
not executed catalog SQL) is intentionally left as-is — different domain, and
a named helper rather than the anonymous footgun.

## Not in scope (verified already complete)

- **R-2** (structured parse errors) — landed in #76; the parse layer carries
  structured `ParseError` with carets resolved at the fault point, and the
  5×-pasted position-manufacturing `map_err` ladder is documented as removed
  (`rewrite.rs:640`). The sole remaining `Result<_, String>` in the parse
  layer, `extract_quoted_string`, is a deliberate leaf helper that centralizes
  call-site-specific error wording (its callers attach real positions) — not
  R-2 debt.

## Verification

- `cargo test` — 1187 pass, 0 failed (includes 2 new escaping tests)
- `cargo clippy -- -D warnings` — clean (project CI command)
- `cargo build` — 0 warnings (validates the `allow(dead_code)` removal)
- `make debug` + `make test_debug` (sqllogictest) — 71/71 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7iM6Q4VAgRjovwgEfesjA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7iM6Q4VAgRjovwgEfesjA)_