### PR TITLE
C-6: dedup wire_len onto a single shared ffi_util helper

### DIFF
--- a/src/ddl/read_ffi.rs
+++ b/src/ddl/read_ffi.rs
@@ -56,6 +56,7 @@
 
 #![cfg(feature = "extension")]
 
+use crate::ffi_util::wire_len;
 use libduckdb_sys as ffi;
 use std::ffi::{CStr, CString};
 
@@ -191,17 +192,6 @@ pub unsafe fn probe_catalog_table_present(borrowed: &BorrowedConnection) -> Resu
 /// `buf_len` bytes.
 pub unsafe fn write_err(buf: *mut u8, buf_len: usize, msg: &str) {
     crate::ffi_util::write_error_to_buffer(buf, buf_len, msg);
-}
-
-/// Encode a length as a little-endian `u32`, erroring rather than clamping
-/// when it exceeds `u32::MAX` (FF-6). A silent `unwrap_or(u32::MAX)` would
-/// write a length prefix that disagrees with the bytes actually appended,
-/// desyncing the header from the payload for every subsequent field on the
-/// C++ read side. The overflow is unreachable for real catalog metadata (a
-/// single row/cell would need >4 GiB), so the error is a hard corruption
-/// signal, not a routine path.
-fn wire_len(n: usize, what: &str) -> Result<u32, String> {
-    u32::try_from(n).map_err(|_| format!("{what} ({n} bytes) exceeds the wire-format u32 limit"))
 }
 
 /// Column type tag in the self-describing schema header (AR-3). Kept in sync

--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -23,6 +23,22 @@
 //! leaked on null out-pointers. Consolidated per ST-4 (code-review
 //! 2026-07-02); do not re-inline these at call sites.
 
+/// Encode a byte length as a little-endian wire `u32`, erroring rather than
+/// clamping when it exceeds `u32::MAX` (FF-6). A silent `as u32` truncation
+/// would write a length prefix that disagrees with the bytes actually
+/// appended, desyncing every subsequent field on the C++ read side. Overflow
+/// is unreachable for real payloads (a single row/cell, or the execution SQL,
+/// would each need to exceed 4 GiB), so the error is a hard corruption signal,
+/// not a routine path.
+///
+/// This is the single source shared by the read-path (`ddl::read_ffi`) and
+/// query-path (`query::wire`) serializers — C-6 (code-review 2026-07-11)
+/// collapsed the two divergent copies (a module fn and an inline closure) onto
+/// it.
+pub(crate) fn wire_len(n: usize, what: &str) -> Result<u32, String> {
+    u32::try_from(n).map_err(|_| format!("{what} ({n} bytes) exceeds the wire-format u32 limit"))
+}
+
 /// Write a NUL-terminated error message into a fixed-size C buffer.
 ///
 /// Truncates to at most `buf_len - 1` payload bytes, walking back to a UTF-8

--- a/src/query/wire.rs
+++ b/src/query/wire.rs
@@ -15,6 +15,7 @@
 //! (`parse_string_list`) — the "fix landed in one copy" hazard §5.1 calls out.
 
 use crate::expand::quote_ident;
+use crate::ffi_util::wire_len;
 use libduckdb_sys as ffi;
 
 /// Decode a length-prefixed LIST(VARCHAR) argument buffer into a `Vec<String>`.
@@ -238,10 +239,6 @@ pub fn serialize_register_payload(
     column_type_ids: &[u32],
     execution_sql: &str,
 ) -> Result<Vec<u8>, String> {
-    let wire_len = |n: usize, what: &str| -> Result<u32, String> {
-        u32::try_from(n)
-            .map_err(|_| format!("{what} ({n} bytes) exceeds the wire-format u32 limit"))
-    };
     // Guard against slice desync: the header writes `n_cols` from
     // `column_names.len()`, but the body serializes via `zip`, which would
     // silently truncate to the shorter slice and emit a header that disagrees


### PR DESCRIPTION
## Summary

Closes out **C-6** (code-review 2026-07-11). `wire_len` — the `usize` → wire
`u32` length encoder that errors (rather than truncating) on `>4 GiB` overflow
per FF-6 — existed **twice**: a module fn in `ddl/read_ffi.rs` and a
byte-identical inline closure in `query/wire.rs::serialize_register_payload`.

Move it to the crate-level, always-compiled `ffi_util` module so the read-path
and query-path serializers share **one** definition and can no longer drift.
Pure refactor — behaviour-identical.

## On the rest of C-6 (self-describing register payload) — assessed and skipped

The review also flagged the `semantic_view` register payload and the C++→Rust
`LIST(VARCHAR)` args as not carrying AR-3's self-describing schema header. On
inspection this is **moot**:

- The row payloads needed AR-3's tag header because C++ *pre-declares* their
  columns and must *assert* the payload matches.
- The register payload is the opposite — it already carries `u32 n_cols` +
  per-column `name` + full `type_id` (`shim.cpp` register-payload decode), and
  C++ *constructs* the result schema **from** it. It's inherently
  self-describing; there is nothing to assert against. The `LIST(VARCHAR)` args
  are likewise already length-prefixed.

Extending the AR-3 tag convention to them would be format-consistency churn on
the FFI wire boundary that fixes no actual out-of-band-trust bug, so it's
deliberately left undone.

## Verification

- `cargo test` — all pass, including the `serialize_register_payload` roundtrip
  and `read_ffi` serialize tests that exercise `wire_len`
- `cargo build` (default) and `cargo clippy -- -D warnings` (default +
  `--features extension`) — clean
- Always-compiled Rust refactor; no wire-format behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7iM6Q4VAgRjovwgEfesjA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7iM6Q4VAgRjovwgEfesjA)_