### PR TITLE
test: close cheap test/infra holes (T-11, T-12, T-13)

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -56,6 +56,20 @@ jobs:
       - name: Clippy (extension feature, deny warnings)
         run: SV_SKIP_CPP_BUILD=1 cargo clippy --no-default-features --features extension -- -D warnings
 
+      # T-12 (code-review 2026-07-16): doctests run in no other job — the
+      # coverage step below uses cargo-nextest, which skips them entirely. Run
+      # the default-feature doctests so their examples cannot silently rot, and
+      # the `extension`-gated FFI doctests separately: the load-bearing one is a
+      # `compile_fail` ABI-safety guard in src/ddl/read_ffi.rs that only
+      # type-checks (SV_SKIP_CPP_BUILD skips the C++ build; a compile_fail
+      # doctest never links). It is scoped to `read_ffi` because the other
+      # doctests assume the default `duckdb` feature and won't compile here.
+      - name: Doctests (default features)
+        run: cargo test --doc
+
+      - name: FFI doctests (extension feature, compile_fail ABI guard)
+        run: SV_SKIP_CPP_BUILD=1 cargo test --doc --no-default-features --features extension read_ffi
+
       # Pinned to a commit SHA (not the floating @v2) because the v2.1.0/v2.1.1
       # releases (2026-07-13) bundle cargo-deny 0.20.2, whose CLI refactor drops
       # the `--log-level` argument this action still passes — breaking the step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A stray or leading comma in any clause list — `DIMENSIONS (a AS x,, b AS y)`, `TABLES (,o AS orders ...)` — is now rejected instead of being silently dropped. A single trailing comma (`METRICS (a AS ..., )`) is still tolerated.
 - Malformed identifier slots in a view body are rejected instead of being silently stored as unqueryable names: a whitespace-separated multi-token name (`o.d junk AS ...`, which previously named the dimension `d junk`) and an empty quoted identifier `""` in a name or alias slot now error, matching the checks already applied to view names. An unqualified dimension/metric entry name whose expression happens to contain a dot (`region AS upper(o.region)`) now reports the missing `alias.name` qualifier instead of a misleading "Expected 'AS'".
 - Documentation corrected against the implemented grammar and Snowflake's own syntax: the README no longer documents the `ONE TO ONE` / `ONE TO MANY` / `MANY TO ONE` cardinality annotations removed in v0.6.0 (cardinality is inferred from PK/UNIQUE constraints) and states the at-least-one-of-`DIMENSIONS`/`METRICS` rule correctly; the Snowflake comparison page no longer shows an `AS` keyword in the Snowflake `CREATE SEMANTIC VIEW` example (Snowflake has none) or an invalid `SEMANTIC_VIEW()` query form, adds pre-aggregation `WHERE` to the not-yet-supported list, and the DDL reference no longer shows `NON ADDITIVE BY` on a derived metric (which the parser rejects).
 

--- a/Justfile
+++ b/Justfile
@@ -32,9 +32,17 @@ build-release:
 test:
     make test_debug
 
-# Run Rust unit tests only (does NOT test LOAD — use 'just test' for that)
+# Run Rust unit tests only (does NOT test LOAD — use 'just test' for that).
+# nextest cannot run doctests, so they run separately (T-12): the default set,
+# plus the `extension`-gated FFI doctests (the load-bearing `compile_fail`
+# ABI-safety guard in src/ddl/read_ffi.rs). The FFI run type-checks only —
+# SV_SKIP_CPP_BUILD skips the C++ amalgamation, and a `compile_fail` doctest
+# never links — and is scoped to `read_ffi` because other doctests assume the
+# default `duckdb` feature.
 test-rust:
     cargo nextest run
+    cargo test --doc
+    SV_SKIP_CPP_BUILD=1 cargo test --doc --no-default-features --features extension read_ffi
 
 # Run all lints
 lint:

--- a/src/body_parser/annotations.rs
+++ b/src/body_parser/annotations.rs
@@ -40,7 +40,7 @@ fn extract_single_quoted_string(s: &str) -> Result<String, ParseError> {
 /// Parse comma-separated single-quoted strings from inside parentheses.
 /// Input: "'syn1', 'syn2'" (already extracted from parens)
 fn parse_synonym_list(content: &str) -> Result<Vec<String>, ParseError> {
-    let entries = split_at_depth0_commas(content);
+    let entries = split_at_depth0_commas(content)?;
     let mut result = Vec::new();
     for (_, entry) in entries {
         let trimmed = entry.trim();

--- a/src/body_parser/entries.rs
+++ b/src/body_parser/entries.rs
@@ -32,7 +32,7 @@ pub(crate) fn parse_qualified_entries(
         return Ok(vec![]);
     }
 
-    let entries = split_at_depth0_commas(body);
+    let entries = split_at_depth0_commas(body)?;
     let mut result = Vec::new();
 
     for (entry_start, entry) in entries {

--- a/src/body_parser/materializations.rs
+++ b/src/body_parser/materializations.rs
@@ -26,7 +26,7 @@ pub(crate) fn parse_materializations_clause(
     body: &str,
     base_offset: usize,
 ) -> Result<Vec<Materialization>, ParseError> {
-    let entries = split_at_depth0_commas(body);
+    let entries = split_at_depth0_commas(body)?;
     let mut result = Vec::new();
     for (entry_start, entry) in entries {
         let entry_offset = base_offset + entry_start;
@@ -255,7 +255,7 @@ fn extract_paren_list(content: &str) -> Result<Vec<String>, ParseError> {
     } else {
         content
     };
-    Ok(split_at_depth0_commas(inner)
+    Ok(split_at_depth0_commas(inner)?
         .into_iter()
         .map(|(_, entry)| entry.to_string())
         .collect())

--- a/src/body_parser/metrics.rs
+++ b/src/body_parser/metrics.rs
@@ -38,7 +38,7 @@ pub(crate) fn parse_metrics_clause(
         return Ok(vec![]);
     }
 
-    let entries = split_at_depth0_commas(body);
+    let entries = split_at_depth0_commas(body)?;
     let mut result = Vec::new();
 
     for (entry_start, entry) in entries {
@@ -62,7 +62,7 @@ fn parse_non_additive_dims(
     content: &str,
     base_offset: usize,
 ) -> Result<Vec<NonAdditiveDim>, ParseError> {
-    let entries = split_at_depth0_commas(content);
+    let entries = split_at_depth0_commas(content)?;
     let mut result = Vec::new();
     for (start, entry_text) in entries {
         let entry_text = entry_text.trim();
@@ -258,7 +258,7 @@ fn parse_single_metric_entry(entry: &str, entry_offset: usize) -> Result<ParsedM
                     position: Some(after_using_abs),
                 });
             };
-            using_relationships = split_at_depth0_commas(inner)
+            using_relationships = split_at_depth0_commas(inner)?
                 .into_iter()
                 .map(|(_, rel)| rel.to_string())
                 .collect();

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -463,7 +463,7 @@ mod tests {
 
     #[test]
     fn split_simple_three_entries() {
-        let result = split_at_depth0_commas("a, b, c");
+        let result = split_at_depth0_commas("a, b, c").unwrap();
         assert_eq!(result.len(), 3, "Expected 3 entries, got {:?}", result);
         assert_eq!(result[0].1, "a");
         assert_eq!(result[1].1, "b");
@@ -473,7 +473,7 @@ mod tests {
     #[test]
     fn split_nested_parens_not_split() {
         // The comma inside SUM(a, b) is at depth 1 — must not split
-        let result = split_at_depth0_commas("SUM(a, b), COUNT(*)");
+        let result = split_at_depth0_commas("SUM(a, b), COUNT(*)").unwrap();
         assert_eq!(result.len(), 2, "Expected 2 entries, got {:?}", result);
         assert_eq!(result[0].1, "SUM(a, b)");
         assert_eq!(result[1].1, "COUNT(*)");
@@ -482,7 +482,7 @@ mod tests {
     #[test]
     fn split_string_literal_comma_not_split() {
         // Comma inside single-quoted string must not split
-        let result = split_at_depth0_commas("a, 'x, y', b");
+        let result = split_at_depth0_commas("a, 'x, y', b").unwrap();
         assert_eq!(result.len(), 3, "Expected 3 entries, got {:?}", result);
         assert_eq!(result[0].1, "a");
         assert_eq!(result[1].1, "'x, y'");
@@ -491,7 +491,7 @@ mod tests {
 
     #[test]
     fn split_trailing_comma_discarded() {
-        let result = split_at_depth0_commas("a,");
+        let result = split_at_depth0_commas("a,").unwrap();
         assert_eq!(
             result.len(),
             1,
@@ -502,8 +502,23 @@ mod tests {
 
     #[test]
     fn split_empty_body() {
-        let result = split_at_depth0_commas("");
+        let result = split_at_depth0_commas("").unwrap();
         assert_eq!(result.len(), 0, "Empty body must produce 0 entries");
+    }
+
+    #[test]
+    fn split_leading_and_interior_empty_entries_rejected() {
+        // T-13 (code-review 2026-07-16): a stray leading (`,a`) or interior
+        // (`a,,b`) comma is rejected rather than silently dropped. A single
+        // trailing comma stays tolerated (covered above).
+        assert!(split_at_depth0_commas(",a").is_err());
+        assert!(split_at_depth0_commas("a,,b").is_err());
+        assert!(split_at_depth0_commas("a, , b").is_err());
+        assert!(split_at_depth0_commas(",").is_err());
+        // A comma inside parens / quotes is still not a top-level split, so an
+        // empty-looking interior there does not trip the check.
+        assert!(split_at_depth0_commas("SUM(a,,b)").is_ok());
+        assert!(split_at_depth0_commas("'a,,b'").is_ok());
     }
 
     #[test]
@@ -512,12 +527,27 @@ mod tests {
         // entry's first byte, not the position right after the comma, so an
         // error caret computed from it lands on the entry rather than drifting
         // left into the inter-entry whitespace.
-        let result = split_at_depth0_commas("a,   b_bad");
+        let result = split_at_depth0_commas("a,   b_bad").unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], (0, "a"));
         assert_eq!(result[1], (5, "b_bad"));
         // Leading whitespace on the first entry is skipped too.
-        assert_eq!(split_at_depth0_commas("   x, y")[0], (3, "x"));
+        assert_eq!(split_at_depth0_commas("   x, y").unwrap()[0], (3, "x"));
+    }
+
+    #[test]
+    fn t13_stray_comma_in_clause_rejected_end_to_end() {
+        // The stray-comma rejection surfaces through the full body parser, not
+        // just the splitter unit.
+        let body = "AS TABLES (o AS orders PRIMARY KEY (id)) \
+                    DIMENSIONS (o.a AS o.a,, o.b AS o.b) \
+                    METRICS (o.rev AS SUM(o.amount))";
+        let err = parse_keyword_body(body, 0).unwrap_err();
+        assert!(
+            err.message.contains("stray or leading"),
+            "got: {}",
+            err.message
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1295,7 +1325,7 @@ mod tests {
 
     #[test]
     fn test_split_commas_ignores_comma_inside_quoted_ident() {
-        let entries = split_at_depth0_commas("o.x AS o.\"a,b\", o.y AS o.c");
+        let entries = split_at_depth0_commas("o.x AS o.\"a,b\", o.y AS o.c").unwrap();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].1, "o.x AS o.\"a,b\"");
         assert_eq!(entries[1].1, "o.y AS o.c");

--- a/src/body_parser/relationships.rs
+++ b/src/body_parser/relationships.rs
@@ -26,7 +26,7 @@ pub(crate) fn parse_relationships_clause(
         return Ok(vec![]);
     }
 
-    let entries = split_at_depth0_commas(body);
+    let entries = split_at_depth0_commas(body)?;
     let mut result = Vec::new();
 
     for (entry_start, entry) in entries {
@@ -191,7 +191,7 @@ fn take_columns(
             position: Some(entry_offset),
         });
     };
-    Ok(split_at_depth0_commas(inner)
+    Ok(split_at_depth0_commas(inner)?
         .into_iter()
         .map(|(_, col)| col.to_string())
         .collect())

--- a/src/body_parser/scan.rs
+++ b/src/body_parser/scan.rs
@@ -107,9 +107,10 @@ pub(super) fn unterminated_quote_error(s: &str) -> Option<&'static str> {
 /// A single **trailing** comma is tolerated (`a, b,` → `[a, b]`). A **leading**
 /// or **interior** empty entry — a stray comma with no content before it
 /// (`,a`, `a,,b`) — is rejected rather than silently dropped (T-13, code-review
-/// 2026-07-16; the P-2 no-silent-discard rule). The error carries no caret: the
-/// helper is base-offset-agnostic (offsets it returns are body-relative), and
-/// its callers surface the message with their own clause context.
+/// 2026-07-16; the P-2 no-silent-discard rule). The returned error has
+/// `position: None` — the helper is base-offset-agnostic (the offsets it returns
+/// are body-relative), so there is no absolute caret to attach — and callers
+/// propagate its message as-is via `?`.
 pub(crate) fn split_at_depth0_commas(body: &str) -> Result<Vec<(usize, &str)>, ParseError> {
     let mut entries = Vec::new();
     let mut depth: i32 = 0;
@@ -131,10 +132,8 @@ pub(crate) fn split_at_depth0_commas(body: &str) -> Result<Vec<(usize, &str)>, P
                         // in the tail below (not between two commas), so `a,`
                         // stays allowed.
                         return Err(ParseError {
-                            message:
-                                "Empty entry: a stray or leading ',' with no content before it. \
-                                 Remove the extra comma."
-                                    .to_string(),
+                            message: "Empty entry: a stray or leading ',' with no content before it. Remove the extra comma."
+                                .to_string(),
                             position: None,
                         });
                     }

--- a/src/body_parser/scan.rs
+++ b/src/body_parser/scan.rs
@@ -1,5 +1,7 @@
 //! Low-level byte/keyword scanning helpers shared by the clause parsers.
 
+use crate::errors::ParseError;
+
 /// Byte-scan state for SQL text: tracks single-quoted string literals and
 /// double-quoted identifiers, honouring the SQL escape doubling (`''` inside
 /// a string, `""` inside a quoted identifier).
@@ -100,9 +102,15 @@ pub(super) fn unterminated_quote_error(s: &str) -> Option<&'static str> {
 /// the **trimmed** slice's first byte — not the position right after the comma.
 /// Leading whitespace between the comma and the entry is excluded, so an error
 /// caret computed as `base + offset` lands on the entry itself rather than
-/// drifting left into the gap (P-4, code-review 2026-07-11). Trailing empty
-/// entries are discarded.
-pub(crate) fn split_at_depth0_commas(body: &str) -> Vec<(usize, &str)> {
+/// drifting left into the gap (P-4, code-review 2026-07-11).
+///
+/// A single **trailing** comma is tolerated (`a, b,` → `[a, b]`). A **leading**
+/// or **interior** empty entry — a stray comma with no content before it
+/// (`,a`, `a,,b`) — is rejected rather than silently dropped (T-13, code-review
+/// 2026-07-16; the P-2 no-silent-discard rule). The error carries no caret: the
+/// helper is base-offset-agnostic (offsets it returns are body-relative), and
+/// its callers surface the message with their own clause context.
+pub(crate) fn split_at_depth0_commas(body: &str) -> Result<Vec<(usize, &str)>, ParseError> {
     let mut entries = Vec::new();
     let mut depth: i32 = 0;
     let mut st = QuoteState::default();
@@ -117,9 +125,20 @@ pub(crate) fn split_at_depth0_commas(body: &str) -> Vec<(usize, &str)> {
                 b')' | b']' | b'}' => depth -= 1,
                 b',' if depth == 0 => {
                     let entry = body[start..i].trim();
-                    if !entry.is_empty() {
-                        entries.push((crate::util::byte_offset_within(body, entry), entry));
+                    if entry.is_empty() {
+                        // A leading (`,a`) or interior (`a,,b`) empty entry is a
+                        // stray comma. A trailing comma leaves its empty segment
+                        // in the tail below (not between two commas), so `a,`
+                        // stays allowed.
+                        return Err(ParseError {
+                            message:
+                                "Empty entry: a stray or leading ',' with no content before it. \
+                                 Remove the extra comma."
+                                    .to_string(),
+                            position: None,
+                        });
                     }
+                    entries.push((crate::util::byte_offset_within(body, entry), entry));
                     start = i + 1;
                 }
                 _ => {}
@@ -131,7 +150,7 @@ pub(crate) fn split_at_depth0_commas(body: &str) -> Vec<(usize, &str)> {
     if !tail.is_empty() {
         entries.push((crate::util::byte_offset_within(body, tail), tail));
     }
-    entries
+    Ok(entries)
 }
 
 // `split_first_token` (first-whitespace split for the MATERIALIZATIONS name)

--- a/src/body_parser/tables.rs
+++ b/src/body_parser/tables.rs
@@ -26,7 +26,7 @@ pub(crate) fn parse_tables_clause(
     body: &str,
     base_offset: usize,
 ) -> Result<Vec<TableRef>, ParseError> {
-    let entries = split_at_depth0_commas(body);
+    let entries = split_at_depth0_commas(body)?;
     let mut result = Vec::new();
 
     for (entry_start, entry) in entries {
@@ -292,7 +292,7 @@ fn take_columns(
     let Some(inner) = cur.take_parens() else {
         return Err(cur.err(off, unclosed_msg));
     };
-    Ok(split_at_depth0_commas(inner)
+    Ok(split_at_depth0_commas(inner)?
         .into_iter()
         .map(|(_, col)| col.to_string())
         .collect())

--- a/src/body_parser/window.rs
+++ b/src/body_parser/window.rs
@@ -70,7 +70,7 @@ pub(super) fn parse_window_over_clause(
     };
 
     // Split function arguments: first is inner_metric, rest are extra_args
-    let func_args: Vec<&str> = split_at_depth0_commas(func_args_content)
+    let func_args: Vec<&str> = split_at_depth0_commas(func_args_content)?
         .into_iter()
         .map(|(_, s)| s.trim())
         .filter(|s| !s.is_empty())
@@ -110,13 +110,14 @@ pub(super) fn parse_window_over_clause(
 type OverContent = (Vec<String>, Vec<String>, Vec<WindowOrderBy>, Option<String>);
 
 /// Split a comma-separated dimension list (already sliced from the source),
-/// trimming and dropping empties.
-fn split_dim_list(text: &str) -> Vec<String> {
-    split_at_depth0_commas(text)
+/// trimming and dropping empties. A stray/leading comma is rejected by
+/// [`split_at_depth0_commas`] (T-13).
+fn split_dim_list(text: &str) -> Result<Vec<String>, ParseError> {
+    Ok(split_at_depth0_commas(text)?
         .into_iter()
         .map(|(_, s)| s.trim().to_string())
         .filter(|s| !s.is_empty())
-        .collect()
+        .collect())
 }
 
 /// Parse the comma-separated `dim [ASC|DESC] [NULLS FIRST|LAST]` entries of an
@@ -129,7 +130,7 @@ fn parse_order_by_entries(
     base_offset: usize,
 ) -> Result<Vec<WindowOrderBy>, ParseError> {
     let mut order_by = Vec::new();
-    for (start, entry_text) in split_at_depth0_commas(order_text) {
+    for (start, entry_text) in split_at_depth0_commas(order_text)? {
         let entry_text = entry_text.trim();
         if entry_text.is_empty() {
             continue;
@@ -216,7 +217,7 @@ fn parse_over_content(content: &str, base_offset: usize) -> Result<OverContent, 
             .find_kw("ORDER")
             .or_else(|| cur.find_any_kw(&FRAME_KEYWORDS));
         let dims_end = boundary.map_or(content.len(), |t| t.start);
-        let dims = split_dim_list(content[dims_start..dims_end].trim());
+        let dims = split_dim_list(content[dims_start..dims_end].trim())?;
         if excluding {
             excluding_dims = dims;
         } else {

--- a/test/integration/test_differential.py
+++ b/test/integration/test_differential.py
@@ -478,6 +478,92 @@ def run_wildcard_section(conn) -> tuple[int, int]:
     return total, failures
 
 
+# ---------------------------------------------------------------------------
+# T-11 (code-review 2026-07-16): role-playing USING section. A single dimension
+# table (airports) is reached from one fact table (flights) via TWO distinct
+# relationships (departure / arrival). Each USING-scoped metric must join
+# through its OWN edge — the alias-binding-under-joins family that produced E-1.
+# The reference is an independent single-edge JOIN (no shared mechanism with the
+# engine's relationship resolver).
+# ---------------------------------------------------------------------------
+
+N_FLIGHTS = 600
+N_AIRPORTS = 12
+
+
+def seed_role_playing(conn) -> None:
+    rng = random.Random(SEED + 2)
+    conn.execute("CREATE TABLE rp_airports (id INTEGER PRIMARY KEY, city VARCHAR)")
+    # Cities collide (several airports per city) so GROUP BY city is non-trivial
+    # and the departure vs arrival paths yield genuinely different totals.
+    cities = [
+        "NYC", "NYC", "LON", "LON", "TYO", "SFO",
+        "SFO", "PAR", "BER", "SYD", "SYD", "DXB",
+    ]
+    conn.executemany(
+        "INSERT INTO rp_airports VALUES (?, ?)",
+        [(i, cities[i]) for i in range(N_AIRPORTS)],
+    )
+    conn.execute(
+        "CREATE TABLE rp_flights (id INTEGER PRIMARY KEY, dep_id INTEGER, arr_id INTEGER)"
+    )
+    # FKs are always valid (non-NULL, in range), so the engine's INNER/LEFT
+    # choice does not change results — the reference joins are unambiguous.
+    rows = [
+        (i, rng.randrange(N_AIRPORTS), rng.randrange(N_AIRPORTS))
+        for i in range(N_FLIGHTS)
+    ]
+    conn.executemany("INSERT INTO rp_flights VALUES (?, ?, ?)", rows)
+
+
+def run_role_playing_section(conn) -> tuple[int, int]:
+    seed_role_playing(conn)
+    conn.execute(
+        "CREATE SEMANTIC VIEW diff_role AS "
+        "TABLES (f AS rp_flights PRIMARY KEY (id), a AS rp_airports PRIMARY KEY (id)) "
+        "RELATIONSHIPS (dep AS f(dep_id) REFERENCES a, arr AS f(arr_id) REFERENCES a) "
+        "DIMENSIONS (a.city AS a.city) "
+        "METRICS (f.dep_count USING (dep) AS COUNT(f.id), "
+        "f.arr_count USING (arr) AS COUNT(f.id))"
+    )
+    total, failures = 0, 0
+
+    # dep_count by city -> flights grouped by their DEPARTURE airport's city.
+    total += 1
+    failures += _check(
+        conn,
+        "role-playing dep_count by city (departure edge)",
+        "SELECT * FROM semantic_view('diff_role', dimensions := ['city'], "
+        "metrics := ['dep_count'])",
+        "SELECT a.city, COUNT(f.id) FROM rp_flights f "
+        "JOIN rp_airports a ON f.dep_id = a.id GROUP BY a.city",
+    )
+
+    # arr_count by city -> flights grouped by their ARRIVAL airport's city. The
+    # SAME dimension resolves through a DIFFERENT edge, so the totals differ.
+    total += 1
+    failures += _check(
+        conn,
+        "role-playing arr_count by city (arrival edge)",
+        "SELECT * FROM semantic_view('diff_role', dimensions := ['city'], "
+        "metrics := ['arr_count'])",
+        "SELECT a.city, COUNT(f.id) FROM rp_flights f "
+        "JOIN rp_airports a ON f.arr_id = a.id GROUP BY a.city",
+    )
+
+    # Metric-only (no dimension): the USING edge still scopes the metric; with
+    # all FKs valid the count equals the flight total on either edge.
+    total += 1
+    failures += _check(
+        conn,
+        "role-playing dep_count total (no dim)",
+        "SELECT * FROM semantic_view('diff_role', metrics := ['dep_count'])",
+        "SELECT COUNT(f.id) FROM rp_flights f JOIN rp_airports a ON f.dep_id = a.id",
+    )
+
+    return total, failures
+
+
 def run_harness() -> int:
     import duckdb
 
@@ -640,6 +726,9 @@ def run_harness() -> int:
     total += t
     failures += f
     t, f = run_wildcard_section(conn)
+    total += t
+    failures += f
+    t, f = run_role_playing_section(conn)
     total += t
     failures += f
 


### PR DESCRIPTION
Test/infra batch from the 2026-07-16 code review (`_notes/code-review-2026-07-16.md`), the review's recommended PR #3 after the merged F-1..F-4 (#116) and F-5..F-14 (#117) PRs.

## T-13 — reject stray/leading commas instead of silently dropping them

`split_at_depth0_commas` discarded *every* empty entry though its doc promised only trailing-empty discard, so `DIMENSIONS (a AS x,, b AS y)` and a leading `,a` parsed silently. It now returns a `Result` and rejects a leading or interior empty entry (the P-2 no-silent-discard rule); a single **trailing** comma stays tolerated. All ~14 call sites propagate the error, and the doc is corrected.

## T-12 — run doctests in CI

`cargo nextest run` (and `cargo llvm-cov nextest`) skip doctests entirely, so the doc blocks — including the load-bearing `compile_fail` FFI ABI-safety guard in `src/ddl/read_ffi.rs` — compiled in no job. The Justfile `test-rust` recipe and the `CodeQuality` workflow now run:

- `cargo test --doc` (default features) — the default doc examples.
- `SV_SKIP_CPP_BUILD=1 cargo test --doc --no-default-features --features extension read_ffi` — the extension-gated FFI guard. It is scoped to `read_ffi` because the other doctests assume the default `duckdb` feature; a `compile_fail` doctest only type-checks (never links), so `SV_SKIP_CPP_BUILD` skips the C++ build.

## T-11 — role-playing USING differential section

The differential oracle had no role-playing coverage — the alias-binding-under-joins family that produced E-1. Added a flights/airports schema where one dimension table is reached from one fact table via two relationships (departure/arrival), and compared each `USING`-scoped metric against an independent single-edge JOIN reference (no shared mechanism with the engine's relationship resolver).

## Verification (full local gate)

- `cargo test` — **1331 passed, 0 failed**.
- sqllogictest — **74/74**.
- differential harness — **194/194** combinations, including the 3 new role-playing cases.
- doctests — default (`cargo test --doc`) and the FFI `compile_fail` guard both pass.
- `cargo clippy -- -D warnings` and `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VwD1GmJQWQbFvRe1b3qxR

---
_Generated by [Claude Code](https://claude.ai/code/session_019VwD1GmJQWQbFvRe1b3qxR)_