### PR TITLE
refactor: parser-diagnostic hardening + hygiene sweep (F-15, F-16, F-18, E-8)

### DIFF
--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -229,7 +229,8 @@ Areas where test coverage is reduced compared to ideal, with justification.
 - **Origin:** v0.10.0 Phase 67 Plan 02 audit-grep (D-10). Sibling pattern to TECH-DEBT #24.
 - **Decision (historical):** `parse_non_additive_dims` and the OVER `ORDER BY` parser both peeled the reference off the entry with `split_whitespace()`, so a quoted reference with internal whitespace (`NON ADDITIVE BY ("my dim" ASC)`) split mid-name.
 - **Resolution:** Phase 68 Plan 03 (B1) captures the reference slot via `find_identifier_end` + `is_quoting_balanced` in both sites (`src/body_parser/metrics.rs::parse_non_additive_dims` — its doc comment cites this entry — and the OVER `ORDER BY` parser in `src/body_parser/window.rs`). `split_whitespace` now runs only over the *trailing modifier* slice (ASC/DESC/NULLS FIRST|LAST), which contains no identifiers. Quoted-with-whitespace references parse correctly.
-- **Remaining sibling slots in the same whitespace-tokeniser class (still open, low-risk):** the `TABLES` alias slot (`tables.rs:42`, `split_first_token`), the `MATERIALIZATIONS` name (`materializations.rs:40`), the relationship target alias (`relationships.rs:119,134`), and the SHOW name slots `IN <view>` / `IN SCHEMA` / `FOR METRIC` (`show_clauses.rs:101,133,192`) still peel their identifier on the first whitespace, so a quoted-with-whitespace value there would split. Same vanishingly-rare-case argument as #24 applies; the fix, if ever needed, is to route each through `find_identifier_end`.
+- **Remaining sibling slots in the same whitespace-tokeniser class (still open, low-risk):** the SHOW name slots `IN SCHEMA` / `IN DATABASE`, `IN <view>`, and `FOR METRIC` (`show_clauses.rs:113`, `:152`, and the `IN <view>` slot) still peel their identifier on the first whitespace (`str::find(char::is_whitespace)`), so a quoted-with-whitespace value there would split. Same vanishingly-rare-case argument as #24 applies; the fix, if ever needed, is to route each through `find_identifier_end`.
+  - **Updated 2026-07-16 (code-review sweep):** the body-parser siblings this entry previously listed — the `TABLES` alias slot, the `MATERIALIZATIONS` name, and the relationship target alias — were **all migrated to the shared `Cursor`/lexer** by the §6.1 lexer/cursor migration (`tables.rs`, `materializations.rs`, `relationships.rs` now lex their name slots), so a quoted-with-whitespace value parses correctly there. Only the SHOW name slots (which live in `parse/show_clauses.rs`, outside the body-parser cursor) remain on the whitespace tokeniser.
 
 ### 26. ❓ Single-catalog write guard does not cover an attached DB that has its own catalog table
 
@@ -252,16 +253,42 @@ Areas where test coverage is reduced compared to ideal, with justification.
 
 - **Origin:** v0.11 identifier-contract work for dimension/metric/fact names; code review on that PR (2026-07-12). The original entry flagged a case-sensitivity *split* (a Snowflake-style quoted-case-sensitive query boundary vs case-insensitive internals); that split was **resolved** by adopting DuckDB's uniform case-insensitive rule everywhere (quoted identifiers are case-insensitive too). What remains is narrower and is purely about quote *stripping*.
 - **Limitation:** matching is now case-insensitive uniformly, but only the query-facing sites *strip* surrounding quotes before matching — `ident::ident_matches` / `ident::normalize_ident_part` at the resolution boundary (`find_dimension` / `find_metric` / `Fact::find`), the CREATE-time uniqueness key (`graph/names.rs::validate_name_uniqueness`), `alias.*` wildcard de-duplication (`expand/wildcard.rs`), and the `explain_semantic_view()` materialization-header lookup (`query/explain.rs`). The remaining name-comparison / keying sites fold case (correct) but do **not** strip quotes, so a *quoted* name written in one of these internal positions is compared with its quote characters intact and fails to match its unquoted declaration:
-  - the materialization set-matcher (`expand/materialization.rs::find_routing_materialization_name`, plus a second duplicated copy) over a `MATERIALIZATIONS` clause's *declared* names;
+  - the materialization set-matcher (`expand/materialization.rs::find_routing_materialization_name`) over a `MATERIALIZATIONS` clause's *declared* names;
   - `NON ADDITIVE BY` dimension references and window inner-metric references;
   - derived-metric / fact expression inlining (identifier references scanned inside expression *text*);
   - the table-alias slot in the qualified-reference path, output-column aliasing for quoted names, and `CiName`'s `Eq`.
 - **Why this is acceptable (interim):** the common case — unquoted names — is entirely unaffected (`ident_matches` reduces to `eq_ignore_ascii_case` when neither side is quoted, and the internal sites already did that). The gap only bites when a name is written *quoted* in one of these internal positions (a `NON ADDITIVE BY` list, a derived-metric expression, a `MATERIALIZATIONS` declaration) — rare, and quoting there buys nothing since matching is case-insensitive regardless.
-- **Action:** Route all of these through one quote-aware reference-scanning engine as part of §6.2 of `_notes/code-review-2026-07-11.md` (which also collapses the duplicated materialization matcher and the copies of the word-boundary reference scanner). The expression-text sites specifically need a quote-aware tokenizer, not a name comparison — that engine is the right home. Tracked here so the follow-up is not lost (the "half-migrated abstraction" pattern §7 of that review warns about).
+- **Action:** Route all of these through one quote-aware reference-scanning engine as part of §6.2 of `_notes/code-review-2026-07-11.md` (which also collapses the remaining copies of the word-boundary reference scanner). The expression-text sites specifically need a quote-aware tokenizer, not a name comparison — that engine is the right home. Tracked here so the follow-up is not lost (the "half-migrated abstraction" pattern §7 of that review warns about).
+  - **Updated 2026-07-16 (code-review sweep):** the "second duplicated copy" of the materialization set-matcher this entry used to cite was **collapsed by E-6** — `explain` now reuses the single `find_routing_materialization_name` (`query/explain.rs:219`), so there is one matcher, not two. The quote-stripping gap itself is unchanged.
+
+### 29. ✅ `fk_columns.is_empty()` legacy-relationship guards are load-bearing — do NOT remove (E-8)
+
+- **Origin:** code-review 2026-07-16 §6 listed "the 13 unchanged `fk_columns.is_empty()` legacy guards (E-8, untouched)" as removable sediment, on the premise they are "mostly unreachable since SG-7 hard-errors on incomplete relationships." A dedicated reachability analysis (2026-07-16) **refuted that premise**; recording the result here so the guards are not mistaken for dead code and stripped.
+- **Finding:** SG-7's hard-error (`model.rs::has_incomplete_relationships` → `fan_trap.rs` `UncheckableDefinition`) is **not** a universal read gate. It fires only through `build_relationship_graph`, which three supported paths reach *without* triggering:
+  1. **single-table fact queries** — `validate_fact_table_path` early-returns for ≤1 table, so an empty-FK join flows into role-playing / `resolve_joins_pkfk`;
+  2. **`SHOW SEMANTIC DIMENSIONS FOR METRIC`** — calls `from_definition` directly, no SG-7 gate;
+  3. **`CREATE`/`ALTER … FROM YAML`** — an incomplete relationship can be deserialized (`#[serde(default)]` on `fk_columns`) from user YAML or a hand-written catalog row.
+  An empty-`fk_columns` join means exactly one thing (a legacy/pre-Phase-24 encoding — `Cardinality` has only `ManyToOne`/`OneToOne`, both PK/FK), so these are legacy-skip guards, not join-category selectors, but they are genuinely reachable on the paths above. The load-bearing sites: `graph/relationship.rs:57,126,193,304`, `graph/cardinality.rs:29`, `expand/role_playing.rs:21,43`, `ddl/show_dims_for_metric.rs:167`, `ddl/define.rs:85`, plus the SG-7 detector itself (`model.rs:488`).
+- **Also:** three items originally counted under E-8 (`cardinality.rs:47,74`, `join_resolver.rs:45`) are `ref_columns` resolution / count-match logic, not fk-empty guards. Three (`fan_trap.rs:242,311`, `join_resolver.rs:144`) are dead *only* behind an upstream SG-7 gate and are kept as defense-in-depth — the fact path already demonstrated once that such a gate can be bypassed.
+- **Decision:** Keep all guards. E-8 is **not** a safe deletion.
+
+### 30. ❓ Dotted-qualified `NON ADDITIVE BY` reference is untested in semi-additive snapshot expansion (F-18)
+
+- **Origin:** code-review 2026-07-16 F-18, extended during the hygiene sweep. `body_parser` Phase 47 validation accepts an NA dim written either bare (`date_dim`) or dotted (`alias.date_dim`), but stores the reference verbatim.
+- **Limitation:** `expand/semi_additive.rs` resolves the NA dim for the snapshot `ORDER BY` by **bare-name** comparison only (`rd.dim.name` / `d.name` vs `nd.dimension`). A dotted reference therefore misses both lookups and falls to the `quote_ident(&nd.dimension)` arm, emitting the quoted qualifier as an `ORDER BY` term. This fails cleanly at bind time (a quoted non-column) rather than corrupting results, and is never the aliased-column shape E-1 fixed — but the dotted × semi-additive cell has no test.
+- **Why acceptable (interim):** bare NA-dim references (the overwhelmingly common form, and the only form any example/test uses) resolve correctly; quoting/qualifying an NA dim buys nothing since matching is case-insensitive and the dim is already unambiguous by name.
+- **Action:** when the quote-aware reference engine (#28) lands, resolve NA-dim references through it (bare **and** dotted, honouring quotes) in both the queried (`resolved_dims`) and unqueried (`def.dimensions`) branches, and add a semi-additive × dotted-NA-dim sqllogictest. Related SPECULATIVE cell: semi-additive × role-playing (review T-15).
 
 ---
 
-**Last updated:** 2026-07-12 (v0.11 unreleased) — added entry #28 (component-name
+**Last updated:** 2026-07-16 (v0.11 unreleased) — accuracy sweep against the
+2026-07-16 code review: refreshed entry #25 (the `TABLES` / `MATERIALIZATIONS` /
+relationship-target slots it listed were migrated to the shared cursor by §6.1;
+only the SHOW name slots remain) and entry #28 (the duplicated materialization
+matcher was collapsed by E-6); added entry #29 (the `fk_columns.is_empty()`
+guards are reachable and load-bearing — E-8 is not a safe deletion) and entry #30
+(dotted `NON ADDITIVE BY` reference untested in semi-additive expansion, F-18).
+Prior: 2026-07-12 (v0.11 unreleased) — added entry #28 (component-name
 identifier contract deferred to review §6.2). Prior: 2026-07-11 (v0.10.4) accuracy
 sweep against the 2026-07-11
 code review: retired the ghost-code descriptions in entries #1, #4, #9, #12, #20

--- a/cpp/src/shim.cpp
+++ b/cpp/src/shim.cpp
@@ -2355,6 +2355,15 @@ struct SemanticViewBindData : public TableFunctionData {
 };
 
 struct SemanticViewGlobalState : public GlobalTableFunctionState {
+    // `result` is drained by a single, unsynchronized cursor: the exec
+    // function (`sv_semantic_view_function`) calls `result->Fetch()` with no
+    // lock. That is safe ONLY because this state does not override
+    // `MaxThreads()`, so it inherits the base `GlobalTableFunctionState`
+    // default of 1 — DuckDB scans the semantic_view() table function
+    // single-threaded and never calls the exec function concurrently on the
+    // same global state. If a future change overrides `MaxThreads()` to allow
+    // parallel scans, the `Fetch()` cursor must be guarded (mutex, or a
+    // per-thread local state) or it will data-race.
     std::unique_ptr<MaterializedQueryResult> result;
 };
 

--- a/src/body_parser/annotations.rs
+++ b/src/body_parser/annotations.rs
@@ -19,27 +19,35 @@ pub(super) struct ParsedAnnotations {
 /// ignored (COMMENT extraction hands this function the whole annotation
 /// tail, e.g. `'x' WITH SYNONYMS = (...)`).
 ///
+/// `base_offset` is the absolute byte offset of `s[0]` in the original query,
+/// so the error carets point at the offending quote (F-15, code-review
+/// 2026-07-16).
+///
 /// Thin adapter over the shared UTF-8-correct extractor: this used to be
 /// the byte-wise copy that the WR-04 fix missed, Latin-1-izing every
 /// non-ASCII codepoint in COMMENT/SYNONYMS payloads (PA-2, code-review
 /// 2026-07-02).
-fn extract_single_quoted_string(s: &str) -> Result<String, ParseError> {
+fn extract_single_quoted_string(s: &str, base_offset: usize) -> Result<String, ParseError> {
     match crate::util::extract_single_quoted_prefix(s) {
         Ok((content, _consumed)) => Ok(content),
         Err(crate::util::SingleQuoteError::NotQuoted) => Err(ParseError {
             message: "Expected single-quoted string.".to_string(),
-            position: None,
+            position: Some(base_offset),
         }),
         Err(crate::util::SingleQuoteError::Unterminated) => Err(ParseError {
             message: "Unclosed single-quoted string.".to_string(),
-            position: None,
+            position: Some(base_offset),
         }),
     }
 }
 
 /// Parse comma-separated single-quoted strings from inside parentheses.
-/// Input: "'syn1', 'syn2'" (already extracted from parens)
-fn parse_synonym_list(content: &str) -> Result<Vec<String>, ParseError> {
+/// Input: "'syn1', 'syn2'" (already extracted from parens).
+///
+/// `base_offset` is the absolute byte offset of `content[0]` in the original
+/// query; each synonym's caret is recovered from its position within `content`
+/// (F-15, code-review 2026-07-16).
+fn parse_synonym_list(content: &str, base_offset: usize) -> Result<Vec<String>, ParseError> {
     let entries = split_at_depth0_commas(content)?;
     let mut result = Vec::new();
     for (_, entry) in entries {
@@ -47,7 +55,8 @@ fn parse_synonym_list(content: &str) -> Result<Vec<String>, ParseError> {
         if trimmed.is_empty() {
             continue;
         }
-        result.push(extract_single_quoted_string(trimmed)?);
+        let entry_offset = base_offset + crate::util::byte_offset_within(content, trimmed);
+        result.push(extract_single_quoted_string(trimmed, entry_offset)?);
     }
     Ok(result)
 }
@@ -68,11 +77,21 @@ fn parse_synonym_list(content: &str) -> Result<Vec<String>, ParseError> {
 /// clauses separated by whitespace: a duplicate `COMMENT` / `WITH SYNONYMS`, a
 /// malformed clause, or any leftover text is an error (P-2) — none of it is
 /// silently dropped.
+///
+/// `base_offset` is the absolute byte offset of `text[0]` in the original
+/// query; every error caret in this subtree is recovered from the offending
+/// token's position within `text` (F-15, code-review 2026-07-16).
 #[allow(clippy::too_many_lines)]
 pub(super) fn parse_trailing_annotations(
     text: &str,
+    base_offset: usize,
 ) -> Result<(String, ParsedAnnotations), ParseError> {
+    // Re-anchor past any leading whitespace `trim` will drop, so `base_offset`
+    // remains the absolute offset of `text[0]` after trimming.
+    let base_offset = base_offset + (text.len() - text.trim_start().len());
     let text = text.trim();
+    // Absolute caret for any subslice of `text` (F-15).
+    let pos_of = |sub: &str| base_offset + crate::util::byte_offset_within(text, sub);
     let upper = text.to_ascii_uppercase();
 
     // Find the FIRST occurrence of COMMENT or WITH SYNONYMS at depth-0 with word boundaries.
@@ -151,21 +170,22 @@ pub(super) fn parse_trailing_annotations(
             if comment.is_some() {
                 return Err(ParseError {
                     message: "Duplicate COMMENT annotation.".to_string(),
-                    position: None,
+                    position: Some(pos_of(rest)),
                 });
             }
             // `COMMENT` is 7 ASCII bytes, so slicing at 7 is on a char boundary.
-            let Some(after_eq) = rest[7..].trim_start().strip_prefix('=') else {
+            let after_kw = rest[7..].trim_start();
+            let Some(after_eq) = after_kw.strip_prefix('=') else {
                 return Err(ParseError {
                     message: "Expected '=' after COMMENT keyword.".to_string(),
-                    position: None,
+                    position: Some(pos_of(after_kw)),
                 });
             };
             let after_eq = after_eq.trim_start();
             if !after_eq.starts_with('\'') {
                 return Err(ParseError {
                     message: "Expected single-quoted string after COMMENT =.".to_string(),
-                    position: None,
+                    position: Some(pos_of(after_eq)),
                 });
             }
             let (content, consumed) =
@@ -178,7 +198,7 @@ pub(super) fn parse_trailing_annotations(
                             "Unclosed single-quoted string.".to_string()
                         }
                     },
-                    position: None,
+                    position: Some(pos_of(after_eq)),
                 })?;
             comment = Some(content);
             rest = &after_eq[consumed..];
@@ -186,7 +206,7 @@ pub(super) fn parse_trailing_annotations(
             if synonyms.is_some() {
                 return Err(ParseError {
                     message: "Duplicate WITH SYNONYMS annotation.".to_string(),
-                    position: None,
+                    position: Some(pos_of(rest)),
                 });
             }
             // `WITH` is 4 ASCII bytes.
@@ -194,7 +214,7 @@ pub(super) fn parse_trailing_annotations(
             if !starts_with_keyword(&after_with.to_ascii_uppercase(), "SYNONYMS") {
                 return Err(ParseError {
                     message: "Expected SYNONYMS after WITH keyword.".to_string(),
-                    position: None,
+                    position: Some(pos_of(after_with)),
                 });
             }
             // `SYNONYMS` is 8 ASCII bytes. Snowflake makes the `=` optional, so
@@ -207,16 +227,16 @@ pub(super) fn parse_trailing_annotations(
                 .trim_start();
             let (content, consumed) = extract_paren_prefix(after_eq).ok_or_else(|| ParseError {
                 message: "Expected parenthesized list after WITH SYNONYMS.".to_string(),
-                position: None,
+                position: Some(pos_of(after_eq)),
             })?;
-            synonyms = Some(parse_synonym_list(content)?);
+            synonyms = Some(parse_synonym_list(content, pos_of(content))?);
             rest = &after_eq[consumed..];
         } else {
             return Err(ParseError {
                 message: format!(
                     "Unexpected text in annotations: '{rest}'. Expected COMMENT = '...' or WITH SYNONYMS = (...)."
                 ),
-                position: None,
+                position: Some(pos_of(rest)),
             });
         }
     }

--- a/src/body_parser/cursor.rs
+++ b/src/body_parser/cursor.rs
@@ -72,6 +72,15 @@ impl<'a> Cursor<'a> {
         self.base + off
     }
 
+    /// Absolute caret position of `sub`, which MUST be a subslice of this
+    /// cursor's `src` (as produced by slicing / `.trim()` of `src`). Lets a
+    /// caller hand a re-sliced tail to a sub-parser together with the absolute
+    /// offset of its first byte, so the sub-parser can anchor its own carets
+    /// (F-15, code-review 2026-07-16).
+    pub(super) fn abs_of(&self, sub: &str) -> usize {
+        self.base + crate::util::byte_offset_within(self.src, sub)
+    }
+
     /// Build a [`ParseError`] anchored at a source-relative offset.
     pub(super) fn err(&self, off: usize, message: String) -> ParseError {
         ParseError {

--- a/src/body_parser/entries.rs
+++ b/src/body_parser/entries.rs
@@ -160,7 +160,7 @@ fn parse_single_qualified_entry(
     }
 
     // Phase 43: Parse trailing annotations from expression
-    let (expr, annotations) = parse_trailing_annotations(raw_expr)?;
+    let (expr, annotations) = parse_trailing_annotations(raw_expr, cur.abs_of(raw_expr))?;
 
     Ok(ParsedQualifiedEntry {
         source_alias,

--- a/src/body_parser/metrics.rs
+++ b/src/body_parser/metrics.rs
@@ -157,7 +157,7 @@ fn parse_single_metric_entry(entry: &str, entry_offset: usize) -> Result<ParsedM
     }
 
     // Phase 43: Parse trailing annotations from expression
-    let (expr, annotations) = parse_trailing_annotations(raw_expr)?;
+    let (expr, annotations) = parse_trailing_annotations(raw_expr, cur.abs_of(raw_expr))?;
 
     // Phase 48: Detect and parse OVER clause from the expression text.
     //   AVG(total_qty) OVER (PARTITION BY EXCLUDING d1, d2 ORDER BY d1)

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -85,11 +85,19 @@ pub struct KeywordBody {
 /// `base_offset` is the byte offset of `text[0]` in the original query string.
 #[allow(clippy::too_many_lines)]
 pub fn parse_keyword_body(text: &str, base_offset: usize) -> Result<KeywordBody, ParseError> {
-    // Strip leading "AS" (case-insensitive)
+    // Strip leading "AS" (case-insensitive). F-16 (code-review 2026-07-16):
+    // require a word boundary after "AS" so `ASTABLES(...)` is not silently
+    // read as `AS TABLES(...)`. The front door (`create_body.rs`) already
+    // whitespace-delimits this, but `parse_keyword_body` is `pub` and
+    // fuzz-facing, so it must self-guard against a following identifier byte.
     let trimmed = text.trim();
     let after_as = if trimmed
         .get(..2)
         .is_some_and(|s| s.eq_ignore_ascii_case("AS"))
+        && trimmed
+            .as_bytes()
+            .get(2)
+            .is_none_or(|&b| !crate::util::is_ident_byte(b))
     {
         trimmed[2..].trim_start()
     } else {
@@ -428,7 +436,7 @@ fn split_trailing_view_comment(
         return Ok((after_as, None));
     };
     let trailing = &after_as[comment_tok.start..];
-    let (leftover, ann) = annotations::parse_trailing_annotations(trailing)?;
+    let (leftover, ann) = annotations::parse_trailing_annotations(trailing, cur.abs_of(trailing))?;
     // `trailing` begins at the COMMENT keyword, so the "expression" prefix the
     // annotation parser peels off must be empty.
     if !leftover.trim().is_empty() {
@@ -564,6 +572,36 @@ mod tests {
         assert_eq!(kb.tables.len(), 1);
         assert_eq!(kb.dimensions.len(), 1);
         assert_eq!(kb.metrics.len(), 1);
+    }
+
+    #[test]
+    fn f16_leading_as_requires_word_boundary() {
+        // F-16 (code-review 2026-07-16): the leading-"AS" strip must not fire
+        // when "AS" is only a prefix of a longer identifier run. `ASTABLES(...)`
+        // must NOT be read as `AS TABLES(...)`.
+        let glued = "ASTABLES (o AS orders PRIMARY KEY (id)) DIMENSIONS (o.x AS x)";
+        let err = parse_keyword_body(glued, 0).unwrap_err();
+        assert!(
+            err.message.contains("Expected 'AS'"),
+            "glued ASTABLES should be rejected as a missing 'AS', got: {}",
+            err.message
+        );
+        // A genuine word boundary (space, or end-of-input right after AS) still
+        // strips as before.
+        assert!(parse_keyword_body(
+            "AS TABLES (o AS orders PRIMARY KEY (id)) DIMENSIONS (o.x AS x) METRICS (o.y AS SUM(y))",
+            0,
+        )
+        .is_ok());
+        // Lower-case and a non-identifier byte (`(`) immediately after AS are
+        // both boundaries, so the strip fires (then fails later for other
+        // reasons — the point is it is NOT rejected as "Expected 'AS'").
+        let paren_after = parse_keyword_body("AS(", 0).unwrap_err();
+        assert!(
+            !paren_after.message.contains("Expected 'AS'"),
+            "`(` after AS is a word boundary; got: {}",
+            paren_after.message
+        );
     }
 
     #[test]
@@ -1164,7 +1202,7 @@ mod tests {
     fn test_comment_annotation_non_ascii_payload_survives() {
         // PA-2: the pre-fix extractor stored 'café et plus' as mojibake.
         let (expr, ann) =
-            parse_trailing_annotations("SUM(o.amount) COMMENT = 'café et plus'").unwrap();
+            parse_trailing_annotations("SUM(o.amount) COMMENT = 'café et plus'", 0).unwrap();
         assert_eq!(expr, "SUM(o.amount)");
         assert_eq!(ann.comment.as_deref(), Some("café et plus"));
     }
@@ -1172,7 +1210,7 @@ mod tests {
     #[test]
     fn test_synonyms_annotation_non_ascii_payload_survives() {
         let (expr, ann) =
-            parse_trailing_annotations("o.city WITH SYNONYMS = ('ciudad', 'stadt', '都市')")
+            parse_trailing_annotations("o.city WITH SYNONYMS = ('ciudad', 'stadt', '都市')", 0)
                 .unwrap();
         assert_eq!(expr, "o.city");
         assert_eq!(ann.synonyms, vec!["ciudad", "stadt", "都市"]);
@@ -1182,7 +1220,8 @@ mod tests {
     fn test_annotation_scan_non_ascii_expression_no_panic() {
         // Multi-byte chars ahead of the annotation keywords exercise the
         // depth-0 scanner's byte loop.
-        let (expr, ann) = parse_trailing_annotations("concat(city, ' – ') COMMENT = 'ok'").unwrap();
+        let (expr, ann) =
+            parse_trailing_annotations("concat(city, ' – ') COMMENT = 'ok'", 0).unwrap();
         assert_eq!(expr, "concat(city, ' – ')");
         assert_eq!(ann.comment.as_deref(), Some("ok"));
     }
@@ -1196,10 +1235,12 @@ mod tests {
     #[test]
     fn test_annotation_both_orders_still_parse() {
         // Regression: valid single-clause and both-order forms are unaffected.
-        let (_, a) = parse_trailing_annotations("x COMMENT = 'c' WITH SYNONYMS = ('s')").unwrap();
+        let (_, a) =
+            parse_trailing_annotations("x COMMENT = 'c' WITH SYNONYMS = ('s')", 0).unwrap();
         assert_eq!(a.comment.as_deref(), Some("c"));
         assert_eq!(a.synonyms, vec!["s"]);
-        let (_, b) = parse_trailing_annotations("x WITH SYNONYMS = ('s') COMMENT = 'c'").unwrap();
+        let (_, b) =
+            parse_trailing_annotations("x WITH SYNONYMS = ('s') COMMENT = 'c'", 0).unwrap();
         assert_eq!(b.comment.as_deref(), Some("c"));
         assert_eq!(b.synonyms, vec!["s"]);
     }
@@ -1207,7 +1248,7 @@ mod tests {
     #[test]
     fn test_annotation_duplicate_comment_rejected() {
         // Previously the second COMMENT was silently dropped.
-        let err = parse_trailing_annotations("x COMMENT = 'a' COMMENT = 'b'").unwrap_err();
+        let err = parse_trailing_annotations("x COMMENT = 'a' COMMENT = 'b'", 0).unwrap_err();
         assert!(
             err.message.contains("Duplicate COMMENT"),
             "got: {}",
@@ -1217,7 +1258,7 @@ mod tests {
 
     #[test]
     fn test_annotation_duplicate_synonyms_rejected() {
-        let err = parse_trailing_annotations("x WITH SYNONYMS = ('a') WITH SYNONYMS = ('b')")
+        let err = parse_trailing_annotations("x WITH SYNONYMS = ('a') WITH SYNONYMS = ('b')", 0)
             .unwrap_err();
         assert!(
             err.message.contains("Duplicate WITH SYNONYMS"),
@@ -1229,7 +1270,7 @@ mod tests {
     #[test]
     fn test_annotation_trailing_garbage_rejected() {
         // Previously `banana` was silently accepted and discarded.
-        let err = parse_trailing_annotations("x COMMENT = 'a' banana").unwrap_err();
+        let err = parse_trailing_annotations("x COMMENT = 'a' banana", 0).unwrap_err();
         assert!(
             err.message.contains("Unexpected text in annotations"),
             "got: {}",
@@ -1241,7 +1282,7 @@ mod tests {
     fn test_annotation_keyword_word_boundary_preserved() {
         // A column-ish token that merely starts with COMMENT must not be
         // mistaken for the keyword — it stays part of the expression.
-        let (expr, ann) = parse_trailing_annotations("commentary_col").unwrap();
+        let (expr, ann) = parse_trailing_annotations("commentary_col", 0).unwrap();
         assert_eq!(expr, "commentary_col");
         assert!(ann.comment.is_none() && ann.synonyms.is_empty());
     }
@@ -1249,9 +1290,43 @@ mod tests {
     #[test]
     fn test_annotation_with_without_synonyms_rejected() {
         // A second WITH clause that isn't WITH SYNONYMS is an error, not junk.
-        let err = parse_trailing_annotations("x COMMENT = 'a' WITH FOO").unwrap_err();
+        let err = parse_trailing_annotations("x COMMENT = 'a' WITH FOO", 0).unwrap_err();
         assert!(
             err.message.contains("Expected SYNONYMS after WITH"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn f15_annotation_errors_carry_carets() {
+        // F-15 (code-review 2026-07-16): annotation-path errors used to carry
+        // `position: None`. They now anchor at the offending token, offset by
+        // the caller-supplied `base_offset`.
+        let text = "x COMMENT = 'a' banana";
+        let base = 100;
+        let err = parse_trailing_annotations(text, base).unwrap_err();
+        // Caret points at `banana` (the unexpected trailing text).
+        let banana_at = base + text.find("banana").unwrap();
+        assert_eq!(
+            err.position,
+            Some(banana_at),
+            "caret should point at the trailing junk: {}",
+            err.message
+        );
+
+        // Duplicate COMMENT anchors at the second COMMENT keyword.
+        let dup = "x COMMENT = 'a' COMMENT = 'b'";
+        let err = parse_trailing_annotations(dup, 0).unwrap_err();
+        let second_comment = dup.rfind("COMMENT").unwrap();
+        assert_eq!(err.position, Some(second_comment), "got: {}", err.message);
+
+        // A malformed synonym (missing quotes) anchors inside the paren list.
+        let bad_syn = "x WITH SYNONYMS = (foo)";
+        let err = parse_trailing_annotations(bad_syn, 0).unwrap_err();
+        assert_eq!(
+            err.position,
+            Some(bad_syn.find("foo").unwrap()),
             "got: {}",
             err.message
         );
@@ -3872,7 +3947,7 @@ mod tests {
     fn f12_with_synonyms_without_equals_accepted() {
         // Snowflake accepts `WITH SYNONYMS (...)` without the `=`.
         let (expr, ann) =
-            parse_trailing_annotations("SUM(o.amount) WITH SYNONYMS ('territory', 'area')")
+            parse_trailing_annotations("SUM(o.amount) WITH SYNONYMS ('territory', 'area')", 0)
                 .unwrap();
         assert_eq!(expr, "SUM(o.amount)");
         assert_eq!(ann.synonyms, vec!["territory", "area"]);
@@ -3881,7 +3956,7 @@ mod tests {
     #[test]
     fn f12_with_synonyms_with_equals_still_accepted() {
         let (_expr, ann) =
-            parse_trailing_annotations("SUM(o.amount) WITH SYNONYMS = ('territory')").unwrap();
+            parse_trailing_annotations("SUM(o.amount) WITH SYNONYMS = ('territory')", 0).unwrap();
         assert_eq!(ann.synonyms, vec!["territory"]);
     }
 

--- a/src/body_parser/tables.rs
+++ b/src/body_parser/tables.rs
@@ -195,7 +195,8 @@ fn parse_single_table_entry(entry: &str, entry_offset: usize) -> Result<TableRef
     // Step 6: trailing COMMENT / WITH SYNONYMS annotations. The shared parser
     // tiles the region exactly; any non-annotation text left in front of it is
     // reported here rather than silently dropped (PA-9 companion).
-    let (leftover, annotations) = parse_trailing_annotations(cur.rest())?;
+    let rest = cur.rest();
+    let (leftover, annotations) = parse_trailing_annotations(rest, cur.abs_of(rest))?;
     if !leftover.trim().is_empty() {
         return Err(ParseError {
             message: format!(

--- a/src/expand/semi_additive.rs
+++ b/src/expand/semi_additive.rs
@@ -225,7 +225,25 @@ pub(super) fn expand_semi_additive(
                     .map_or_else(
                         || {
                             // NA dim not in queried dims -- find it in the view definition
-                            // and use its raw expression
+                            // and use its raw expression.
+                            //
+                            // F-18 (code-review 2026-07-16): the final
+                            // `quote_ident(&nd.dimension)` arm is a defensive
+                            // fallback, not a live path for the validated
+                            // bare-name form. Phase 47 (`body_parser::mod`)
+                            // hard-errors at CREATE time on any NA dim that
+                            // doesn't name a declared dimension, so a bare-name
+                            // `nd.dimension` always matches a `def.dimensions`
+                            // entry here. The one residual shape that reaches
+                            // the fallback is a *dotted* qualifier
+                            // (`alias.dim`): Phase 47 accepts it via its
+                            // dotted-path branch, but this bare-name `.find`
+                            // does not resolve it, so it emits the quoted
+                            // qualifier and fails cleanly at bind time rather
+                            // than corrupting results. That dotted × semi-
+                            // additive cell is untested (TECH-DEBT); emitting a
+                            // quoted non-column is the safe failure, never the
+                            // aliased-column shape E-1 fixed.
                             def.dimensions
                                 .iter()
                                 .find(|d| d.name.eq_ignore_ascii_case(&nd.dimension))

--- a/src/render_ddl.rs
+++ b/src/render_ddl.rs
@@ -11,8 +11,15 @@
 use crate::model::{AccessModifier, NullsOrder, SemanticViewDefinition, SortOrder};
 
 /// SQL single-quote escaping: `'` -> `''`.
+///
+/// Delegates to [`crate::sql_lit::SqlLit`], the single source of the quote-
+/// doubling rule, so this logic lives in exactly one place and cannot drift
+/// (code-review 2026-07-16 hygiene: this was the one `''`-escape copy outside
+/// `SqlLit`). `render_ddl` keeps a thin named wrapper because its output is
+/// `GET_DDL` *display* text rather than executable catalog SQL — a different
+/// consumer, but an identical escaping rule.
 fn escape_single_quote(s: &str) -> String {
-    s.replace('\'', "''")
+    crate::sql_lit::SqlLit::escape(s).to_string()
 }
 
 /// Append ` COMMENT = '<escaped>'` to `out` if comment is present.


### PR DESCRIPTION
Code-review 2026-07-16 §7 **PR #4 (hygiene)**, part 1 of 2.

## Parser diagnostics
- **F-16** — guard the leading-`AS` strip in the `pub`, fuzz-facing `parse_keyword_body` with a word-boundary check, so `ASTABLES(...)` is no longer read as `AS TABLES(...)`. The front door (`create_body.rs`) already whitespace-delimits this; the internal entry point now self-guards. + regression test.
- **F-15** — thread a `base_offset` through the trailing-annotation parser so its ten error sites carry carets instead of `position: None`. Adds a `Cursor::abs_of` helper and anchors each error at the offending token's offset within the annotation text. + caret-position test (incl. non-zero base).

## Defensive hardening / comments
- **F-18** — document the semi-additive `quote_ident` fallback. Phase-47 CREATE-time validation makes it unreachable for the bare-name form; the one residual edge is a dotted-qualified NA dim, which fails cleanly at bind time. A bare `debug_assert!(false)` would have been wrong (that dotted path can reach it), so this is a precise comment, not an assert.
- **MaxThreads** — document the single-threaded-scan invariant (`MaxThreads() == 1`) that makes `SemanticViewGlobalState`'s unsynchronized `Fetch()` cursor safe, and what to change if a future parallel scan is enabled.
- **escape-copy** — `render_ddl::escape_single_quote` now delegates to `SqlLit::escape`, so the `'`→`''` doubling rule lives in exactly one place (it keeps its thin named wrapper because its output is GET_DDL display text, not executable SQL).

## E-8 — guards **kept**, not removed
The review suggested deleting the 13 `fk_columns.is_empty()` guards as dead "scar tissue." A dedicated reachability analysis **refuted the premise**: SG-7's hard-error is *not* a universal read gate — it fires only through `build_relationship_graph`, which three supported paths reach without triggering:
1. single-table fact queries (`validate_fact_table_path` early-returns for ≤1 table),
2. `SHOW SEMANTIC DIMENSIONS FOR METRIC` (calls `from_definition` directly),
3. `CREATE`/`ALTER … FROM YAML` with an incomplete relationship (`#[serde(default)]` on `fk_columns`).

So the guards are reachable and load-bearing. **No guard removed.** Recorded as TECH-DEBT #29 so a future agent doesn't strip them. (Three items the review counted under E-8 are also mislabeled — `cardinality.rs:47,74` / `join_resolver.rs:45` are `ref_columns` logic, not fk-empty guards.)

## TECH-DEBT accuracy sweep
- Refreshed **#25** — the `TABLES` alias, `MATERIALIZATIONS` name, and relationship-target slots it listed were migrated to the shared `Cursor`/lexer by §6.1; only the SHOW name slots (`parse/show_clauses.rs`) remain on the whitespace tokeniser.
- Refreshed **#28** — the "second duplicated copy" of the materialization matcher was collapsed by E-6; `explain` now reuses the single `find_routing_materialization_name`.
- Added **#29** (E-8 guards are reachable — not a safe deletion) and **#30** (dotted `NON ADDITIVE BY` reference untested in semi-additive expansion, F-18).

## Deferred to the follow-up PR
Dead `extract_ddl_name` deletion — a clean, separable removal (`pub`, zero production callers) but ~35 test call-sites to re-point at `plan_rewrite`/`RewriteAction`. Kept out to keep this PR focused; lands as the next PR once this merges.

## Verification
Full local gate green:
- `cargo test` — 1227 lib + 3 integration + 1 doctest, 0 failed
- sqllogictest (`make test_debug`) — 74 files, 0 failed
- `cargo fmt --check`, `cargo clippy -- -D warnings` (default) and `SV_SKIP_CPP_BUILD=1 cargo clippy --features extension -- -D warnings` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VwD1GmJQWQbFvRe1b3qxR

---
_Generated by [Claude Code](https://claude.ai/code/session_019VwD1GmJQWQbFvRe1b3qxR)_