### PR TITLE
Return typed ParseError from the CREATE validation boundary (§7.5 error architecture)

### DIFF
--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -295,10 +295,10 @@ Areas where test coverage is reduced compared to ideal, with justification.
 
 ---
 
-**Last updated:** 2026-07-16 (v0.11 unreleased) — added entry #31 (graph/
-validation errors are now typed `ParseError`, deliberately positionless — the
-review §6.1 / §7.5 error-architecture item). Prior same-day: entry #28: Slice 2
-landed —
+**Last updated:** 2026-07-16 (v0.11 unreleased) — added entry #31
+(graph/validation errors are now typed `ParseError`, deliberately positionless
+— the review §6.1 / §7.5 error-architecture item). Prior same-day: entry #28:
+Slice 2 landed —
 every expression-text scanner (alias-qualifier rewriters, derived-metric
 reference validator, aggregate detection) now rides `expr_tokens`;
 `util::replace_word_boundary` and `derived_metrics::extract_identifiers` are

--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -286,9 +286,19 @@ Areas where test coverage is reduced compared to ideal, with justification.
 - **Why acceptable (interim):** bare NA-dim references (the overwhelmingly common form, and the only form any example/test uses) resolve correctly; quoting/qualifying an NA dim buys nothing since matching is case-insensitive and the dim is already unambiguous by name.
 - **Action:** when the quote-aware reference engine (#28) lands, resolve NA-dim references through it (bare **and** dotted, honouring quotes) in both the queried (`resolved_dims`) and unqueried (`def.dimensions`) branches, and add a semi-additive × dotted-NA-dim sqllogictest. Related SPECULATIVE cell: semi-additive × role-playing (review T-15).
 
+### 31. ✅ Graph/validation errors are typed (`ParseError`) but deliberately positionless
+
+- **Origin:** code-review 2026-07-16 §6 item 1 / §7.5: "the typed-error rollout stops at the graph/validation layer (~15 `Result<_, String>` signatures with no positions)… Extend the treatment or write the paragraph declaring the boundary deliberate — currently it reads as an unfinished rollout."
+- **Resolution (2026-07-16):** the CREATE-time funnel and the graph module's public validators now speak the shared typed error `crate::errors::ParseError` instead of bare `String`: `validate_name_uniqueness`, `validate_facts`, `validate_derived_metrics`, `validate_graph`, `validate_using_relationships`, and `enrich_definition_for_create` (`ddl/define.rs`) all return `Result<_, ParseError>`; the two CREATE call sites (`parse/native_sql.rs`, `ddl/alter_helpers_ffi.rs`) consume it directly. Errors are constructed via `ParseError::positionless(..)`, a named constructor that makes the absence of a caret explicit. The private per-check helpers (`check_*`) and the externally-shared sub-validators (`RelationshipGraph::from_definition` / `check_no_diamonds` / `check_no_orphans` / `validate_fk_references` / `toposort`, also called by `SHOW … FOR METRIC`) keep their `String` signatures and are wrapped at the public boundary — so nothing `String`-typed propagates upward past the graph module, and no unrelated caller is disturbed.
+- **Why `position` is `None` (the deliberate boundary):** these validators receive a fully-built `SemanticViewDefinition` whose members (`Metric`/`Dimension`/`Fact`/`Join`) hold **owned** names and expressions, not byte spans into the original DDL, and the original query text is out of scope by the time they run — so `util::byte_offset_within` (which needs the offending token to be a *subslice of the original query*) cannot be applied here. Additionally, several of these failures are **global/topological** (a derived-metric or fact dependency cycle, an ambiguous join *diamond*, an empty `TABLES` clause) with no single offending token to point a caret at. This mirrors the already-accepted positionless-typed `expand::ExpandError` (fan-trap) and the pervasive `position: None` idiom at the parse layer's own semantic-failure sites.
+- **What real carets here would require (not done — out of proportion):** threading the original DDL body **and** a per-item byte-span table down into `SemanticViewDefinition`'s members (or passing them as a side channel into `enrich_definition_for_create`), then, for the *token-shaped* subset — duplicate name, unknown metric/fact reference, unknown source table, unknown/misrouted USING relationship, self-reference, FK/PK mismatch — recovering the offset with `byte_offset_within`. The global/topological subset stays positionless regardless. A future PR can add spans if define-time carets for these become worth the model change.
+
 ---
 
-**Last updated:** 2026-07-16 (v0.11 unreleased) — entry #28: Slice 2 landed —
+**Last updated:** 2026-07-16 (v0.11 unreleased) — added entry #31 (graph/
+validation errors are now typed `ParseError`, deliberately positionless — the
+review §6.1 / §7.5 error-architecture item). Prior same-day: entry #28: Slice 2
+landed —
 every expression-text scanner (alias-qualifier rewriters, derived-metric
 reference validator, aggregate detection) now rides `expr_tokens`;
 `util::replace_word_boundary` and `derived_metrics::extract_identifiers` are

--- a/src/ddl/alter_helpers_ffi.rs
+++ b/src/ddl/alter_helpers_ffi.rs
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn sv_compute_create_from_yaml_rust(
                 0_u8
             }
             Err(e) => {
-                write_error_buf(error_buf, error_buf_len, &e);
+                write_error_buf(error_buf, error_buf_len, &e.message);
                 2_u8
             }
         }

--- a/src/ddl/define.rs
+++ b/src/ddl/define.rs
@@ -58,12 +58,12 @@
 pub fn enrich_definition_for_create(
     _name: &str,
     mut def: crate::model::SemanticViewDefinition,
-) -> Result<String, String> {
+) -> Result<String, crate::errors::ParseError> {
     // 1. Re-run cardinality inference. Phase 65: no longer preceded by
     //    `resolve_pk_from_catalog` (D-05). Tables without explicit PRIMARY
     //    KEY in the TABLES clause that are FK-referenced by another table
     //    surface as the D-06 hard error in step 2.
-    crate::graph::infer_cardinality(&def.tables, &mut def.joins).map_err(|e| e.message)?;
+    crate::graph::infer_cardinality(&def.tables, &mut def.joins)?;
 
     // 2. Catch joins that reference a target without a PRIMARY KEY (or
     //    UNIQUE constraint) declared in the TABLES clause.
@@ -111,7 +111,7 @@ pub fn enrich_definition_for_create(
         // declared in the TABLES clause. This is unambiguously the D-06
         // case regardless of whether ref_columns is empty (implicit
         // REFERENCES) or set (explicit REFERENCES with cols).
-        return Err(format!(
+        return Err(crate::errors::ParseError::positionless(format!(
             "Table '{target}' has no PRIMARY KEY declared but is \
              referenced by FK in '{fk_source}'. Add PRIMARY KEY \
              (cols) or UNIQUE (cols) to the TABLES clause for \
@@ -119,7 +119,7 @@ pub fn enrich_definition_for_create(
              removed -- see CHANGELOG.)",
             target = t.alias,
             fk_source = fk_source,
-        ));
+        )));
     }
 
     // 3. Graph validations. Name uniqueness runs first (SG-13): dimensions,
@@ -136,5 +136,5 @@ pub fn enrich_definition_for_create(
     // 4. Serialize. Metadata (created_on, database_name, schema_name) is
     //    populated by SQL inside the rewritten INSERT — not here. Column
     //    type inference is deferred to read-side bind (Plan 05).
-    serde_json::to_string(&def).map_err(|e| e.to_string())
+    serde_json::to_string(&def).map_err(|e| crate::errors::ParseError::positionless(e.to_string()))
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,6 +15,33 @@ pub struct ParseError {
     pub position: Option<usize>,
 }
 
+impl ParseError {
+    /// A validation error carrying **no** caret position.
+    ///
+    /// Used by the graph / semantic-validation layer (`graph::*`,
+    /// [`crate::ddl::define::enrich_definition_for_create`]). Those validators
+    /// receive a fully-built
+    /// [`SemanticViewDefinition`](crate::model::SemanticViewDefinition) whose
+    /// members hold owned names / expressions, not byte spans into the original
+    /// DDL — and the original query text is no longer in scope by then — so a
+    /// caret offset is genuinely not recoverable there. Many of these failures
+    /// are also global/topological (a dependency cycle, an ambiguous join
+    /// diamond) with no single offending token to point at.
+    ///
+    /// Emitting a typed `ParseError` (rather than a bare `String`) keeps one
+    /// error type across the parse, graph, and query layers; `position` is
+    /// honestly `None`, exactly as at the parse layer's own semantic-failure
+    /// sites. See TECH-DEBT #31 for the boundary rationale and what threading
+    /// real positions here would require.
+    #[must_use]
+    pub fn positionless(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            position: None,
+        }
+    }
+}
+
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // The `position` is caret-rendering metadata for DuckDB, not part of
@@ -40,6 +67,18 @@ mod tests {
         assert_eq!(err.to_string(), "unexpected token 'FOO'");
         // `Display` must agree with the `.message` field callers still read.
         assert_eq!(err.to_string(), err.message);
+    }
+
+    #[test]
+    fn positionless_has_no_caret_and_displays_message() {
+        let err = ParseError::positionless("duplicate metric name 'revenue'");
+        assert_eq!(err.position, None);
+        assert_eq!(err.to_string(), "duplicate metric name 'revenue'");
+        // Accepts both &str and String.
+        assert_eq!(
+            ParseError::positionless(format!("cycle in {}", "facts")).message,
+            "cycle in facts"
+        );
     }
 
     #[test]

--- a/src/graph/derived_metrics.rs
+++ b/src/graph/derived_metrics.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::Write as _;
 
+use crate::errors::ParseError;
 use crate::model::SemanticViewDefinition;
 use crate::util::suggest_closest;
 
@@ -90,7 +91,7 @@ pub fn contains_aggregate_function(expr: &str) -> Option<&'static str> {
 ///
 /// Returns `Ok(())` if valid, `Err` with descriptive message otherwise.
 #[allow(clippy::too_many_lines)]
-pub fn validate_derived_metrics(def: &SemanticViewDefinition) -> Result<(), String> {
+pub fn validate_derived_metrics(def: &SemanticViewDefinition) -> Result<(), ParseError> {
     let derived: Vec<&crate::model::Metric> = def
         .metrics
         .iter()
@@ -102,10 +103,10 @@ pub fn validate_derived_metrics(def: &SemanticViewDefinition) -> Result<(), Stri
     }
 
     // 1. Check metric name uniqueness (case-insensitive)
-    check_metric_name_uniqueness(def)?;
+    check_metric_name_uniqueness(def).map_err(ParseError::positionless)?;
 
     // 2. Check for aggregate functions in derived metrics
-    check_no_aggregates_in_derived(&derived)?;
+    check_no_aggregates_in_derived(&derived).map_err(ParseError::positionless)?;
 
     // 3. Check for unknown metric references in derived expressions
     let all_metric_names: Vec<&str> = def.metrics.iter().map(|m| m.name.as_str()).collect();
@@ -114,11 +115,12 @@ pub fn validate_derived_metrics(def: &SemanticViewDefinition) -> Result<(), Stri
         .copied()
         .map(ToString::to_string)
         .collect();
-    check_derived_metric_references(&derived, &all_metric_names, &all_metric_names_display)?;
+    check_derived_metric_references(&derived, &all_metric_names, &all_metric_names_display)
+        .map_err(ParseError::positionless)?;
 
     // 4. Check for cycles in derived metric dependency graph
     let derived_name_strs: Vec<&str> = derived.iter().map(|m| m.name.as_str()).collect();
-    check_derived_metric_cycles(&derived, &derived_name_strs)
+    check_derived_metric_cycles(&derived, &derived_name_strs).map_err(ParseError::positionless)
 }
 
 /// Check that no two metrics (base or derived) share the same name (case-insensitive).
@@ -437,7 +439,7 @@ mod tests {
     fn validate_derived_metrics_cycle_detected() {
         // a -> b -> a (cycle)
         let def = make_def_with_derived_metrics(vec![], vec![("a", "b + 1"), ("b", "a + 1")]);
-        let err = validate_derived_metrics(&def).unwrap_err();
+        let err = validate_derived_metrics(&def).unwrap_err().message;
         assert!(
             err.contains("cycle detected in derived metrics"),
             "Expected cycle error, got: {err}"
@@ -451,7 +453,7 @@ mod tests {
             vec![("revenue", "SUM(o.amount)", "o")],
             vec![("profit", "revenue - nonexistent")],
         );
-        let err = validate_derived_metrics(&def).unwrap_err();
+        let err = validate_derived_metrics(&def).unwrap_err().message;
         assert!(
             err.contains("unknown metric") && err.contains("nonexistent"),
             "Expected unknown metric error, got: {err}"
@@ -465,7 +467,7 @@ mod tests {
             vec![("revenue", "SUM(o.amount)", "o")],
             vec![("bad", "SUM(revenue)")],
         );
-        let err = validate_derived_metrics(&def).unwrap_err();
+        let err = validate_derived_metrics(&def).unwrap_err().message;
         assert!(
             err.contains("aggregate function") && err.contains("bad"),
             "Expected aggregate error, got: {err}"
@@ -524,7 +526,7 @@ mod tests {
             vec![("revenue", "SUM(o.amount)", "o")],
             vec![("profit", "revnue - cost")],
         );
-        let err = validate_derived_metrics(&def).unwrap_err();
+        let err = validate_derived_metrics(&def).unwrap_err().message;
         assert!(
             err.contains("did you mean"),
             "Expected 'did you mean?' suggestion, got: {err}"
@@ -567,7 +569,7 @@ mod tests {
             vec![("revenue", "SUM(o.amount)", "o")],
             vec![("bad", "\"No Such Metric\" + 1")],
         );
-        let err = validate_derived_metrics(&def).unwrap_err();
+        let err = validate_derived_metrics(&def).unwrap_err().message;
         assert!(
             err.contains("unknown metric") && err.contains("\"No Such Metric\""),
             "Expected raw quoted name in error, got: {err}"
@@ -596,7 +598,7 @@ mod tests {
             vec![("revenue", "SUM(o.amount)", "o")],
             vec![("revenue", "cost + 1")],
         );
-        let err = validate_derived_metrics(&def).unwrap_err();
+        let err = validate_derived_metrics(&def).unwrap_err().message;
         assert!(
             err.contains("duplicate metric name"),
             "Expected duplicate name error, got: {err}"

--- a/src/graph/facts.rs
+++ b/src/graph/facts.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::Write as _;
 
+use crate::errors::ParseError;
 use crate::model::SemanticViewDefinition;
 use crate::util::suggest_closest;
 
@@ -39,13 +40,13 @@ pub fn find_fact_references<'a>(expr: &str, names: &[&'a str]) -> Vec<&'a str> {
 ///
 /// Returns `Ok(())` if valid, `Err` with descriptive message otherwise.
 #[allow(clippy::too_many_lines)]
-pub fn validate_facts(def: &SemanticViewDefinition) -> Result<(), String> {
+pub fn validate_facts(def: &SemanticViewDefinition) -> Result<(), ParseError> {
     if def.facts.is_empty() {
         return Ok(());
     }
 
     // 1. Check source_table references
-    check_fact_source_tables(def)?;
+    check_fact_source_tables(def).map_err(ParseError::positionless)?;
 
     // Collect fact names
     let fact_names: Vec<&str> = def.facts.iter().map(|f| f.name.as_str()).collect();
@@ -54,10 +55,10 @@ pub fn validate_facts(def: &SemanticViewDefinition) -> Result<(), String> {
     let (edges, in_degree) = build_fact_dag(def, &fact_names);
 
     // 3. Check that all referenced facts exist
-    check_fact_references_exist(&edges, &fact_names)?;
+    check_fact_references_exist(&edges, &fact_names).map_err(ParseError::positionless)?;
 
     // 4. Cycle detection via Kahn's algorithm
-    check_fact_cycles(&edges, in_degree, &fact_names)
+    check_fact_cycles(&edges, in_degree, &fact_names).map_err(ParseError::positionless)
 }
 
 /// Check that each fact's `source_table` is a declared table alias.
@@ -246,7 +247,7 @@ mod tests {
             vec![("o", "orders")],
             vec![("net_price", "x.price", "x")], // 'x' is not a declared table
         );
-        let err = validate_facts(&def).unwrap_err();
+        let err = validate_facts(&def).unwrap_err().message;
         assert!(
             err.contains("unknown source table"),
             "Expected unknown source table error, got: {err}"
@@ -259,7 +260,7 @@ mod tests {
             vec![("orders", "orders")],
             vec![("net_price", "x.price", "ordres")], // typo: 'ordres' vs 'orders'
         );
-        let err = validate_facts(&def).unwrap_err();
+        let err = validate_facts(&def).unwrap_err().message;
         assert!(
             err.contains("unknown source table"),
             "Expected unknown source table error, got: {err}"
@@ -305,7 +306,7 @@ mod tests {
             vec![("o", "orders")],
             vec![("fact_a", "fact_b + 1", "o"), ("fact_b", "fact_a + 1", "o")],
         );
-        let err = validate_facts(&def).unwrap_err();
+        let err = validate_facts(&def).unwrap_err().message;
         assert!(
             err.contains("cycle detected in facts"),
             "Expected cycle error, got: {err}"
@@ -323,7 +324,7 @@ mod tests {
                 ("fact_c", "fact_a + 1", "o"),
             ],
         );
-        let err = validate_facts(&def).unwrap_err();
+        let err = validate_facts(&def).unwrap_err().message;
         assert!(
             err.contains("cycle detected in facts"),
             "Expected cycle error, got: {err}"

--- a/src/graph/names.rs
+++ b/src/graph/names.rs
@@ -24,6 +24,7 @@
 
 use std::collections::HashMap;
 
+use crate::errors::ParseError;
 use crate::model::SemanticViewDefinition;
 
 /// Validate that dimension, metric, and fact names are unique across the
@@ -32,7 +33,7 @@ use crate::model::SemanticViewDefinition;
 /// [`crate::ident::normalize_ident_part`]).
 ///
 /// Returns `Err` naming the colliding item and the kinds involved.
-pub fn validate_name_uniqueness(def: &SemanticViewDefinition) -> Result<(), String> {
+pub fn validate_name_uniqueness(def: &SemanticViewDefinition) -> Result<(), ParseError> {
     let mut seen: HashMap<String, (&str, &str)> = HashMap::new();
     let items = def
         .dimensions
@@ -43,11 +44,11 @@ pub fn validate_name_uniqueness(def: &SemanticViewDefinition) -> Result<(), Stri
     for (kind, name) in items {
         let key = crate::ident::normalize_ident_part(name);
         if let Some((first_kind, first_name)) = seen.get(key.as_str()) {
-            return Err(format!(
+            return Err(ParseError::positionless(format!(
                 "duplicate name '{name}': {kind} '{name}' collides with {first_kind} \
                  '{first_name}' -- dimension, metric, and fact names share one namespace \
                  and are case-insensitive (quoting does not make a name distinct)"
-            ));
+            )));
         }
         seen.insert(key, (kind, name));
     }
@@ -100,7 +101,7 @@ mod tests {
     #[test]
     fn duplicate_metric_names_rejected_case_insensitively() {
         let def = def_with(&[], &["Revenue", "revenue"], &[]);
-        let err = validate_name_uniqueness(&def).unwrap_err();
+        let err = validate_name_uniqueness(&def).unwrap_err().message;
         assert!(
             err.contains("duplicate name 'revenue'")
                 && err.contains("metric 'revenue' collides with metric 'Revenue'"),
@@ -111,7 +112,7 @@ mod tests {
     #[test]
     fn dimension_metric_collision_rejected() {
         let def = def_with(&["region"], &["REGION"], &[]);
-        let err = validate_name_uniqueness(&def).unwrap_err();
+        let err = validate_name_uniqueness(&def).unwrap_err().message;
         assert!(
             err.contains("metric 'REGION' collides with dimension 'region'"),
             "unexpected error: {err}"
@@ -121,7 +122,7 @@ mod tests {
     #[test]
     fn fact_dimension_collision_rejected() {
         let def = def_with(&["amount"], &[], &["amount"]);
-        let err = validate_name_uniqueness(&def).unwrap_err();
+        let err = validate_name_uniqueness(&def).unwrap_err().message;
         assert!(
             err.contains("fact 'amount' collides with dimension 'amount'"),
             "unexpected error: {err}"
@@ -131,7 +132,7 @@ mod tests {
     #[test]
     fn duplicate_dimension_names_rejected() {
         let def = def_with(&["region", "Region"], &[], &[]);
-        let err = validate_name_uniqueness(&def).unwrap_err();
+        let err = validate_name_uniqueness(&def).unwrap_err().message;
         assert!(
             err.contains("dimension 'Region' collides with dimension 'region'"),
             "unexpected error: {err}"
@@ -141,7 +142,7 @@ mod tests {
     #[test]
     fn metric_fact_collision_rejected() {
         let def = def_with(&[], &["net_price"], &["Net_Price"]);
-        let err = validate_name_uniqueness(&def).unwrap_err();
+        let err = validate_name_uniqueness(&def).unwrap_err().message;
         assert!(
             err.contains("fact 'Net_Price' collides with metric 'net_price'"),
             "unexpected error: {err}"
@@ -157,7 +158,7 @@ mod tests {
     #[test]
     fn quoted_and_unquoted_folding_to_same_key_collide() {
         let def = def_with(&["\"region\"", "REGION"], &[], &[]);
-        let err = validate_name_uniqueness(&def).unwrap_err();
+        let err = validate_name_uniqueness(&def).unwrap_err().message;
         assert!(
             err.contains("duplicate name 'REGION'") && err.contains("dimension '\"region\"'"),
             "unexpected error: {err}"
@@ -172,7 +173,7 @@ mod tests {
     #[test]
     fn quoted_names_differing_in_case_collide() {
         let def = def_with(&["\"Region\"", "\"REGION\""], &[], &[]);
-        let err = validate_name_uniqueness(&def).unwrap_err();
+        let err = validate_name_uniqueness(&def).unwrap_err().message;
         assert!(
             err.contains("duplicate name"),
             "quoted mixed-case names share key `region`: {err}"
@@ -185,7 +186,7 @@ mod tests {
     #[test]
     fn unquoted_and_quoted_same_name_collide() {
         let def = def_with(&["region", "\"Region\""], &[], &[]);
-        let err = validate_name_uniqueness(&def).unwrap_err();
+        let err = validate_name_uniqueness(&def).unwrap_err().message;
         assert!(
             err.contains("duplicate name"),
             "unquoted `region` and quoted `\"Region\"` share key `region`: {err}"

--- a/src/graph/relationship.rs
+++ b/src/graph/relationship.rs
@@ -10,6 +10,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
+use crate::errors::ParseError;
 use crate::model::SemanticViewDefinition;
 use crate::util::suggest_closest;
 
@@ -299,7 +300,7 @@ fn check_source_tables_reachable(
 /// **Legacy skip:** If no joins have non-empty `fk_columns`, or if `tables`
 /// is empty, returns `Ok` with a default empty graph. This preserves backward
 /// compatibility with Phase 10/11 definitions.
-pub fn validate_graph(def: &SemanticViewDefinition) -> Result<RelationshipGraph, String> {
+pub fn validate_graph(def: &SemanticViewDefinition) -> Result<RelationshipGraph, ParseError> {
     // Legacy skip: no Phase 24 joins -> skip graph validation entirely.
     let has_pkfk_joins = def.joins.iter().any(|j| !j.fk_columns.is_empty());
     if !has_pkfk_joins || def.tables.is_empty() {
@@ -311,22 +312,24 @@ pub fn validate_graph(def: &SemanticViewDefinition) -> Result<RelationshipGraph,
         });
     }
 
-    let graph = RelationshipGraph::from_definition(def)?;
+    let graph = RelationshipGraph::from_definition(def).map_err(ParseError::positionless)?;
 
     // 1. Cycle detection (Kahn's algorithm).
-    let _topo_order = graph.toposort()?;
+    let _topo_order = graph.toposort().map_err(ParseError::positionless)?;
 
     // 2. Diamond detection (multiple parents, relaxed for named role-playing).
-    graph.check_no_diamonds(def)?;
+    graph
+        .check_no_diamonds(def)
+        .map_err(ParseError::positionless)?;
 
     // 3. Orphan table detection.
-    graph.check_no_orphans()?;
+    graph.check_no_orphans().map_err(ParseError::positionless)?;
 
     // 4. FK reference validation (Phase 33: replaces FK/PK count check).
-    validate_fk_references(def)?;
+    validate_fk_references(def).map_err(ParseError::positionless)?;
 
     // 5. Source table reachability.
-    check_source_tables_reachable(def, &graph)?;
+    check_source_tables_reachable(def, &graph).map_err(ParseError::positionless)?;
 
     Ok(graph)
 }
@@ -350,7 +353,7 @@ mod tests {
             vec![],
             vec![],
         );
-        let err = validate_graph(&def).unwrap_err();
+        let err = validate_graph(&def).unwrap_err().message;
         assert!(
             err.contains("cannot reference itself"),
             "expected self-reference error, got: {err}"
@@ -378,7 +381,7 @@ mod tests {
             vec![],
             vec![],
         );
-        let err = validate_graph(&def).unwrap_err();
+        let err = validate_graph(&def).unwrap_err().message;
         assert!(
             err.contains("cycle detected in relationships"),
             "expected cycle error, got: {err}"
@@ -408,7 +411,7 @@ mod tests {
             vec![],
             vec![],
         );
-        let err = validate_graph(&def).unwrap_err();
+        let err = validate_graph(&def).unwrap_err().message;
         assert!(
             err.contains("diamond") && err.contains("reachable from multiple tables"),
             "expected diamond error, got: {err}"
@@ -432,7 +435,7 @@ mod tests {
             vec![],
             vec![],
         );
-        let err = validate_graph(&def).unwrap_err();
+        let err = validate_graph(&def).unwrap_err().message;
         assert!(err.contains("orphan"), "expected orphan error, got: {err}");
     }
 
@@ -471,7 +474,7 @@ mod tests {
             vec![("name", Some("x"))], // 'x' is not in tables
             vec![],
         );
-        let err = validate_graph(&def).unwrap_err();
+        let err = validate_graph(&def).unwrap_err().message;
         assert!(
             err.contains("unknown source table"),
             "expected unreachable source table error, got: {err}"
@@ -486,7 +489,7 @@ mod tests {
             vec![],
             vec![("revenue", Some("missing"))],
         );
-        let err = validate_graph(&def).unwrap_err();
+        let err = validate_graph(&def).unwrap_err().message;
         assert!(
             err.contains("unknown source table"),
             "expected unreachable source table error, got: {err}"
@@ -612,7 +615,7 @@ mod tests {
             vec![("name", Some("custmers"))], // typo -> should suggest "c" or similar
             vec![],
         );
-        let err = validate_graph(&def).unwrap_err();
+        let err = validate_graph(&def).unwrap_err().message;
         assert!(
             err.contains("unknown source table"),
             "expected unknown source table error, got: {err}"
@@ -716,7 +719,7 @@ mod tests {
             ],
             vec![("cnt", Some("a"), vec![])],
         );
-        let err = validate_graph(&def).unwrap_err();
+        let err = validate_graph(&def).unwrap_err().message;
         assert!(
             err.contains("diamond") && err.contains("reachable from multiple tables"),
             "cross-source named diamond must be rejected: {err}"
@@ -734,7 +737,7 @@ mod tests {
             ],
             vec![("flight_count", Some("f"), vec![])],
         );
-        let err = validate_graph(&def).unwrap_err();
+        let err = validate_graph(&def).unwrap_err().message;
         assert!(
             err.contains("diamond"),
             "Unnamed diamonds should be rejected: {err}"
@@ -752,7 +755,7 @@ mod tests {
             ],
             vec![("flight_count", Some("f"), vec![])],
         );
-        let err = validate_graph(&def).unwrap_err();
+        let err = validate_graph(&def).unwrap_err().message;
         assert!(
             err.contains("diamond"),
             "Mixed named/unnamed diamonds should be rejected: {err}"

--- a/src/graph/using.rs
+++ b/src/graph/using.rs
@@ -4,6 +4,7 @@
 //! derived metrics must not have USING, each relationship must exist, and
 //! each relationship must originate from the metric's source table.
 
+use crate::errors::ParseError;
 use crate::model::SemanticViewDefinition;
 
 /// Validate that all `using_relationships` references on metrics are valid.
@@ -14,7 +15,7 @@ use crate::model::SemanticViewDefinition;
 /// 3. Each referenced relationship must originate from the metric's `source_table`.
 ///
 /// Returns `Ok(())` if all references are valid, `Err` with descriptive message otherwise.
-pub fn validate_using_relationships(def: &SemanticViewDefinition) -> Result<(), String> {
+pub fn validate_using_relationships(def: &SemanticViewDefinition) -> Result<(), ParseError> {
     // Collect all named relationships for lookup
     let named_rels: Vec<(&crate::model::Join, String)> = def
         .joins
@@ -31,10 +32,10 @@ pub fn validate_using_relationships(def: &SemanticViewDefinition) -> Result<(), 
 
         // Check 1: derived metrics must not have USING
         if metric.source_table.is_none() {
-            return Err(format!(
+            return Err(ParseError::positionless(format!(
                 "USING clause not allowed on derived metric '{}'",
                 metric.name
-            ));
+            )));
         }
 
         let metric_source = metric.source_table.as_ref().unwrap().to_ascii_lowercase();
@@ -47,23 +48,23 @@ pub fn validate_using_relationships(def: &SemanticViewDefinition) -> Result<(), 
 
             match found {
                 None => {
-                    return Err(format!(
+                    return Err(ParseError::positionless(format!(
                         "unknown relationship '{rel_name}' in USING clause of metric '{}'. \
                          Available: [{}]",
                         metric.name,
                         available_names.join(", ")
-                    ));
+                    )));
                 }
                 Some((join, _)) => {
                     // Check 3: relationship must originate from metric's source_table
                     let from_lower = join.from_alias.to_ascii_lowercase();
                     if from_lower != metric_source {
-                        return Err(format!(
+                        return Err(ParseError::positionless(format!(
                             "relationship '{rel_name}' does not originate from table '{}' \
                              (metric '{}')",
                             metric.source_table.as_ref().unwrap(),
                             metric.name
-                        ));
+                        )));
                     }
                 }
             }
@@ -104,7 +105,7 @@ mod tests {
             vec![(Some("dep_airport"), "f", "a", vec!["dep_id"])],
             vec![("departure_count", Some("f"), vec!["nonexistent"])],
         );
-        let err = validate_using_relationships(&def).unwrap_err();
+        let err = validate_using_relationships(&def).unwrap_err().message;
         assert!(
             err.contains("unknown relationship") && err.contains("nonexistent"),
             "Expected unknown relationship error, got: {err}"
@@ -131,7 +132,7 @@ mod tests {
             // Metric is on "p" but references "dep_airport" which originates from "f"
             vec![("pax_count", Some("p"), vec!["dep_airport"])],
         );
-        let err = validate_using_relationships(&def).unwrap_err();
+        let err = validate_using_relationships(&def).unwrap_err().message;
         assert!(
             err.contains("does not originate"),
             "Expected wrong source table error, got: {err}"
@@ -146,7 +147,7 @@ mod tests {
             vec![(Some("dep_airport"), "f", "a", vec!["dep_id"])],
             vec![("derived_met", None, vec!["dep_airport"])],
         );
-        let err = validate_using_relationships(&def).unwrap_err();
+        let err = validate_using_relationships(&def).unwrap_err().message;
         assert!(
             err.contains("derived metric") && err.contains("USING"),
             "Expected USING on derived metric error, got: {err}"

--- a/src/parse/native_sql.rs
+++ b/src/parse/native_sql.rs
@@ -203,11 +203,7 @@ fn emit_native_create_sql(
     // column type inference (`column_type_names`, fact `output_type`)
     // is deferred to read-side bind under Plan 05's C++ Catalog API
     // migration (D-17).
-    let enriched_json =
-        crate::ddl::define::enrich_definition_for_create(&name, def).map_err(|e| ParseError {
-            message: e,
-            position: None,
-        })?;
+    let enriched_json = crate::ddl::define::enrich_definition_for_create(&name, def)?;
     let enriched_escaped = SqlLit::escape(&enriched_json);
 
     // Metadata-via-SQL sub-expression: produces a VARCHAR by patching

--- a/src/parse/rewrite.rs
+++ b/src/parse/rewrite.rs
@@ -1802,7 +1802,8 @@ mod tests {
                 ..Default::default()
             };
             let err = crate::ddl::define::enrich_definition_for_create("v_bad", def)
-                .expect_err("D-06 hard error must fire for FK→no-PK");
+                .expect_err("D-06 hard error must fire for FK→no-PK")
+                .message;
             assert!(
                 err.contains("has no PRIMARY KEY declared but is referenced by FK in"),
                 "D-06 substring missing in error: {err}"
@@ -1840,7 +1841,8 @@ mod tests {
                 ..Default::default()
             };
             let err = crate::ddl::define::enrich_definition_for_create("v_dup", def)
-                .expect_err("cross-kind name collision must be rejected at define time");
+                .expect_err("cross-kind name collision must be rejected at define time")
+                .message;
             assert!(
                 err.contains("duplicate name 'REGION'")
                     && err.contains("metric 'REGION' collides with dimension 'region'"),


### PR DESCRIPTION
Completes the last named structural item from code-review 2026-07-16 (§6 item 1 / §7.5): *"the typed-error rollout stops at the graph/validation layer (~15 `Result<_, String>` signatures with no positions)… Extend the treatment **or** write the paragraph declaring the boundary deliberate — currently it reads as an unfinished rollout."* This does **both**.

## What changed

The CREATE-time funnel and the graph module's **public** validators now speak the shared typed error `ParseError` (which `graph::infer_cardinality` already returned), instead of bare `String`:

- `validate_name_uniqueness`, `validate_facts`, `validate_derived_metrics`, `validate_graph`, `validate_using_relationships` → `Result<_, ParseError>`
- `enrich_definition_for_create` → `Result<String, ParseError>`; the two CREATE call sites (`parse::native_sql`, `ddl::alter_helpers_ffi`) consume it directly (the manual `ParseError { message, position: None }` wrap at the funnel is gone).
- New constructor `ParseError::positionless(msg)` makes the absence of a caret explicit and self-documenting at each site.

**Bounded by design:** the private per-check helpers (`check_*`) and the externally-shared sub-validators (`RelationshipGraph::from_definition` / `check_no_diamonds` / `check_no_orphans` / `validate_fk_references` / `toposort` — also called by `SHOW … FOR METRIC`) keep their `String` signatures and are wrapped with `.map_err(ParseError::positionless)` at the public boundary. So nothing `String`-typed propagates upward past the graph module, and **no non-CREATE caller is disturbed**.

## Why `position` is `None` (documented, not forgotten)

Scoping this revealed the positionless boundary is currently *forced*, not merely stylistic: these validators receive a fully-built `SemanticViewDefinition` whose members (`Metric`/`Dimension`/`Fact`/`Join`) hold **owned** names/expressions — not byte spans into the original DDL, which is out of scope by then — so `util::byte_offset_within` (needs the token to be a subslice of the original query) can't apply. Several failures are also **global/topological** (dependency cycles, ambiguous join diamonds, empty TABLES) with no single token to point at. This mirrors the already-accepted positionless-typed `expand::ExpandError` and the parse layer's own `position: None` semantic-failure sites. TECH-DEBT #31 documents the rationale and exactly what threading real carets here would require (a model change), so a future PR can pick it up deliberately.

## Behavior-preserving

Error messages are **byte-identical** (`Display` emits only `message`), and CREATE already surfaced `position: None` for these errors — so there is zero user-visible change. This is why there's no CHANGELOG entry and no new sqllogictest: the existing CREATE-validation sqllogictests (cycles, name collisions, diamonds, unknown references) exercise every converted path and **pass unchanged**, which is the regression proof.

## Also in this PR — a test-infrastructure gap this change exposed

The `ParseError` signature change broke two `#[cfg(feature = "extension")]` unit tests that assert on the returned error — and **no CI job compiled them**, because CI builds the Rust suite on default features (`cargo nextest run` / `llvm-cov nextest`) and `extension` is not a default feature. Fixing that:

- `parse::rewrite` tests calling `enrich_definition_for_create` now read `.message` before `.contains(..)`.
- Found a second, pre-existing casualty of the same blind spot: `ddl::read_yaml::resolve_bare_name_folds_unquoted` asserted a quoted `"MyView"` keeps its case, contradicting `ident::normalize_view_name` (which folds quoted names to lowercase, per its own tests and the documented view-name rule). Corrected to `myview`, renamed to `resolve_bare_name_folds_to_lowercase`.
- **Closed the gap**: added an extension-feature unit-test step to `just test-rust` and CI (`CodeQuality.yml`), mirroring the existing extension-doctest step, so `#[cfg(feature = "extension")]` unit tests can no longer rot unnoticed.

## Verification

Full local gate green: `cargo test` (1225 default, 0 failed — +1 for the `positionless` constructor test; graph-validator unit tests updated to assert on `.message`), **`cargo test --lib --no-default-features --features extension` (1242, 0 failed)**, `cargo clippy -- -D warnings` (default + extension), `make debug` + `make test_debug` (sqllogictest 76/76). DuckLake relied on CI as in prior PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VwD1GmJQWQbFvRe1b3qxR