### PR TITLE
Run extension-feature unit tests in CI (and fix a stale test they were hiding)

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -70,6 +70,15 @@ jobs:
       - name: FFI doctests (extension feature, compile_fail ABI guard)
         run: SV_SKIP_CPP_BUILD=1 cargo test --doc --no-default-features --features extension read_ffi
 
+      # The coverage step below runs `cargo llvm-cov nextest` on default
+      # features, so #[cfg(feature = "extension")] UNIT tests are compiled in no
+      # other job — they silently rotted twice (a stale assertion and a
+      # signature-change compile break) before this step existed. --lib scopes
+      # to the library's own tests (integration crates assume the default
+      # `duckdb` feature); SV_SKIP_CPP_BUILD skips the C++ build.
+      - name: Unit tests (extension feature)
+        run: SV_SKIP_CPP_BUILD=1 cargo test --lib --no-default-features --features extension
+
       # Pinned to a commit SHA (not the floating @v2) because the v2.1.0/v2.1.1
       # releases (2026-07-13) bundle cargo-deny 0.20.2, whose CLI refactor drops
       # the `--log-level` argument this action still passes — breaking the step

--- a/Justfile
+++ b/Justfile
@@ -43,6 +43,13 @@ test-rust:
     cargo nextest run
     cargo test --doc
     SV_SKIP_CPP_BUILD=1 cargo test --doc --no-default-features --features extension read_ffi
+    # `cargo nextest run` above uses default features, so #[cfg(feature =
+    # "extension")] UNIT tests are otherwise never compiled or run — two such
+    # tests silently rotted (a stale assertion + a signature-change compile
+    # break) before this step was added. --lib scopes to the library's own
+    # tests (the integration crates assume the default `duckdb` feature);
+    # SV_SKIP_CPP_BUILD skips the C++ build, the pure-Rust tests still run.
+    SV_SKIP_CPP_BUILD=1 cargo test --lib --no-default-features --features extension
 
 # Run all lints
 lint:

--- a/src/ddl/read_yaml.rs
+++ b/src/ddl/read_yaml.rs
@@ -126,10 +126,14 @@ mod tests {
     }
 
     #[test]
-    fn resolve_bare_name_folds_unquoted() {
-        // PA-8 consistency: unquoted references fold to lowercase like
-        // every other lookup path.
+    fn resolve_bare_name_folds_to_lowercase() {
+        // View-name lookup folds to lowercase the same way `normalize_view_name`
+        // and every other lookup path does — for quoted names too. Under
+        // DuckDB's identifier rule (and this project's documented view-name
+        // normalization) quoting only lets a name carry special characters; it
+        // does NOT preserve case. Stored view names are lowercase, so a request
+        // written `"MyView"` must resolve to `myview` to find the view.
         assert_eq!(resolve_bare_name("MyView"), "myview");
-        assert_eq!(resolve_bare_name("\"MyView\""), "MyView");
+        assert_eq!(resolve_bare_name("\"MyView\""), "myview");
     }
 }


### PR DESCRIPTION
Follow-up to #123. That PR's `ParseError` signature change broke two `#[cfg(feature = "extension")]` unit tests — and **no CI job compiled them**, so nothing caught it. This closes that gap and fixes a second, pre-existing casualty of it.

## The gap

CI builds the Rust suite on **default features** (`cargo nextest run` and `llvm-cov nextest`), and `extension` is not a default feature (`default = ["duckdb/bundled"]`). So every `#[cfg(feature = "extension")]` unit test is compiled in **no CI job** — four such test modules (`read_yaml`, `rewrite`, `alter_helpers_ffi`, `parse/mod`) were entirely dark to CI and could rot silently. Two already had.

## Changes

- **Fix a stale assertion the gap was hiding.** `ddl::read_yaml`'s `resolve_bare_name_folds_unquoted` asserted that a quoted `"MyView"` resolves to `MyView` (case preserved). That contradicts `ident::normalize_view_name`, which folds quoted names to lowercase too — per its own authoritative tests (`"Sales"` → `sales`, `"ORDERS SV"` → `orders sv`) and the documented DuckDB view-name rule (stored view names are lowercase, so a `"MyView"` request must fold to `myview` to find the view). Corrected the assertion to `myview`, renamed the test to `resolve_bare_name_folds_to_lowercase`, and fixed the self-contradictory comment.
- **Close the gap.** Added an extension-feature unit-test step to `just test-rust` and CI (`CodeQuality.yml`), mirroring the existing extension-doctest step: `SV_SKIP_CPP_BUILD=1 cargo test --lib --no-default-features --features extension`. `--lib` scopes to the library's own tests (the integration crates assume the default `duckdb` feature); `SV_SKIP_CPP_BUILD` skips the C++ build (the pure-Rust unit tests still run).

(The other casualty — the `rewrite.rs` `.contains()` calls on what's now a `ParseError` — was already fixed and merged as part of #123.)

## Verification

The full extension-feature lib suite is green — **1242 passed, 0 failed** — covering all four previously-dark modules. Default `cargo test`, clippy (default + extension), and fmt are unaffected (the assertion fix is extension-gated test code; the Justfile/CI additions aren't compiled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VwD1GmJQWQbFvRe1b3qxR

---
_Generated by [Claude Code](https://claude.ai/code/session_019VwD1GmJQWQbFvRe1b3qxR)_