### PR TITLE
test/fuzz: run CI fuzzing, harden proptests, correct fuzz oracles + render round-trip guard (CI-1 + Bucket A)

### DIFF
--- a/.github/workflows/Fuzz.yml
+++ b/.github/workflows/Fuzz.yml
@@ -40,7 +40,30 @@ jobs:
         run: cargo fuzz build ${{ matrix.target }}
 
       - name: Run fuzzer
-        run: cargo fuzz run ${{ matrix.target }} fuzz/corpus/${{ matrix.target }} fuzz/seeds/${{ matrix.target }} -- -max_total_time=${{ env.FUZZ_TIME }} || true
+        run: |
+          # libFuzzer refuses to start if the corpus/seeds directories are
+          # absent (they are gitignored), exiting instantly — so create them
+          # first. Without this, 7 of 8 targets fuzzed nothing yet went green.
+          mkdir -p fuzz/corpus/${{ matrix.target }} fuzz/seeds/${{ matrix.target }}
+          set +e
+          cargo fuzz run ${{ matrix.target }} fuzz/corpus/${{ matrix.target }} fuzz/seeds/${{ matrix.target }} -- -max_total_time=${{ env.FUZZ_TIME }}
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            exit 0
+          fi
+          # A non-zero exit WITH a crash artifact is a real finding — the
+          # "Check for crash artifacts" step (and its uploader/issue/fail
+          # steps) owns that path, so let this step succeed and hand off.
+          if find fuzz/artifacts/${{ matrix.target }} -type f \( -name 'crash-*' -o -name 'oom-*' -o -name 'timeout-*' -o -name 'slow-unit-*' \) 2>/dev/null | grep -q .; then
+            echo "Fuzzer exited $rc with crash artifacts present — handled by crash-detection steps."
+            exit 0
+          fi
+          # Non-zero with NO artifacts means the fuzzer failed to start (bad
+          # corpus dir, build/link error, OOM before writing). Fail loudly
+          # instead of masking it with a trailing || true.
+          echo "::error::cargo fuzz run ${{ matrix.target }} failed to start (exit $rc) with no crash artifacts"
+          exit $rc
 
       - name: Check for crash artifacts
         id: check

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -509,7 +509,7 @@ cargo +nightly fuzz list          # see available targets
 | `fuzz_yaml_parse` | Feeds arbitrary bytes to the YAML import path | Panics / serde surprises in YAML deserialization |
 | `fuzz_ddl_parse` | Arbitrary bytes → `plan_rewrite` (the full CREATE/DDL front door) | Panics or hangs in DDL parsing on malformed statements |
 | `fuzz_keyword_body` | Arbitrary bytes → `parse_keyword_body` (bypasses prefix detection) | Panics in the clause-body parser; asserts anything parsed also renders |
-| `fuzz_render_roundtrip` | Generated definitions → render → parse → render | Break in the fixpoint `render(parse(render(def))) == render(def)` |
+| `fuzz_render_roundtrip` | Generated definitions → normalize once via `parse(render(def))` → assert `render` is idempotent on the parser-produced def | Grammar drift between `render_ddl` and the body parser (dropped field, reordered clause, mis-quoted identifier). Uses the converge-once invariant, not the strong `render(parse(render(def))) == render(def)` fixpoint — that is unsatisfiable on arbitrary defs (a free-form `expr`'s surrounding whitespace is trimmed by the parser and cannot be quote-protected) |
 | `fuzz_sql_expand` | Arbitrary `SemanticViewDefinition` + name arrays → `expand()` | Panics/assertion failures in SQL generation; quote/paren imbalance in the emitted SQL |
 | `fuzz_query_names` | Fuzzes dimension/metric name strings against a fixed known-good definition | SQL injection via user-supplied column names, quoting bugs, name resolution panics |
 | `fuzz_parser_override_ffi` | Drives the `parser_override` FFI entry path with fuzzed input | Panics crossing the FFI boundary; unexpected rc / error propagation |

--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -306,9 +306,26 @@ Areas where test coverage is reduced compared to ideal, with justification.
 - **Resolution (2026-07-17):** `expand/semi_additive.rs` routes every NON ADDITIVE BY dimension through the **same** `find_using_context` the queried-dim path uses, via a new `na_dim_scoped_alias(view_name, def, met, na_dim)` helper (single-metric `USING` context per NA dim). The three outcomes mirror the queried-dim path exactly: not role-playing → `None` → raw expression (unchanged, backward-compatible); role-playing + one `USING` → `Some(scoped)` → the snapshot `ORDER BY` is rewritten to the scoped alias (`a__arr_airport.city`) and the redundant bare join is suppressed (`collect_na_dim_source_tables` skips it — the metric's `USING` already joins the scoped instance); role-playing + no/ambiguous `USING` → `Err(AmbiguousPath)` (fail loud, was silent-wrong). The resolved scoped alias is folded into the `collect_na_groups` group key, so two metrics that share an NA dim but pin different roles land on separate `RANK()` columns (the same defence the #129 polarity fix added for order/nulls).
 - **Tests:** four `semi_additive.rs` unit tests (scoped-alias ORDER BY under `arr`/`dep`; the no-`USING` ambiguity error; different-`USING` metrics get separate RANK columns) plus a data-level `execution` test whose fixture makes the arrival-role and departure-role snapshots pick different rows (arrival → 200, departure → 100) so a role regression flips the number, and an end-to-end sqllogictest fixture through `CREATE SEMANTIC VIEW` + `semantic_view()`. This closes the last SPECULATIVE cell from the 2026-07-16 review.
 
+### 33. ❌ Struct-domain fuzz targets test unreachable inputs — oracle patched (converge-once + fragment precondition); full redesign deferred
+
+- **Origin:** 2026-07-18. Once CI-1 made the fuzz targets actually run, `fuzz_render_roundtrip` and `fuzz_sql_expand` both flagged non-bugs. Both are symptoms of one design flaw: the targets `#[derive(Arbitrary)]` a whole `SemanticViewDefinition`, but `render`/`expand` are only ever called on **parser-produced** structs. The manufactured input domain is far larger than the reachable one, so each oracle has to re-derive "is this input well-formed?" — and that re-derivation is where the false positives live.
+  - `fuzz_render_roundtrip`: the strong fixpoint `render(parse(render(def))) == render(def)` is **unsatisfiable** on arbitrary defs — a free-form `expr` with surrounding whitespace is trimmed by the parser (`" "` → `""`) and cannot be quote-protected. (The e35cf15 identifier quote-protection only ever mattered for such unreachable inputs; it is a no-op for parser-produced defs and is kept as defensive hardening.)
+  - `fuzz_sql_expand`: `def_fragments_balanced()` (a precondition guarding the `is_balanced` assertion) omitted the `output_type` and window `window_function` fragments, which `expand` interpolates raw into `CAST(expr AS <type>)` / `FUNC(...)`; an unbalanced type/function name then manufactured unbalanced SQL from "balanced" inputs.
+- **Applied now (A):** `fuzz_render_roundtrip` switched to the **converge-once** invariant — normalize once via `parse(render(def))` to land on a parser-produced def, then assert `render` is idempotent on it (mirrored by the `assert_render_fixpoint` unit helper + three regression tests in `render_ddl.rs`). `fuzz_sql_expand`'s precondition extended to include `output_type` (dim/metric/fact) and `window_function`. Coverage is preserved: the strict `parse(render(def)) == def` equality for canonical defs lives in `tests/roundtrip_proptest.rs`.
+- **Deferred (B):** a from-scratch redesign that removes the domain mismatch instead of patching each instance —
+  - fuzz at the **trust boundary** (raw text / bytes) and derive every downstream struct by running the real parser, so preconditions and "tolerate re-parse failure" escapes vanish (a parsed def's fragments are balanced by construction);
+  - prefer **differential oracles** (does DuckDB parse the expanded SQL? does re-parse reproduce the struct?) over hand-rolled structural checks like `is_balanced`, which re-implement the lexer and can drift into their own bug source;
+  - split harnesses by fit — **libFuzzer** for coverage-guided byte mutation on the text→parser targets, **proptest** (shrinking, in-tree `cargo test`) for the struct-property round-trip/idempotence/differential checks, removing today's overlap;
+  - ship a **curated seed corpus** of real DDL (valid + known-tricky: quoted idents with commas, dotted FQNs, window frames) so mutation starts from reachable inputs.
+  - `Arbitrary`-on-the-struct stays correct only for the serde boundary (`fuzz_json_parse` / `fuzz_yaml_parse`), which has no sub-grammar. Tracked as its own follow-up PR.
+
 ---
 
-**Last updated:** 2026-07-17 (v0.11 unreleased) — semi-additive × role-playing
+**Last updated:** 2026-07-18 (v0.11 unreleased) — added entry #33: the
+struct-domain fuzz targets (`fuzz_render_roundtrip`, `fuzz_sql_expand`) test
+inputs the parser can't produce; oracles patched now (converge-once idempotence +
+`output_type`/`window_function` in the balance precondition), full trust-boundary
+redesign deferred to its own PR. Prior: 2026-07-17 — semi-additive × role-playing
 landed (entry #32, F-18 / T-15): an unqueried `NON ADDITIVE BY` dimension on a
 role-playing target now resolves through `role_playing::find_using_context` like
 a queried dimension, so the snapshot ranks by the role the metric's `USING`

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1695,6 +1695,8 @@ dependencies = [
  "arbitrary",
  "libfuzzer-sys",
  "semantic_views",
+ "serde_json",
+ "yaml_serde",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,10 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
 semantic_views = { path = "..", features = ["arbitrary"] }
+# Symmetric (de)serializers for the JSON / YAML parse-target round-trip oracles.
+# Kept at the same versions the parent crate pins so resolution is a no-op.
+serde_json = "1"
+yaml_serde = "0.10"
 
 # Prevent this from being absorbed into the parent workspace
 [workspace]

--- a/fuzz/fuzz_targets/fuzz_ddl_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_ddl_parse.rs
@@ -6,7 +6,10 @@
 // The same inputs are asserted as permanent regression tests in
 // tests/quoted_idents_regression.rs (workspace-level cargo test).
 use libfuzzer_sys::fuzz_target;
-use semantic_views::parse::{detect_semantic_view_ddl, plan_rewrite, PARSE_DETECTED};
+use semantic_views::parse::{
+    detect_semantic_view_ddl, plan_rewrite, RewriteAction, PARSE_DETECTED,
+};
+use semantic_views::render_ddl::render_create_ddl;
 
 fuzz_target!(|data: &[u8]| {
     // Reject invalid UTF-8 — not a crash, just out of scope for this target.
@@ -21,6 +24,18 @@ fuzz_target!(|data: &[u8]| {
     // (a structured RewriteAction, None, or ParseError) is all acceptable —
     // only a panic would be a fuzz failure.
     if detected == PARSE_DETECTED {
-        let _ = plan_rewrite(query);
+        if let Ok(Some(RewriteAction::Create { name, def, .. })) = plan_rewrite(query) {
+            // Render oracle: a definition the CREATE front door accepted must
+            // reconstruct to DDL. `render_create_ddl`'s ONLY error is the
+            // documented legacy case of an empty `tables` list (reachable via
+            // `FROM YAML $$...$$`), so any OTHER failure is a real render bug.
+            match render_create_ddl(&name, &def) {
+                Ok(_) => {}
+                Err(_) => assert!(
+                    def.tables.is_empty(),
+                    "render_create_ddl failed on a non-legacy definition plan_rewrite accepted"
+                ),
+            }
+        }
     }
 });

--- a/fuzz/fuzz_targets/fuzz_json_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_json_parse.rs
@@ -1,10 +1,25 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use semantic_views::model::SemanticViewDefinition;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
         // Must not panic regardless of input.
         // Errors are fine -- panics/UB are not.
-        let _ = semantic_views::model::SemanticViewDefinition::from_json("fuzz_test", s);
+        if let Ok(def) = SemanticViewDefinition::from_json("fuzz_test", s) {
+            // Serde round-trip oracle: a definition that parsed must
+            // re-serialize and re-parse to an equal value. `from_json` is a
+            // thin wrapper over `serde_json::from_str`, and every field's
+            // `skip_serializing_if` matches its `default`, so serialize ->
+            // deserialize is the identity.
+            let reserialized =
+                serde_json::to_string(&def).expect("serialize parsed def back to JSON");
+            let reparsed = SemanticViewDefinition::from_json("fuzz_test", &reserialized)
+                .expect("re-parse of serialized def must succeed");
+            assert_eq!(
+                def, reparsed,
+                "JSON serde round-trip changed the definition"
+            );
+        }
     }
 });

--- a/fuzz/fuzz_targets/fuzz_query_names.rs
+++ b/fuzz/fuzz_targets/fuzz_query_names.rs
@@ -19,9 +19,51 @@ fuzz_target!(|input: NameFuzzInput| {
     };
     if let Ok(sql) = expand("fuzz_view", &def, &req) {
         assert!(!sql.is_empty());
-        assert!(sql.starts_with("WITH"));
+        // Structural oracle: the emitted SQL must have balanced parentheses
+        // once single-quoted string literals are ignored, and every literal
+        // must be closed. The fixed definition's identifiers are known-good
+        // (no parens/quotes), so any imbalance is a real code-gen defect —
+        // strictly stronger than the previous `starts_with("WITH")` check.
+        assert!(
+            parens_balanced_outside_quotes(&sql),
+            "expand produced structurally-invalid SQL: {sql}"
+        );
     }
 });
+
+/// True iff parentheses are balanced when single-quoted string literals are
+/// skipped, the nesting depth never goes negative, and no literal is left open.
+/// A doubled `''` inside a literal is an escaped quote (stays inside the
+/// literal). `(`, `)`, and `'` are ASCII, so byte scanning is UTF-8-safe.
+fn parens_balanced_outside_quotes(sql: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut depth: i32 = 0;
+    let mut in_str = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' if in_str => {
+                if bytes.get(i + 1) == Some(&b'\'') {
+                    // Escaped quote — consume both, remain inside the literal.
+                    i += 2;
+                    continue;
+                }
+                in_str = false;
+            }
+            b'\'' => in_str = true,
+            b'(' if !in_str => depth += 1,
+            b')' if !in_str => {
+                depth -= 1;
+                if depth < 0 {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    depth == 0 && !in_str
+}
 
 fn fixed_definition() -> SemanticViewDefinition {
     SemanticViewDefinition {

--- a/fuzz/fuzz_targets/fuzz_query_names.rs
+++ b/fuzz/fuzz_targets/fuzz_query_names.rs
@@ -19,11 +19,16 @@ fuzz_target!(|input: NameFuzzInput| {
     };
     if let Ok(sql) = expand("fuzz_view", &def, &req) {
         assert!(!sql.is_empty());
-        // Structural oracle: the emitted SQL must have balanced parentheses
-        // once single-quoted string literals are ignored, and every literal
-        // must be closed. The fixed definition's identifiers are known-good
-        // (no parens/quotes), so any imbalance is a real code-gen defect —
-        // strictly stronger than the previous `starts_with("WITH")` check.
+        // Structural oracle: the emitted SQL must have balanced parentheses once
+        // single-quoted string literals AND double-quoted identifiers are
+        // ignored, the depth never goes negative, and every quoted region is
+        // closed. The fixed definition's identifiers are known-good, but the
+        // FUZZED names are user-controlled and `expand` emits them as
+        // `quote_ident`-quoted identifiers — a name like `)` becomes `")"`, whose
+        // parenthesis is legal SQL inside the quotes and must not affect the
+        // count (Copilot review, 2026-07-18). Any imbalance outside quotes is a
+        // real code-gen defect — strictly stronger than the old
+        // `starts_with("WITH")` check.
         assert!(
             parens_balanced_outside_quotes(&sql),
             "expand produced structurally-invalid SQL: {sql}"
@@ -31,18 +36,21 @@ fuzz_target!(|input: NameFuzzInput| {
     }
 });
 
-/// True iff parentheses are balanced when single-quoted string literals are
-/// skipped, the nesting depth never goes negative, and no literal is left open.
-/// A doubled `''` inside a literal is an escaped quote (stays inside the
-/// literal). `(`, `)`, and `'` are ASCII, so byte scanning is UTF-8-safe.
+/// True iff parentheses are balanced when both single-quoted string literals
+/// (`'...'`) and double-quoted identifiers (`"..."`) are skipped, the nesting
+/// depth never goes negative, and no quoted region is left open. A doubled `''`
+/// / `""` inside its region is an escape (stays inside). `(`, `)`, `'`, `"` are
+/// ASCII, so byte scanning is UTF-8-safe. Mirrors `fuzz_sql_expand::is_balanced`.
 fn parens_balanced_outside_quotes(sql: &str) -> bool {
     let bytes = sql.as_bytes();
     let mut depth: i32 = 0;
     let mut in_str = false;
+    let mut in_ident = false;
     let mut i = 0;
     while i < bytes.len() {
-        match bytes[i] {
-            b'\'' if in_str => {
+        let b = bytes[i];
+        if in_str {
+            if b == b'\'' {
                 if bytes.get(i + 1) == Some(&b'\'') {
                     // Escaped quote — consume both, remain inside the literal.
                     i += 2;
@@ -50,19 +58,32 @@ fn parens_balanced_outside_quotes(sql: &str) -> bool {
                 }
                 in_str = false;
             }
-            b'\'' => in_str = true,
-            b'(' if !in_str => depth += 1,
-            b')' if !in_str => {
-                depth -= 1;
-                if depth < 0 {
-                    return false;
+        } else if in_ident {
+            if b == b'"' {
+                if bytes.get(i + 1) == Some(&b'"') {
+                    // Escaped quote — consume both, remain inside the identifier.
+                    i += 2;
+                    continue;
                 }
+                in_ident = false;
             }
-            _ => {}
+        } else {
+            match b {
+                b'\'' => in_str = true,
+                b'"' => in_ident = true,
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth < 0 {
+                        return false;
+                    }
+                }
+                _ => {}
+            }
         }
         i += 1;
     }
-    depth == 0 && !in_str
+    depth == 0 && !in_str && !in_ident
 }
 
 fn fixed_definition() -> SemanticViewDefinition {

--- a/fuzz/fuzz_targets/fuzz_render_roundtrip.rs
+++ b/fuzz/fuzz_targets/fuzz_render_roundtrip.rs
@@ -1,21 +1,30 @@
 #![no_main]
 // RT-3 (code-review 2026-07-02): machine-check for parse ↔ render drift.
 //
-// For an ARBITRARY `SemanticViewDefinition` the strict round-trip
-// `parse(render(def)) == def` cannot hold (arbitrary field content need not
-// be in the parser's canonical form — unbalanced quotes in expressions,
-// annotation keywords at depth 0, etc.). The robust invariant is the
-// FIXPOINT: whenever `render(def)` re-parses at all, rendering the re-parsed
-// definition must reproduce the same DDL byte-for-byte:
+// An ARBITRARY `SemanticViewDefinition` is NOT in the image of the parser: a
+// metric `expr` may carry surrounding whitespace the parser trims (`" "` →
+// `""`), an alias may be a NUL-bearing byte string no lexer emits, a stored
+// column may hold a bare depth-0 comma. So the strong fixpoint
+// `render(parse(render(def))) == render(def)` is UNSATISFIABLE on arbitrary
+// defs — a free-form `expr` cannot be quote-protected, and the parser will
+// always re-normalize it (fuzz_render_roundtrip, 2026-07-18).
 //
-//   render(parse(render(def))) == render(def)
+// The satisfiable, meaningful invariant is IDEMPOTENCE OF `render` ON A
+// PARSER-PRODUCED def. We normalize once — render the arbitrary def and parse
+// it back to land on a def the parser could actually produce — then assert that
+// re-rendering that def is a fixpoint:
 //
-// Any grammar drift between `render_ddl.rs` and the body parser shows up as
-// either a re-parse failure on freshly rendered DDL (tolerated here — the
-// exact-equality property for canonical definitions lives in
-// tests/roundtrip_proptest.rs) or a fixpoint violation (asserted).
+//   d1 = parse(render(def))                 // parser-produced (canonical)
+//   render(parse(render(d1))) == render(d1) // render is idempotent on d1
+//
+// Genuine grammar drift between `render_ddl.rs` and the body parser (a dropped
+// field, a reordered clause, a mis-quoted special identifier) still breaks this.
+// A re-parse failure at either stage is tolerated — the strict
+// `parse(render(def)) == def` equality for CANONICAL defs lives in
+// tests/roundtrip_proptest.rs, which backstops the "canonical def renders to
+// parseable, identical DDL" property this target deliberately does not re-assert.
 use libfuzzer_sys::fuzz_target;
-use semantic_views::body_parser::parse_keyword_body;
+use semantic_views::body_parser::{parse_keyword_body, KeywordBody};
 use semantic_views::model::SemanticViewDefinition;
 use semantic_views::render_ddl::render_create_ddl;
 
@@ -32,8 +41,7 @@ fn body_of(ddl: &str) -> Option<&str> {
     if trimmed.len() >= 7 && trimmed.as_bytes()[..7].eq_ignore_ascii_case(b"COMMENT") {
         let after_kw = trimmed[7..].trim_start();
         let after_eq = after_kw.strip_prefix('=')?.trim_start();
-        let (_, consumed) =
-            semantic_views::util::extract_single_quoted_prefix(after_eq).ok()?;
+        let (_, consumed) = semantic_views::util::extract_single_quoted_prefix(after_eq).ok()?;
         after = &after_eq[consumed..];
     }
     let trimmed = after.trim_start();
@@ -44,33 +52,53 @@ fn body_of(ddl: &str) -> Option<&str> {
     }
 }
 
+/// Assemble the subset of a parsed [`KeywordBody`] that `render_create_ddl`
+/// consumes into a `SemanticViewDefinition`.
+fn kb_to_def(kb: KeywordBody) -> SemanticViewDefinition {
+    SemanticViewDefinition {
+        tables: kb.tables,
+        joins: kb.relationships,
+        facts: kb.facts,
+        dimensions: kb.dimensions,
+        metrics: kb.metrics,
+        materializations: kb.materializations,
+        ..Default::default()
+    }
+}
+
 fuzz_target!(|def: SemanticViewDefinition| {
-    let Ok(rendered) = render_create_ddl("fuzz_view", &def) else {
+    // --- Normalize once into the parser's image ---
+    let Ok(rendered0) = render_create_ddl("fuzz_view", &def) else {
         return; // legacy-format defs (empty tables) don't render
     };
-    let Some(body) = body_of(&rendered) else {
+    let Some(body0) = body_of(&rendered0) else {
         return;
     };
-    let Ok(reparsed) = parse_keyword_body(body, 0) else {
-        return; // non-canonical arbitrary content — exact property covered by proptest
+    let Ok(kb1) = parse_keyword_body(body0, 0) else {
+        return; // arbitrary content the parser can't accept — not a reachable def
     };
-    let reparsed_def = SemanticViewDefinition {
-        tables: reparsed.tables,
-        joins: reparsed.relationships,
-        facts: reparsed.facts,
-        dimensions: reparsed.dimensions,
-        metrics: reparsed.metrics,
-        materializations: reparsed.materializations,
-        ..Default::default()
+    let d1 = kb_to_def(kb1); // parser-produced (canonical)
+
+    // --- Assert render is idempotent on the parser-produced def ---
+    let rendered1 =
+        render_create_ddl("fuzz_view", &d1).expect("parser-produced definition must render");
+    let Some(body1) = body_of(&rendered1) else {
+        panic!("rendered DDL lost its AS body: {rendered1}");
     };
-    let rerendered =
-        render_create_ddl("fuzz_view", &reparsed_def).expect("re-parsed definition must render");
-    let Some(body2) = body_of(&rerendered) else {
-        panic!("re-rendered DDL lost its AS body: {rerendered}");
+    let Ok(kb2) = parse_keyword_body(body1, 0) else {
+        // Re-parse of freshly-rendered canonical DDL failed. The strict
+        // "canonical def renders to parseable, identical DDL" property is
+        // covered by tests/roundtrip_proptest.rs; tolerated here.
+        return;
+    };
+    let d2 = kb_to_def(kb2);
+    let rendered2 = render_create_ddl("fuzz_view", &d2).expect("re-parsed definition must render");
+    let Some(body2) = body_of(&rendered2) else {
+        panic!("re-rendered DDL lost its AS body: {rendered2}");
     };
     assert_eq!(
-        body, body2,
-        "render(parse(render(def))) != render(def) — grammar drift between \
-         render_ddl and the body parser.\nfirst:\n{rendered}\nsecond:\n{rerendered}"
+        body1, body2,
+        "render is not idempotent on a parser-produced definition — grammar drift \
+         between render_ddl and the body parser.\nfirst:\n{rendered1}\nsecond:\n{rendered2}"
     );
 });

--- a/fuzz/fuzz_targets/fuzz_sql_expand.rs
+++ b/fuzz/fuzz_targets/fuzz_sql_expand.rs
@@ -102,8 +102,6 @@ fuzz_target!(|input: FuzzInput| {
     if let Ok(sql) = expand("fuzz_view", &input.def, &req) {
         // Successful expansion must produce non-empty SQL
         assert!(!sql.is_empty());
-        // Basic validity: starts with expected CTE prefix
-        assert!(sql.starts_with("WITH"));
         // Structural validity (TC-9): balanced quotes and parens whenever
         // the input fragments were balanced.
         if fragments_ok {

--- a/fuzz/fuzz_targets/fuzz_sql_expand.rs
+++ b/fuzz/fuzz_targets/fuzz_sql_expand.rs
@@ -63,20 +63,41 @@ fn is_balanced(sql: &str) -> bool {
 /// SQL fragments are themselves balanced — expansion copies expressions
 /// through, and define-time validation (not exercised here) is what keeps
 /// unbalanced fragments out of the real catalog.
+///
+/// A "verbatim fragment" is anything `expand` interpolates UN-quoted into the
+/// generated SQL. That is every `expr`, plus the `output_type` that fills the
+/// `CAST(expr AS <output_type>)` slot (`sql_gen.rs` / `window.rs`) and a window
+/// metric's `window_function` (the `FUNC(...)` head, `window.rs`). It is NOT the
+/// names/aliases — those pass through `quote_ident`, whose output is always
+/// balanced. Omitting `output_type` / `window_function` let an unbalanced type
+/// or function name manufacture unbalanced SQL from otherwise-balanced inputs
+/// and trip the `is_balanced` assertion on a non-bug (fuzz_sql_expand,
+/// 2026-07-18). Over-inclusion is harmless — it can only make the guard skip
+/// more inputs, never assert a false positive.
 fn def_fragments_balanced(def: &SemanticViewDefinition) -> bool {
     let mut frags: Vec<&str> = Vec::new();
     for d in &def.dimensions {
         frags.push(&d.expr);
+        if let Some(ot) = &d.output_type {
+            frags.push(ot);
+        }
     }
     for f in &def.facts {
         frags.push(&f.expr);
+        if let Some(ot) = &f.output_type {
+            frags.push(ot);
+        }
     }
     for m in &def.metrics {
         frags.push(&m.expr);
+        if let Some(ot) = &m.output_type {
+            frags.push(ot);
+        }
         for na in &m.non_additive_by {
             frags.push(&na.dimension);
         }
         if let Some(ws) = &m.window_spec {
+            frags.push(&ws.window_function);
             frags.push(&ws.inner_metric);
             frags.extend(ws.extra_args.iter().map(String::as_str));
             frags.extend(ws.excluding_dims.iter().map(String::as_str));

--- a/fuzz/fuzz_targets/fuzz_yaml_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_yaml_parse.rs
@@ -1,10 +1,25 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use semantic_views::model::SemanticViewDefinition;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
         // Must not panic regardless of input.
         // Errors are fine -- panics/UB are not.
-        let _ = semantic_views::model::SemanticViewDefinition::from_yaml("fuzz_test", s);
+        if let Ok(def) = SemanticViewDefinition::from_yaml("fuzz_test", s) {
+            // Serde round-trip oracle: a definition that parsed must
+            // re-serialize and re-parse to an equal value. `from_yaml` is a
+            // thin wrapper over `yaml_serde::from_str`, and every field's
+            // `skip_serializing_if` matches its `default`, so serialize ->
+            // deserialize is the identity.
+            let reserialized =
+                yaml_serde::to_string(&def).expect("serialize parsed def back to YAML");
+            let reparsed = SemanticViewDefinition::from_yaml("fuzz_test", &reserialized)
+                .expect("re-parse of serialized def must succeed");
+            assert_eq!(
+                def, reparsed,
+                "YAML serde round-trip changed the definition"
+            );
+        }
     }
 });

--- a/fuzz/seeds/fuzz_render_roundtrip/seed_basic.txt
+++ b/fuzz/seeds/fuzz_render_roundtrip/seed_basic.txt
@@ -1,0 +1,1 @@
+semantic view render roundtrip seed: tables t0, dim region, metric revenue = sum(amount)

--- a/src/body_parser/mod.rs
+++ b/src/body_parser/mod.rs
@@ -28,7 +28,10 @@ pub(crate) use entries::parse_qualified_entries;
 pub(crate) use materializations::parse_materializations_clause;
 pub(crate) use metrics::parse_metrics_clause;
 pub(crate) use relationships::parse_relationships_clause;
-pub(crate) use scan::split_at_depth0_commas;
+pub(crate) use scan::{
+    column_roundtrips_verbatim, identifier_slot_roundtrips_verbatim,
+    source_table_roundtrips_verbatim, split_at_depth0_commas,
+};
 pub(crate) use tables::parse_tables_clause;
 
 /// Parsed DIMENSIONS / FACTS entry (R-4: named fields, was a 6-tuple).

--- a/src/body_parser/scan.rs
+++ b/src/body_parser/scan.rs
@@ -258,6 +258,148 @@ pub(super) fn identifier_slot_error(slot: &str) -> Option<String> {
     crate::ident::parse_qualified_identifier(s).err()
 }
 
+// ---------------------------------------------------------------------------
+// Render-side round-trip guards (RT-4, fuzz_render_roundtrip 2026-07-18)
+//
+// `render_ddl` must satisfy the fixpoint `render(parse(render(def))) ==
+// render(def)`. A stored column / alias / table string that does NOT re-parse
+// back to itself verbatim breaks that invariant when emitted raw (a depth-0
+// comma splits one column into two, a blank alias re-parses as garbage, etc.).
+// The renderer consults these predicates and wraps any non-round-tripping
+// string with `quote_ident`; because they must agree exactly with how the
+// clause parsers tokenize, they live here beside `QuoteState` / the lexer /
+// `identifier_slot_error` and reuse the same primitives. Each predicate is
+// conservative: canonical values (bare words, well-formed `"quoted"` idents,
+// dotted table names) return `true` and are emitted UNCHANGED; anything whose
+// verbatim round-trip is not guaranteed returns `false` and is quoted.
+// ---------------------------------------------------------------------------
+
+/// True when `s`, emitted verbatim as ONE element of a `(a, b, ...)` column
+/// list (PRIMARY KEY / UNIQUE / FK / REFERENCES), re-parses back to exactly
+/// `s` via `take_parens` + [`split_at_depth0_commas`].
+///
+/// Requirements, matching those two consumers: non-empty; no leading/trailing
+/// whitespace (which the parser trims away); no depth-0 comma (which would
+/// split it into multiple columns); and balanced quotes and brackets that
+/// never dip negative (so it neither leaks an open quote/paren into the list
+/// nor closes the enclosing `(...)` early). Both the `(`/`)`-only balance
+/// `take_parens` tracks and the `()[]{}` balance `split_at_depth0_commas`
+/// tracks are enforced. Idempotent on already-`quote_ident`ed input: a
+/// well-formed `"..."` token has no depth-0 comma and balanced quotes, so it
+/// returns `true` and is left as-is (never re-quoted).
+pub(crate) fn column_roundtrips_verbatim(s: &str) -> bool {
+    if s.is_empty() || s.trim() != s {
+        return false;
+    }
+    let bytes = s.as_bytes();
+    let mut st = QuoteState::default();
+    let mut paren_depth: i32 = 0; // '(' / ')' only — matches take_parens
+    let mut bracket_depth: i32 = 0; // ()[]{} — matches split_at_depth0_commas
+    let mut i = 0;
+    while i < bytes.len() {
+        let (next, live) = st.step(bytes, i);
+        if live {
+            match bytes[i] {
+                b'(' => {
+                    paren_depth += 1;
+                    bracket_depth += 1;
+                }
+                b')' => {
+                    paren_depth -= 1;
+                    bracket_depth -= 1;
+                    if paren_depth < 0 || bracket_depth < 0 {
+                        return false;
+                    }
+                }
+                b'[' | b'{' => bracket_depth += 1,
+                b']' | b'}' => {
+                    bracket_depth -= 1;
+                    if bracket_depth < 0 {
+                        return false;
+                    }
+                }
+                b',' if bracket_depth == 0 => return false,
+                _ => {}
+            }
+        }
+        i = next;
+    }
+    paren_depth == 0 && bracket_depth == 0 && !st.in_string && !st.in_ident
+}
+
+/// True when `s`, emitted verbatim in a single-identifier slot (a table alias,
+/// a relationship `from_alias`, or a `REFERENCES` target alias), re-parses
+/// back to exactly `s`.
+///
+/// Those slots are read as ONE value token by the cursor, so `s` must lex to
+/// exactly one terminated identifier token (bare or `"quoted"`) spanning the
+/// whole string, and pass [`identifier_slot_error`] (rejecting the empty
+/// quoted `""`). A multi-token run (`a b`, `a.b`, `a(b`) or an empty string
+/// therefore returns `false` and is quoted. Idempotent: a well-formed
+/// `"..."` token lexes as one quoted identifier and passes the slot check.
+pub(crate) fn identifier_slot_roundtrips_verbatim(s: &str) -> bool {
+    use super::lexer::{lex, TokenKind};
+    let toks = lex(s);
+    let [tok] = toks.as_slice() else {
+        return false;
+    };
+    matches!(tok.kind, TokenKind::Ident { .. })
+        && tok.start == 0
+        && tok.end == s.len()
+        && identifier_slot_error(s).is_none()
+}
+
+/// True when `s`, emitted verbatim as a source-table name (the `AS <table>`
+/// slot of a TABLES entry), re-parses back to exactly `s` via
+/// `take_source_table_name`.
+///
+/// Unlike an alias slot, a source-table name is a maximal CONTIGUOUS run of
+/// tokens, so a dot-qualified name (`schema.orders`, `"db"."t"`) is captured
+/// whole and round-trips verbatim — this predicate must leave such canonical
+/// names UNCHANGED (never always-quote). It returns `true` iff `s` lexes into
+/// a gap-free run of identifier tokens joined only by `.` symbols, covering
+/// the whole string, is not a bare reserved keyword the name slot rejects, and
+/// is a well-formed dotted identifier. Any interior whitespace, `(`/`)`/`,`/`;`
+/// symbol, string literal, unterminated quote, or empty input returns `false`
+/// and is quoted (collapsing to a single quoted part — acceptable, since such
+/// values are non-canonical). Idempotent on a `quote_ident`ed value: `"..."`
+/// is one quoted token covering the whole string.
+pub(crate) fn source_table_roundtrips_verbatim(s: &str) -> bool {
+    use super::lexer::{lex, TokenKind};
+    let toks = lex(s);
+    let Some(first) = toks.first() else {
+        return false; // empty
+    };
+    // No surrounding whitespace (lexer skips it, so a covered run starts at 0
+    // and ends at len only when there is none).
+    if first.start != 0 || toks.last().is_none_or(|t| t.end != s.len()) {
+        return false;
+    }
+    let mut prev_end: Option<usize> = None;
+    for t in &toks {
+        if let Some(pe) = prev_end {
+            if pe != t.start {
+                return false; // interior whitespace gap ends the name early
+            }
+        }
+        match t.kind {
+            // An identifier part, or the `.` that separates a dotted FQN.
+            TokenKind::Ident { .. } | TokenKind::Symbol(b'.') => {}
+            _ => return false, // (, ), comma, ;, string literal, unterminated, ...
+        }
+        prev_end = Some(t.end);
+    }
+    // A bare reserved keyword in the name slot is rejected by the parser.
+    if matches!(
+        s.to_ascii_uppercase().as_str(),
+        "PRIMARY" | "UNIQUE" | "FOREIGN" | "REFERENCES" | "NOT"
+    ) {
+        return false;
+    }
+    // Well-formed dotted identifier (rejects `""`, `a..b`, `foo"bar"`, ...).
+    crate::ident::parse_qualified_identifier(s).is_ok()
+}
+
 /// Phase 68 A4: returns `true` if `s` has balanced double-quote runs, treating
 /// a doubled-quote `""` inside a quoted region as an escape (does NOT close).
 /// Mirrors the escape rule used by `src/ident.rs::find_identifier_end` so the

--- a/src/render_ddl.rs
+++ b/src/render_ddl.rs
@@ -1237,14 +1237,16 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
-    // RT-4 (fuzz_render_roundtrip, 2026-07-18): non-canonical stored
-    // column / alias / table strings must not break the render fixpoint
-    //   render(parse(render(def))) == render(def)
-    // A stored value that does not round-trip verbatim — a depth-0 comma
-    // inside a column, an empty / whitespace alias or table, unbalanced
-    // quotes — must be quoted at emission so the freshly-rendered DDL either
-    // re-parses to the identical DDL (fixpoint holds) or fails to re-parse
-    // (the fuzz target skips it). A DIFFERENT successful re-render is the bug.
+    // RT-4 (fuzz_render_roundtrip, 2026-07-18): render must be IDEMPOTENT on a
+    // parser-produced definition (the converge-once invariant the fuzz target
+    // asserts):
+    //   d1 = parse(render(def));  render(parse(render(d1))) == render(d1)
+    // The strong fixpoint render(parse(render(def))) == render(def) on an
+    // ARBITRARY def is unsatisfiable — a free-form `expr` with surrounding
+    // whitespace is trimmed by the parser and cannot be quote-protected. So we
+    // normalize once into the parser's image, then assert re-rendering that def
+    // is a fixpoint. The strict parse(render(def)) == def equality for CANONICAL
+    // defs lives in tests/roundtrip_proptest.rs.
     // -------------------------------------------------------------------
 
     /// Mirror of `fuzz_render_roundtrip::body_of`: return the ` AS\n...`
@@ -1270,46 +1272,63 @@ mod tests {
         }
     }
 
-    /// The `fuzz_render_roundtrip` invariant as a deterministic assertion:
-    /// `render(def)` must either fail to re-parse OR its re-render must be
-    /// byte-identical to the first render (the fixpoint). A re-parse that
-    /// SUCCEEDS but re-renders to a DIFFERENT string is the failure the fuzz
-    /// target catches.
+    /// The `fuzz_render_roundtrip` converge-once invariant as a deterministic
+    /// assertion, mirroring that target exactly: normalize the (possibly
+    /// arbitrary) `def` once via `parse(render(def))` to land on a
+    /// parser-produced def, then assert `render` is IDEMPOTENT on it. A re-parse
+    /// failure at either stage is tolerated (the strict equality for canonical
+    /// defs lives in `roundtrip_proptest`); a SUCCESSFUL re-parse whose
+    /// re-render differs is the drift this catches.
     fn assert_render_fixpoint(def: &SemanticViewDefinition) {
-        use crate::body_parser::parse_keyword_body;
-        let rendered = render_create_ddl("fuzz_view", def).expect("def renders");
-        let Some(body) = body_of(&rendered) else {
-            panic!("rendered DDL lost its AS body:\n{rendered}");
+        use crate::body_parser::{parse_keyword_body, KeywordBody};
+        fn kb_to_def(kb: KeywordBody) -> SemanticViewDefinition {
+            SemanticViewDefinition {
+                tables: kb.tables,
+                joins: kb.relationships,
+                facts: kb.facts,
+                dimensions: kb.dimensions,
+                metrics: kb.metrics,
+                materializations: kb.materializations,
+                ..Default::default()
+            }
+        }
+        // Normalize once into the parser's image.
+        let rendered0 = render_create_ddl("fuzz_view", def).expect("def renders");
+        let Some(body0) = body_of(&rendered0) else {
+            panic!("rendered DDL lost its AS body:\n{rendered0}");
         };
-        let Ok(reparsed) = parse_keyword_body(body, 0) else {
-            return; // freshly-rendered DDL no longer re-parses — acceptable
+        let Ok(kb1) = parse_keyword_body(body0, 0) else {
+            return; // arbitrary content the parser can't accept — not reachable
         };
-        let reparsed_def = SemanticViewDefinition {
-            tables: reparsed.tables,
-            joins: reparsed.relationships,
-            facts: reparsed.facts,
-            dimensions: reparsed.dimensions,
-            metrics: reparsed.metrics,
-            materializations: reparsed.materializations,
-            ..Default::default()
+        let d1 = kb_to_def(kb1);
+        // Assert render is idempotent on the parser-produced def.
+        let rendered1 =
+            render_create_ddl("fuzz_view", &d1).expect("parser-produced def must render");
+        let Some(body1) = body_of(&rendered1) else {
+            panic!("rendered DDL lost its AS body:\n{rendered1}");
         };
-        let rerendered = render_create_ddl("fuzz_view", &reparsed_def)
-            .expect("re-parsed definition must render");
-        let body2 = body_of(&rerendered).expect("re-rendered DDL kept its AS body");
+        let Ok(kb2) = parse_keyword_body(body1, 0) else {
+            return; // freshly-rendered canonical DDL no longer re-parses — tolerated
+        };
+        let d2 = kb_to_def(kb2);
+        let rendered2 =
+            render_create_ddl("fuzz_view", &d2).expect("re-parsed definition must render");
+        let body2 = body_of(&rendered2).expect("re-rendered DDL kept its AS body");
         assert_eq!(
-            body, body2,
-            "render(parse(render(def))) != render(def)\nfirst:\n{rendered}\nsecond:\n{rerendered}"
+            body1, body2,
+            "render not idempotent on a parser-produced def\nfirst:\n{rendered1}\nsecond:\n{rendered2}"
         );
     }
 
     #[test]
     fn test_render_fixpoint_unique_constraint_column_with_comma() {
-        // A fully VALID view (a table with a dimension + metric, so the
-        // re-parse SUCCEEDS) whose only UNIQUE constraint column is the bare
-        // string `a,b`. Rendered verbatim it becomes `UNIQUE (a,b)`, which
-        // re-parses by splitting at the comma into TWO columns and re-renders
-        // as `UNIQUE (a, b)` — a DIFFERENT successful re-render. This exercises
-        // the fixpoint-holds branch, not the re-parse-fails escape.
+        // A fully VALID view (a table with a dimension + metric) whose only
+        // UNIQUE constraint column is the bare string `a,b`. Emitted verbatim it
+        // would be `UNIQUE (a,b)`, which re-parses by splitting at the comma into
+        // TWO columns; the quote-protection emits `UNIQUE ("a,b")` instead, so
+        // the parser-produced def keeps one column `"a,b"` and re-render is
+        // idempotent. Exercises the converge-once assert branch (both parses
+        // succeed), not the re-parse-fails escape.
         let mut def = minimal_def();
         def.tables[0].unique_constraints = vec![vec!["a,b".to_string()]];
         assert_render_fixpoint(&def);
@@ -1317,13 +1336,12 @@ mod tests {
 
     #[test]
     fn test_render_fixpoint_fuzz_seed_empty_alias_and_table() {
-        // The exact fuzz_render_roundtrip counterexample: empty alias / table,
+        // The first fuzz_render_roundtrip counterexample: empty alias / table,
         // a UNIQUE constraint whose first column carries a depth-0 comma and
-        // whose second column is empty, plus assorted empty / edge synonyms
-        // and a metric. Rendered verbatim the blank alias/table re-parse as
-        // garbage (`AS AS AS ...`), a different successful re-render. Post-fix
-        // the empty alias/table are quoted to `""`, which the parser rejects,
-        // so render(def) re-parses to Err and the fixpoint holds vacuously.
+        // whose second column is empty, plus assorted empty / edge synonyms and
+        // a metric. The empty alias/table are quoted to `""`, which the parser
+        // rejects, so the first-stage parse(render(def)) fails and converge-once
+        // returns before asserting (the re-parse-fails escape).
         let def = SemanticViewDefinition {
             tables: vec![TableRef {
                 alias: String::new(),
@@ -1351,6 +1369,36 @@ mod tests {
                 name: "b".into(),
                 expr: "les ,".into(),
                 source_table: Some("\0\0\0".into()),
+                access: AccessModifier::Public,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert_render_fixpoint(&def);
+    }
+
+    #[test]
+    fn test_render_fixpoint_fuzz_seed_nul_alias_empty_pk() {
+        // Second fuzz_render_roundtrip counterexample (2026-07-18): a NUL byte
+        // inside the table alias, an EMPTY PRIMARY KEY column, and a metric
+        // whose expr is a single space with a trailing COMMENT. `output_type`
+        // (also NUL-bearing) is not rendered, so it is irrelevant. The metric
+        // expr `" "` is emitted verbatim on the first render but TRIMMED to ""
+        // by the parser on re-parse — a free-form expr cannot be quote-protected,
+        // so the strong fixpoint is unsatisfiable. `render` must still be
+        // idempotent on the parser-produced definition (converge-once).
+        let def = SemanticViewDefinition {
+            tables: vec![TableRef {
+                alias: "emasemant\0".to_string(),
+                table: "e".to_string(),
+                pk_columns: vec![String::new()],
+                ..Default::default()
+            }],
+            metrics: vec![Metric {
+                name: "m".to_string(),
+                expr: " ".to_string(),
+                output_type: Some("gint\0".to_string()),
+                comment: Some("im regp seeum".to_string()),
                 access: AccessModifier::Public,
                 ..Default::default()
             }],

--- a/src/render_ddl.rs
+++ b/src/render_ddl.rs
@@ -47,22 +47,75 @@ fn emit_synonyms(out: &mut String, synonyms: &[String]) {
     }
 }
 
+/// Emit a stored single-identifier slot (table alias, relationship
+/// `from_alias`, `REFERENCES` target alias) so it round-trips through the body
+/// parser. Canonical values — bare words and well-formed `"quoted"`
+/// identifiers — are emitted UNCHANGED; anything that would not re-parse to
+/// itself as one identifier token (empty, embedded whitespace/comma/paren,
+/// unbalanced quotes) is wrapped via [`crate::expand::quote_ident`], which
+/// escapes internal `"` and produces a token that DOES round-trip. Idempotent:
+/// an already-quoted value is recognised as round-tripping and left as-is.
+fn emit_alias(s: &str) -> String {
+    if crate::body_parser::identifier_slot_roundtrips_verbatim(s) {
+        s.to_string()
+    } else {
+        crate::expand::quote_ident(s)
+    }
+}
+
+/// Emit a stored column identifier (a PRIMARY KEY / UNIQUE / FK / REFERENCES
+/// column-list entry) so it round-trips. Emitted UNCHANGED when it re-parses
+/// verbatim as a single column (no depth-0 comma, balanced quotes/brackets, no
+/// surrounding whitespace); otherwise wrapped via
+/// [`crate::expand::quote_ident`]. Idempotent (see [`emit_alias`]).
+fn emit_column(s: &str) -> String {
+    if crate::body_parser::column_roundtrips_verbatim(s) {
+        s.to_string()
+    } else {
+        crate::expand::quote_ident(s)
+    }
+}
+
+/// Emit a comma-separated column list, each entry passed through
+/// [`emit_column`] so a stored value containing a comma cannot silently split
+/// into two columns on re-parse.
+fn emit_column_list(cols: &[String]) -> String {
+    cols.iter()
+        .map(|c| emit_column(c))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Emit a stored source-table name (the `AS <table>` slot of a TABLES entry)
+/// so it round-trips. Dot-aware: canonical bare and dotted names
+/// (`orders`, `schema.orders`, `"db"."t"`) are emitted UNCHANGED; only names
+/// that would not re-parse verbatim (empty, embedded whitespace/comma/paren,
+/// unbalanced quotes, a bare reserved keyword) are wrapped via
+/// [`crate::expand::quote_ident`]. Idempotent (see [`emit_alias`]).
+fn emit_table(s: &str) -> String {
+    if crate::body_parser::source_table_roundtrips_verbatim(s) {
+        s.to_string()
+    } else {
+        crate::expand::quote_ident(s)
+    }
+}
+
 /// Emit TABLES clause entries.
 fn emit_tables(out: &mut String, def: &SemanticViewDefinition) {
     out.push_str("TABLES (\n");
     for (i, table) in def.tables.iter().enumerate() {
         out.push_str("    ");
-        out.push_str(&table.alias);
+        out.push_str(&emit_alias(&table.alias));
         out.push_str(" AS ");
-        out.push_str(&table.table);
+        out.push_str(&emit_table(&table.table));
         if !table.pk_columns.is_empty() {
             out.push_str(" PRIMARY KEY (");
-            out.push_str(&table.pk_columns.join(", "));
+            out.push_str(&emit_column_list(&table.pk_columns));
             out.push(')');
         }
         for uc in &table.unique_constraints {
             out.push_str(" UNIQUE (");
-            out.push_str(&uc.join(", "));
+            out.push_str(&emit_column_list(uc));
             out.push(')');
         }
         emit_comment(out, table.comment.as_deref());
@@ -84,11 +137,11 @@ fn emit_relationships(out: &mut String, def: &SemanticViewDefinition) {
             out.push_str(rel_name);
         }
         out.push_str(" AS ");
-        out.push_str(&join.from_alias);
+        out.push_str(&emit_alias(&join.from_alias));
         out.push('(');
-        out.push_str(&join.fk_columns.join(", "));
+        out.push_str(&emit_column_list(&join.fk_columns));
         out.push_str(") REFERENCES ");
-        out.push_str(&join.table);
+        out.push_str(&emit_alias(&join.table));
         // RT-1 (code-review 2026-07-02): a relationship declared against a
         // UNIQUE key (or any explicit column list differing from the
         // target's PRIMARY KEY) must render its `(ref_columns)` — omitting
@@ -97,7 +150,7 @@ fn emit_relationships(out: &mut String, def: &SemanticViewDefinition) {
         // list is redundant and is omitted for the historical compact form.
         if !join.ref_columns.is_empty() && !ref_columns_match_target_pk(def, join) {
             out.push('(');
-            out.push_str(&join.ref_columns.join(", "));
+            out.push_str(&emit_column_list(&join.ref_columns));
             out.push(')');
         }
         if i + 1 < def.joins.len() {
@@ -1181,6 +1234,129 @@ mod tests {
             metrics_pos < mats_pos,
             "MATERIALIZATIONS should come after METRICS"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // RT-4 (fuzz_render_roundtrip, 2026-07-18): non-canonical stored
+    // column / alias / table strings must not break the render fixpoint
+    //   render(parse(render(def))) == render(def)
+    // A stored value that does not round-trip verbatim — a depth-0 comma
+    // inside a column, an empty / whitespace alias or table, unbalanced
+    // quotes — must be quoted at emission so the freshly-rendered DDL either
+    // re-parses to the identical DDL (fixpoint holds) or fails to re-parse
+    // (the fuzz target skips it). A DIFFERENT successful re-render is the bug.
+    // -------------------------------------------------------------------
+
+    /// Mirror of `fuzz_render_roundtrip::body_of`: return the ` AS\n...`
+    /// body suffix of a rendered DDL, locating the header's (possibly
+    /// quoted) name and optional COMMENT the same quote-aware way the fuzz
+    /// target and the body parser do.
+    fn body_of(ddl: &str) -> Option<&str> {
+        let rest = ddl.strip_prefix("CREATE OR REPLACE SEMANTIC VIEW ")?;
+        let name_end = crate::ident::find_identifier_end(rest, true);
+        let mut after = &rest[name_end..];
+        let trimmed = after.trim_start();
+        if trimmed.len() >= 7 && trimmed.as_bytes()[..7].eq_ignore_ascii_case(b"COMMENT") {
+            let after_kw = trimmed[7..].trim_start();
+            let after_eq = after_kw.strip_prefix('=')?.trim_start();
+            let (_, consumed) = crate::util::extract_single_quoted_prefix(after_eq).ok()?;
+            after = &after_eq[consumed..];
+        }
+        let trimmed = after.trim_start();
+        if trimmed.len() >= 2 && trimmed.as_bytes()[..2].eq_ignore_ascii_case(b"AS") {
+            Some(trimmed)
+        } else {
+            None
+        }
+    }
+
+    /// The `fuzz_render_roundtrip` invariant as a deterministic assertion:
+    /// `render(def)` must either fail to re-parse OR its re-render must be
+    /// byte-identical to the first render (the fixpoint). A re-parse that
+    /// SUCCEEDS but re-renders to a DIFFERENT string is the failure the fuzz
+    /// target catches.
+    fn assert_render_fixpoint(def: &SemanticViewDefinition) {
+        use crate::body_parser::parse_keyword_body;
+        let rendered = render_create_ddl("fuzz_view", def).expect("def renders");
+        let Some(body) = body_of(&rendered) else {
+            panic!("rendered DDL lost its AS body:\n{rendered}");
+        };
+        let Ok(reparsed) = parse_keyword_body(body, 0) else {
+            return; // freshly-rendered DDL no longer re-parses — acceptable
+        };
+        let reparsed_def = SemanticViewDefinition {
+            tables: reparsed.tables,
+            joins: reparsed.relationships,
+            facts: reparsed.facts,
+            dimensions: reparsed.dimensions,
+            metrics: reparsed.metrics,
+            materializations: reparsed.materializations,
+            ..Default::default()
+        };
+        let rerendered = render_create_ddl("fuzz_view", &reparsed_def)
+            .expect("re-parsed definition must render");
+        let body2 = body_of(&rerendered).expect("re-rendered DDL kept its AS body");
+        assert_eq!(
+            body, body2,
+            "render(parse(render(def))) != render(def)\nfirst:\n{rendered}\nsecond:\n{rerendered}"
+        );
+    }
+
+    #[test]
+    fn test_render_fixpoint_unique_constraint_column_with_comma() {
+        // A fully VALID view (a table with a dimension + metric, so the
+        // re-parse SUCCEEDS) whose only UNIQUE constraint column is the bare
+        // string `a,b`. Rendered verbatim it becomes `UNIQUE (a,b)`, which
+        // re-parses by splitting at the comma into TWO columns and re-renders
+        // as `UNIQUE (a, b)` — a DIFFERENT successful re-render. This exercises
+        // the fixpoint-holds branch, not the re-parse-fails escape.
+        let mut def = minimal_def();
+        def.tables[0].unique_constraints = vec![vec!["a,b".to_string()]];
+        assert_render_fixpoint(&def);
+    }
+
+    #[test]
+    fn test_render_fixpoint_fuzz_seed_empty_alias_and_table() {
+        // The exact fuzz_render_roundtrip counterexample: empty alias / table,
+        // a UNIQUE constraint whose first column carries a depth-0 comma and
+        // whose second column is empty, plus assorted empty / edge synonyms
+        // and a metric. Rendered verbatim the blank alias/table re-parse as
+        // garbage (`AS AS AS ...`), a different successful re-render. Post-fix
+        // the empty alias/table are quoted to `""`, which the parser rejects,
+        // so render(def) re-parses to Err and the fixpoint holds vacuously.
+        let def = SemanticViewDefinition {
+            tables: vec![TableRef {
+                alias: String::new(),
+                table: String::new(),
+                pk_columns: vec![],
+                unique_constraints: vec![vec![
+                    "nticer ,roundtrip seed: tab".to_string(),
+                    String::new(),
+                ]],
+                comment: Some(String::new()),
+                synonyms: vec![
+                    "".into(),
+                    "".into(),
+                    "".into(),
+                    "n)\n r".into(),
+                    "".into(),
+                    "".into(),
+                    "".into(),
+                    "egion,".into(),
+                ],
+                ..Default::default()
+            }],
+            dimensions: vec![],
+            metrics: vec![Metric {
+                name: "b".into(),
+                expr: "les ,".into(),
+                source_table: Some("\0\0\0".into()),
+                access: AccessModifier::Public,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert_render_fixpoint(&def);
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -20,7 +20,7 @@
 
 use proptest::prelude::*;
 use semantic_views::model::{
-    AccessModifier, Dimension, Fact, Join, Metric, NonAdditiveDim, NullsOrder,
+    AccessModifier, Dimension, Fact, Join, Materialization, Metric, NonAdditiveDim, NullsOrder,
     SemanticViewDefinition, SortOrder, TableRef,
 };
 
@@ -116,6 +116,12 @@ type JoinSpec = (bool, Vec<String>, Option<Vec<String>>);
 type EntrySpec = (usize, String, String, bool, Option<String>, Vec<String>);
 /// Raw material for one metric: entry + (wants USING, wants NAB(order,nulls)).
 type MetricSpec = (EntrySpec, bool, Option<(SortOrder, NullsOrder)>);
+/// Raw material for one materialization: (name base, dimension include-mask,
+/// public-metric include-mask). The masks are zipped against the already-built
+/// dimension / public-metric name lists inside `prop_map`, so every reference
+/// resolves to a declared name by construction (mirroring how USING / NON
+/// ADDITIVE BY resolve against the built `joins` / `dimensions`).
+type MaterializationSpec = (String, Vec<bool>, Vec<bool>);
 
 /// All cross-references (USING → declared relationship, NON ADDITIVE BY →
 /// declared dimension) are resolved during assembly, so every generated
@@ -153,6 +159,13 @@ pub fn arb_canonical_def() -> impl Strategy<Value = SemanticViewDefinition> {
             prop::sample::select(vec![NullsOrder::First, NullsOrder::Last]),
         )),
     );
+    // Masks are sized to cover the maximum 2 dims / 2 metrics a def can hold, so
+    // a materialization can reference any subset of them.
+    let materialization_spec = (
+        arb_stored_ident(),
+        prop::collection::vec(any::<bool>(), 0..=2),
+        prop::collection::vec(any::<bool>(), 0..=2),
+    );
 
     (
         prop::collection::vec(table_spec, 1..=3),
@@ -160,9 +173,10 @@ pub fn arb_canonical_def() -> impl Strategy<Value = SemanticViewDefinition> {
         prop::collection::vec(entry_spec(3), 0..=2), // dims
         prop::collection::vec(entry_spec(3), 0..=2), // facts
         prop::collection::vec(metric_spec, 0..=2),
+        prop::collection::vec(materialization_spec, 0..=2),
     )
         .prop_map(
-            |(table_specs, join_specs, dim_specs, fact_specs, metric_specs)| {
+            |(table_specs, join_specs, dim_specs, fact_specs, metric_specs, mat_specs)| {
                 let tables: Vec<TableRef> = table_specs
                     .into_iter()
                     .enumerate()
@@ -312,12 +326,72 @@ pub fn arb_canonical_def() -> impl Strategy<Value = SemanticViewDefinition> {
                     })
                     .collect();
 
+                // MATERIALIZATIONS reference already-declared dimensions and
+                // metrics BY NAME. The body parser stores each name / table /
+                // ref verbatim (quote-aware split) and the renderer emits them
+                // verbatim, so referencing the exact declared `.name` strings
+                // round-trips. Metric refs are restricted to PUBLIC metrics —
+                // referencing a private metric may fail define-time validation
+                // on the CREATE front door. The parser also requires each entry
+                // to carry at least one of DIMENSIONS / METRICS, so an
+                // all-empty selection is forced to keep one valid reference.
+                let dim_names: Vec<String> = dimensions.iter().map(|d| d.name.clone()).collect();
+                let public_metric_names: Vec<String> = metrics
+                    .iter()
+                    .filter(|m| m.access == AccessModifier::Public)
+                    .map(|m| m.name.clone())
+                    .collect();
+                let materializations: Vec<Materialization> = if dim_names.is_empty()
+                    && public_metric_names.is_empty()
+                {
+                    // Nothing valid to reference ⇒ no materializations.
+                    Vec::new()
+                } else {
+                    mat_specs
+                        .into_iter()
+                        .enumerate()
+                        .map(
+                            |(i, (name_base, dim_mask, met_mask)): (usize, MaterializationSpec)| {
+                                let mut sel_dims: Vec<String> = dim_names
+                                    .iter()
+                                    .zip(dim_mask)
+                                    .filter(|(_, keep)| *keep)
+                                    .map(|(n, _)| n.clone())
+                                    .collect();
+                                let mut sel_mets: Vec<String> = public_metric_names
+                                    .iter()
+                                    .zip(met_mask)
+                                    .filter(|(_, keep)| *keep)
+                                    .map(|(n, _)| n.clone())
+                                    .collect();
+                                if sel_dims.is_empty() && sel_mets.is_empty() {
+                                    // Guarantee ≥1 reference (parser invariant).
+                                    if let Some(first) = dim_names.first() {
+                                        sel_dims.push(first.clone());
+                                    } else {
+                                        sel_mets.push(public_metric_names[0].clone());
+                                    }
+                                }
+                                Materialization {
+                                    // Distinct so entry names never collide.
+                                    name: distinct_name(&name_base, i),
+                                    // Bare, safe physical table name.
+                                    table: format!("mat_tbl_{i}"),
+                                    dimensions: sel_dims,
+                                    metrics: sel_mets,
+                                }
+                            },
+                        )
+                        .collect()
+                };
+
                 SemanticViewDefinition {
                     tables,
                     joins,
                     dimensions,
                     facts,
                     metrics,
+                    materializations,
                     ..Default::default()
                 }
             },

--- a/tests/differential_proptest.rs
+++ b/tests/differential_proptest.rs
@@ -26,10 +26,15 @@ use semantic_views::expand::{expand, DimensionName, MetricName, QueryRequest};
 use semantic_views::model::{AccessModifier, Dimension, Metric, SemanticViewDefinition, TableRef};
 
 /// An aggregate over a generated column (or `COUNT(*)`), rendered to SQL.
+///
+/// `CountCol` (`count(v{j})`) counts only non-NULL rows, so with NULL-bearing
+/// value columns it diverges from `Count` (`count(*)`) — the two are now
+/// differentially distinguished (previously only `count(*)` existed).
 #[derive(Debug, Clone)]
 enum Agg {
     Sum(usize),
     Count,
+    CountCol(usize),
     Min(usize),
     Max(usize),
 }
@@ -39,6 +44,7 @@ impl Agg {
         match self {
             Agg::Sum(j) => format!("sum(v{j})"),
             Agg::Count => "count(*)".to_string(),
+            Agg::CountCol(j) => format!("count(v{j})"),
             Agg::Min(j) => format!("min(v{j})"),
             Agg::Max(j) => format!("max(v{j})"),
         }
@@ -47,13 +53,14 @@ impl Agg {
 
 /// A generated schema shape plus its data. Columns are `d0..d{n_dims-1}`
 /// (group-by dimensions) followed by `v0..v{n_vals-1}` (metric inputs), all
-/// `INTEGER`. `rows` holds `n_dims + n_vals` values per row.
+/// `INTEGER`. `rows` holds `n_dims + n_vals` cells per row; `None` is a SQL
+/// `NULL` (exercises NULL group keys and NULL aggregate inputs).
 #[derive(Debug, Clone)]
 struct Schema {
     n_dims: usize,
     n_vals: usize,
     metric_aggs: Vec<Agg>,
-    rows: Vec<Vec<i64>>,
+    rows: Vec<Vec<Option<i64>>>,
 }
 
 /// A full test case: a schema plus the non-empty subset of dims and metrics to
@@ -70,20 +77,38 @@ fn arb_schema() -> impl Strategy<Value = Schema> {
         let agg = prop_oneof![
             (0..n_vals).prop_map(Agg::Sum),
             Just(Agg::Count),
+            (0..n_vals).prop_map(Agg::CountCol),
             (0..n_vals).prop_map(Agg::Min),
             (0..n_vals).prop_map(Agg::Max),
         ];
         let metrics = prop::collection::vec(agg, 1..=3);
-        let ncols = n_dims + n_vals;
-        // Dimension columns are squashed into a small domain (0..3) so rows
-        // collide into real groups; value columns range wider (0..10).
-        let row = prop::collection::vec(0i64..10, ncols).prop_map(move |mut r| {
-            for cell in r.iter_mut().take(n_dims) {
-                *cell %= 3;
-            }
-            r
-        });
-        let rows = prop::collection::vec(row, 1..=25);
+        // Dimension cells: a small domain (0..3) so rows collide into real
+        // groups, plus `None` (NULL) so NULL group keys are exercised.
+        let dim_cell = prop_oneof![
+            1 => Just(None),
+            5 => (0i64..3).prop_map(Some),
+        ];
+        // Value cells: `None` (NULL, so SUM-over-all-NULL and COUNT(col) vs
+        // COUNT(*) diverge), a small signed domain (exact sums / collisions),
+        // and a large signed magnitude — both spanning negatives. The domain
+        // stays within INT32 so it fits the `INTEGER` columns; SUM widens to
+        // HUGEINT in DuckDB so no aggregate overflow arises.
+        let val_cell = prop_oneof![
+            1 => Just(None),
+            2 => (-5i64..=5).prop_map(Some),
+            2 => (-1_000_000_000i64..=1_000_000_000).prop_map(Some),
+        ];
+        let row = (
+            prop::collection::vec(dim_cell, n_dims),
+            prop::collection::vec(val_cell, n_vals),
+        )
+            .prop_map(|(mut cells, vals)| {
+                cells.extend(vals);
+                cells
+            });
+        // 0 rows is allowed — the empty-table path (global aggregate over no
+        // rows, empty DISTINCT) was never differentially checked before.
+        let rows = prop::collection::vec(row, 0..=25);
         (Just(n_dims), Just(n_vals), metrics, rows).prop_map(
             |(n_dims, n_vals, metric_aggs, rows)| Schema {
                 n_dims,
@@ -99,13 +124,22 @@ fn arb_case() -> impl Strategy<Value = Case> {
     arb_schema().prop_flat_map(|schema| {
         let nd = schema.n_dims;
         let nm = schema.metric_aggs.len();
-        let dim_sel = prop::sample::subsequence((0..nd).collect::<Vec<_>>(), 1..=nd);
-        let met_sel = prop::sample::subsequence((0..nm).collect::<Vec<_>>(), 1..=nm);
-        (Just(schema), dim_sel, met_sel).prop_map(|(schema, sel_dims, sel_metrics)| Case {
-            schema,
-            sel_dims,
-            sel_metrics,
-        })
+        // Either selection may be empty (dims-only → SELECT DISTINCT,
+        // metrics-only → global aggregate), but not both — a fully-empty
+        // request is invalid, so the at-least-one invariant is preserved by
+        // the filter below.
+        let dim_sel = prop::sample::subsequence((0..nd).collect::<Vec<_>>(), 0..=nd);
+        let met_sel = prop::sample::subsequence((0..nm).collect::<Vec<_>>(), 0..=nm);
+        (Just(schema), dim_sel, met_sel)
+            .prop_filter(
+                "at least one of dimensions/metrics must be selected",
+                |(_, sel_dims, sel_metrics)| !sel_dims.is_empty() || !sel_metrics.is_empty(),
+            )
+            .prop_map(|(schema, sel_dims, sel_metrics)| Case {
+                schema,
+                sel_dims,
+                sel_metrics,
+            })
     })
 }
 
@@ -173,7 +207,10 @@ fn make_db(s: &Schema) -> duckdb::Connection {
         .map(|r| {
             format!(
                 "({})",
-                r.iter().map(i64::to_string).collect::<Vec<_>>().join(",")
+                r.iter()
+                    .map(|c| c.map_or_else(|| "NULL".to_string(), |v| v.to_string()))
+                    .collect::<Vec<_>>()
+                    .join(",")
             )
         })
         .collect();
@@ -225,11 +262,20 @@ proptest! {
             .cloned()
             .collect::<Vec<_>>()
             .join(", ");
-        let group_by = (1..=case.sel_dims.len())
-            .map(|n| n.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        let oracle = format!("SELECT {select_items} FROM t GROUP BY {group_by}");
+        // Metrics-only requests are a single global-aggregate row (no GROUP
+        // BY). Otherwise GROUP BY the selected dimensions by ordinal — they are
+        // projected first, so positions 1..=sel_dims.len(). Dims-only is a
+        // GROUP BY over all selected dims, multiset-equal to the expansion's
+        // SELECT DISTINCT.
+        let oracle = if case.sel_dims.is_empty() {
+            format!("SELECT {select_items} FROM t")
+        } else {
+            let group_by = (1..=case.sel_dims.len())
+                .map(|n| n.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("SELECT {select_items} FROM t GROUP BY {group_by}")
+        };
 
         // Canonical projection (columns sorted by output name) so a column
         // ORDER difference between the two formulations is not a false diff.

--- a/tests/yaml_proptest.rs
+++ b/tests/yaml_proptest.rs
@@ -23,7 +23,24 @@ fn arb_name() -> impl Strategy<Value = String> {
             "primary key".to_string(),
             "wéird name".to_string(),
         ]).boxed(),
+        // YAML-hostile scalars: bare forms a naive serializer would emit
+        // unquoted and re-read as null / bool / number / mapping / comment
+        // rather than as the original string. A correct serializer must quote
+        // them so they round-trip as plain string scalars; if any of these
+        // breaks the round-trip it is a real serializer bug, not a test bug.
+        2 => prop::sample::select(vec![
+            "null", "~", "no", "on", "yes", "true", "false", "123", "1.5",
+            "-0", "a: b", "x #y", " padded ", "line\nbreak",
+        ]).prop_map(str::to_string).boxed(),
+        1 => Just("has \"embedded\" quote".to_string()).boxed(),
     ]
+}
+
+/// Free-text payload for COMMENT / SYNONYMS fields. Reuses `arb_name`'s
+/// alphabet (including the YAML-hostile scalars) so those optional fields
+/// actually exercise the round-trip instead of being hardcoded empty.
+fn arb_payload() -> impl Strategy<Value = String> {
+    arb_name()
 }
 
 /// Generate an arbitrary SQL-like expression.
@@ -58,28 +75,38 @@ fn arb_table_ref() -> impl Strategy<Value = TableRef> {
         arb_name(),
         arb_name(),
         proptest::collection::vec(arb_name(), 0..=2),
+        proptest::collection::vec(proptest::collection::vec(arb_name(), 1..=2), 0..=2),
+        proptest::option::of(arb_payload()),
+        proptest::collection::vec(arb_payload(), 0..=2),
     )
-        .prop_map(|(alias, table, pk_columns)| TableRef {
-            alias,
-            table,
-            pk_columns,
-            unique_constraints: vec![],
-            comment: None,
-            synonyms: vec![],
-        })
+        .prop_map(
+            |(alias, table, pk_columns, unique_constraints, comment, synonyms)| TableRef {
+                alias,
+                table,
+                pk_columns,
+                unique_constraints,
+                comment,
+                synonyms,
+            },
+        )
 }
 
 fn arb_dimension() -> impl Strategy<Value = Dimension> {
-    (arb_name(), arb_expr(), proptest::option::of(arb_name())).prop_map(
-        |(name, expr, source_table)| Dimension {
+    (
+        arb_name(),
+        arb_expr(),
+        proptest::option::of(arb_name()),
+        proptest::option::of(arb_payload()),
+        proptest::collection::vec(arb_payload(), 0..=2),
+    )
+        .prop_map(|(name, expr, source_table, comment, synonyms)| Dimension {
             name,
             expr,
             source_table,
             output_type: None,
-            comment: None,
-            synonyms: vec![],
-        },
-    )
+            comment,
+            synonyms,
+        })
 }
 
 fn arb_non_additive_dim() -> impl Strategy<Value = NonAdditiveDim> {
@@ -103,16 +130,27 @@ fn arb_window_spec() -> impl Strategy<Value = WindowSpec> {
         arb_name(),
         proptest::collection::vec(arb_name(), 0..=1),
         proptest::collection::vec(arb_window_order_by(), 0..=2),
+        proptest::collection::vec(arb_name(), 0..=2),
+        proptest::collection::vec(arb_name(), 0..=2),
+        proptest::option::of(arb_payload()),
     )
         .prop_map(
-            |(window_function, inner_metric, excluding_dims, order_by)| WindowSpec {
+            |(
                 window_function,
                 inner_metric,
-                extra_args: vec![],
                 excluding_dims,
-                partition_dims: vec![],
                 order_by,
-                frame_clause: None,
+                extra_args,
+                partition_dims,
+                frame_clause,
+            )| WindowSpec {
+                window_function,
+                inner_metric,
+                extra_args,
+                excluding_dims,
+                partition_dims,
+                order_by,
+                frame_clause,
             },
         )
 }
@@ -125,19 +163,32 @@ fn arb_metric() -> impl Strategy<Value = Metric> {
         arb_access(),
         proptest::collection::vec(arb_non_additive_dim(), 0..=1),
         proptest::option::of(arb_window_spec()),
+        proptest::option::of(arb_payload()),
+        proptest::collection::vec(arb_payload(), 0..=2),
     )
         .prop_map(
-            |(name, expr, source_table, access, non_additive_by, window_spec)| Metric {
+            |(
                 name,
                 expr,
                 source_table,
-                output_type: None,
-                using_relationships: vec![],
-                comment: None,
-                synonyms: vec![],
                 access,
                 non_additive_by,
                 window_spec,
+                comment,
+                synonyms,
+            )| {
+                Metric {
+                    name,
+                    expr,
+                    source_table,
+                    output_type: None,
+                    using_relationships: vec![],
+                    comment,
+                    synonyms,
+                    access,
+                    non_additive_by,
+                    window_spec,
+                }
             },
         )
 }
@@ -148,16 +199,20 @@ fn arb_fact() -> impl Strategy<Value = Fact> {
         arb_expr(),
         proptest::option::of(arb_name()),
         arb_access(),
+        proptest::option::of(arb_payload()),
+        proptest::collection::vec(arb_payload(), 0..=2),
     )
-        .prop_map(|(name, expr, source_table, access)| Fact {
-            name,
-            expr,
-            source_table,
-            output_type: None,
-            comment: None,
-            synonyms: vec![],
-            access,
-        })
+        .prop_map(
+            |(name, expr, source_table, access, comment, synonyms)| Fact {
+                name,
+                expr,
+                source_table,
+                output_type: None,
+                comment,
+                synonyms,
+                access,
+            },
+        )
 }
 
 fn arb_join() -> impl Strategy<Value = Join> {
@@ -166,15 +221,19 @@ fn arb_join() -> impl Strategy<Value = Join> {
         arb_name(),
         proptest::collection::vec(arb_name(), 0..=2),
         arb_cardinality(),
+        proptest::collection::vec(arb_name(), 0..=2),
+        proptest::option::of(arb_name()),
     )
-        .prop_map(|(table, from_alias, fk_columns, cardinality)| Join {
-            table,
-            from_alias,
-            fk_columns,
-            ref_columns: vec![],
-            name: None,
-            cardinality,
-        })
+        .prop_map(
+            |(table, from_alias, fk_columns, cardinality, ref_columns, name)| Join {
+                table,
+                from_alias,
+                fk_columns,
+                ref_columns,
+                name,
+                cardinality,
+            },
+        )
 }
 
 fn arb_materialization() -> impl Strategy<Value = Materialization> {


### PR DESCRIPTION
Test-infrastructure hardening from the code review (`_notes/code-review-2026-07-18.md`), plus one small production render fix the newly-running fuzzer surfaced.

**Scope note (updated per review):** the PR started test-only, but it now includes a **production `src/` change** — quote-protection of stored identifiers in `render_ddl.rs` / `body_parser/scan.rs`. It is a **no-op for parser-produced definitions** (real `GET_DDL` output is byte-identical; it only affects hand-constructed non-canonical structs the parser can't produce), so there is **no user-facing behavior change** — but `src/` behavior *is* touched. The fan-trap correctness fixes (EXP-1/2/3) and their differential properties come next, separately.

## CI-1 — fuzzing now actually runs in CI (`Fuzz.yml`)
Previously **7 of 8 fuzz targets fuzzed nothing yet went green**: the run passed a gitignored `fuzz/corpus/` dir that libFuzzer requires to exist, so it exited instantly, and a trailing `|| true` swallowed the failure.
- `mkdir -p` the corpus/seed dirs before running.
- Replace `|| true` with explicit exit-code handling: a fuzzer that **fails to start now fails the job loudly**, while a genuine crash still hands off to the existing artifact-upload / issue-open / fail-job steps (unchanged).
- Add the missing `fuzz/seeds/fuzz_render_roundtrip` seed.

## PBT-3 — de-vacuum the materializations round-trip (`tests/common/mod.rs`)
`roundtrip_proptest`'s `reparsed.materializations == def.materializations` was vacuous — the generator never populated `materializations`. `arb_canonical_def` now generates `MATERIALIZATIONS` referencing declared dimensions and **public** metrics (masks zipped against the built name lists), so the assertion is real across both the roundtrip and CREATE-front-door proptests. (Verified non-vacuous: ~247/500 generated defs carry materializations.)

## PBT-2 — strengthen the differential generator (`tests/differential_proptest.rs`)
The generator never produced the classic aggregation-bug space. Now: `Option` cells (NULL group keys + NULL aggregate inputs), signed and large-magnitude values, empty tables, `COUNT(col)` vs `COUNT(*)`, and dims-only / metrics-only selections. The oracle branches to a GROUP-BY-less global aggregate for metrics-only; the `EXCEPT ALL` multiset comparator is unchanged. **`expand()` matches the hand-written oracle throughout** — no bug surfaced for the base-table single-grain paths (the fan-trap bugs live in the join paths, targeted next).

## PBT-4 — YAML-hostile scalars (`tests/yaml_proptest.rs`)
Added `null`, `~`, `no`, `123`, `a: b`, newlines, embedded quotes, etc. to the yaml generator and populated previously-empty optional fields so they actually round-trip. `yaml_serde` quotes every hostile scalar correctly.

## PBT-5 — real oracles for the five "doesn't-panic" fuzz targets (`fuzz/**`)
- `fuzz_query_names`: paren/quote-balance oracle (was `starts_with("WITH")`).
- `fuzz_json_parse` / `fuzz_yaml_parse`: serde round-trip closure (re-serialize → re-parse → equal).
- `fuzz_ddl_parse`: on an accepted `Create`, assert `render_create_ddl` succeeds (empty-tables legacy case excepted).

## Follow-on — render round-trip guard + fuzz-oracle corrections
Making the fuzzer actually run (CI-1) surfaced weaknesses in the fuzz **oracles** themselves (not production bugs). Both render_roundtrip and sql_expand were asserting properties over *arbitrary* `SemanticViewDefinition` structs, but `render`/`expand` only ever see **parser-produced** structs — so each oracle had to re-derive "is this input well-formed?", which is where the false positives lived.
- **`render_ddl.rs` / `body_parser/scan.rs` (production, no-op for real defs):** quote-protect stored identifiers (table alias / name, PRIMARY KEY / UNIQUE / FK / REFERENCES column lists) so a non-canonical stored value can't break the render round-trip.
- **`fuzz_render_roundtrip`:** switched to the **converge-once** invariant — normalize once via `parse(render(def))` to a parser-produced def, then assert `render` is idempotent on it. The strong fixpoint `render(parse(render(def))) == render(def)` is *unsatisfiable* on arbitrary defs (a free-form `expr`'s surrounding whitespace is parser-trimmed and can't be quote-protected). The strict `parse(render(def)) == def` equality for canonical defs already lives in `tests/roundtrip_proptest.rs`.
- **`fuzz_sql_expand`:** added `output_type` and window `window_function` to the `is_balanced` precondition — raw-interpolated fragments (`CAST(expr AS <type>)` / `FUNC(...)`) it was missing.
- **`fuzz_query_names`:** the paren-balance oracle now also skips double-quoted identifiers — a fuzzed name emitted as a `quote_ident`ed identifier (e.g. `")"`) legally contains a paren.
- The full trust-boundary fuzz **redesign** (fuzz at the parser boundary; derive structs by parsing so preconditions vanish; differential oracles over hand-rolled ones; proptest/libFuzzer split; seed corpus) is filed as **TECH-DEBT #33** for a follow-up PR.

## Verification
`cargo test` green (render_ddl 42/42 incl. the new converge-once regression tests; full suite green); the changed proptests and the fuzz-crate compile check independently re-run green; every fuzz-oracle assumption verified against source. This PR touches `fuzz/**`, `tests/`, and (render-side only) `src/`, so the full CI suite — including the now-actually-running Fuzz workflow — exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019aTdcPteCH6Kt5181Gvetn)_