### PR TITLE
fix(release): rebranch semantic-views off upstream/main before CE PR

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -371,6 +371,12 @@ release:
       exit 1
     fi
     cd "$CE_REPO"
+    # The CE fork must have a clean working tree: we rewrite its branch and
+    # force-push below, which would fail partway (or carry stray edits) otherwise.
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+      echo "ERROR: CE fork working tree at '$CE_REPO' is not clean. Commit or stash there first." >&2
+      exit 1
+    fi
     # Rebranch off CURRENT upstream main so the PR is a clean one-file change.
     # Reusing a stale semantic-views branch makes the PR diff *every* other
     # extension that updated upstream since the last release, which trips the
@@ -383,20 +389,29 @@ release:
       git remote add upstream "$UPSTREAM_URL"
     fi
     git fetch upstream main
+    # Refresh the remote-tracking ref so --force-with-lease below has a current
+    # lease baseline (the branch is absent on the very first release -> ignore).
+    git fetch origin semantic-views 2>/dev/null || true
     git checkout -B semantic-views upstream/main
     mkdir -p extensions/semantic_views
     cp "$DESC_SRC" extensions/semantic_views/description.yml
     git add extensions/semantic_views/description.yml
     git commit -m "Update semantic_views to v$VERSION"
-    git push --force origin semantic-views
+    # --force-with-lease: reset the fork branch to our clean rebranch, but refuse
+    # if someone else pushed to it since the fetch above.
+    git push --force-with-lease origin semantic-views
     echo "Pushed clean semantic-views branch (rebased on upstream/main) to CE fork"
+    # Derive the fork owner from the CE fork's origin remote so the recipe works
+    # from any account/org fork, not just anentropic's.
+    FORK_OWNER=$(basename "$(dirname "$(git remote get-url origin)")")
+    HEAD_REF="$FORK_OWNER:semantic-views"
     # Open the PR, or report the existing open one (force-push updates it in place).
     PR_URL=$(gh pr list --repo duckdb/community-extensions \
-      --head anentropic:semantic-views --state open --json url --jq '.[0].url // empty')
+      --head "$HEAD_REF" --base main --state open --json url --jq '.[0].url // empty')
     if [ -z "$PR_URL" ]; then
       PR_URL=$(gh pr create \
         --repo duckdb/community-extensions \
-        --head anentropic:semantic-views \
+        --head "$HEAD_REF" \
         --base main \
         --title "Update semantic_views to v$VERSION" \
         --body "Update semantic_views extension to v$VERSION (ref: $SHA)")

--- a/Justfile
+++ b/Justfile
@@ -362,6 +362,7 @@ release:
     git commit -m "chore: update description.yml for v$VERSION release"
     git push origin main
     echo "Committed and pushed description.yml update to main"
+    DESC_SRC="$PWD/description.yml"
     # --- Copy to CE fork and open PR ---
     CE_REPO="${CE_REPO:-$HOME/Documents/Dev/Sources/community-extensions}"
     if [ ! -d "$CE_REPO" ]; then
@@ -369,21 +370,39 @@ release:
       echo "  Clone your fork of duckdb/community-extensions there, or set CE_REPO env var." >&2
       exit 1
     fi
-    mkdir -p "$CE_REPO/extensions/semantic_views"
-    cp description.yml "$CE_REPO/extensions/semantic_views/description.yml"
-    echo "Copied description.yml to CE fork"
     cd "$CE_REPO"
-    git checkout semantic-views
+    # Rebranch off CURRENT upstream main so the PR is a clean one-file change.
+    # Reusing a stale semantic-views branch makes the PR diff *every* other
+    # extension that updated upstream since the last release, which trips the
+    # registry's "cannot have multiple descriptors changed" gate (fast-fails the
+    # `prepare` job). Mirrors PublishExtension.yml. See MAINTAINER.md.
+    UPSTREAM_URL="https://github.com/duckdb/community-extensions.git"
+    if git remote get-url upstream &>/dev/null; then
+      git remote set-url upstream "$UPSTREAM_URL"
+    else
+      git remote add upstream "$UPSTREAM_URL"
+    fi
+    git fetch upstream main
+    git checkout -B semantic-views upstream/main
+    mkdir -p extensions/semantic_views
+    cp "$DESC_SRC" extensions/semantic_views/description.yml
     git add extensions/semantic_views/description.yml
     git commit -m "Update semantic_views to v$VERSION"
-    git push origin semantic-views
-    echo "Pushed to CE fork"
-    PR_URL=$(gh pr create \
-      --repo duckdb/community-extensions \
-      --head anentropic:semantic-views \
-      --base main \
-      --title "Update semantic_views to v$VERSION" \
-      --body "Update semantic_views extension to v$VERSION (ref: $SHA)")
+    git push --force origin semantic-views
+    echo "Pushed clean semantic-views branch (rebased on upstream/main) to CE fork"
+    # Open the PR, or report the existing open one (force-push updates it in place).
+    PR_URL=$(gh pr list --repo duckdb/community-extensions \
+      --head anentropic:semantic-views --state open --json url --jq '.[0].url // empty')
+    if [ -z "$PR_URL" ]; then
+      PR_URL=$(gh pr create \
+        --repo duckdb/community-extensions \
+        --head anentropic:semantic-views \
+        --base main \
+        --title "Update semantic_views to v$VERSION" \
+        --body "Update semantic_views extension to v$VERSION (ref: $SHA)")
+    else
+      echo "Existing open PR updated in place: $PR_URL"
+    fi
     echo ""
     echo "=== Release Summary ==="
     echo "  Version: v$VERSION"

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -613,11 +613,13 @@ This will:
 - Verify you're on `main` with a clean working tree and `gh` CLI installed
 - Extract the version from `Cargo.toml` and the current commit SHA
 - Update `description.yml` with the new `ref` and `version`, and commit
-- Copy `description.yml` to the CE fork (default: `~/Documents/Dev/Sources/community-extensions`, override with `CE_REPO` env var)
-- Check out the `semantic-views` branch, commit, push, and open a PR to `duckdb/community-extensions`
+- In the CE fork (default: `~/Documents/Dev/Sources/community-extensions`, override with `CE_REPO` env var): ensure an `upstream` remote, `git fetch upstream main`, and **rebranch `semantic-views` off `upstream/main`** so the PR is a clean one-file change, then copy in `description.yml`, commit, and **force-push**
+- Open a PR to `duckdb/community-extensions` (or report the existing open one, which the force-push updates in place)
+
+> **Why rebranch off `upstream/main` (not reuse the local `semantic-views` branch)?** The registry's `prepare` job rejects a PR that touches more than one extension's descriptor (`ValueError: cannot have multiple descriptors changed`). If the branch is left pinned to a previous release's base, the ~100 other extensions that updated upstream in the meantime all show as changed and the job fast-fails. Rebranching off current `upstream/main` guarantees the diff is only `extensions/semantic_views/description.yml`. The `PublishExtension.yml` CI workflow does the same thing.
 
 **Prerequisites:**
-- A fork of [duckdb/community-extensions](https://github.com/duckdb/community-extensions) cloned locally
+- A fork of [duckdb/community-extensions](https://github.com/duckdb/community-extensions) cloned locally (an `upstream` remote is added automatically if missing)
 - The `gh` CLI authenticated with permissions to create PRs
 
 **After running:**


### PR DESCRIPTION
## Problem

The `just release` recipe reused the CE fork's local `semantic-views` branch, which stays pinned to the *previous* release's base of upstream `main`. Between releases ~100 other extensions update their descriptors upstream, so the resulting PR diffed all of them and the registry's `prepare` job fast-failed with:

```
ValueError: cannot have multiple descriptors changed or packages with spaces in their names
```

Hit on the v0.11.0 release — [community-extensions#2279](https://github.com/duckdb/community-extensions/pull/2279) — and fixed there by hand (rebranch off `upstream/main` + force-push). This bakes that fix into the recipe so it doesn't recur.

## Change

`Justfile` `release` recipe (CE-fork section):
- Ensure an `upstream` remote (`duckdb/community-extensions`) and `git fetch upstream main`
- **`git checkout -B semantic-views upstream/main`** so the PR diff is only `extensions/semantic_views/description.yml`
- Copy `description.yml` in *after* the rebranch, commit, and **force-push**
- Idempotent PR step: report an existing open PR (which the force-push updates in place) instead of erroring on `gh pr create`

Mirrors what `PublishExtension.yml` already does.

`MAINTAINER.md`: updated the release steps and added a note explaining why the rebranch is required (per CLAUDE.md doc-sync rule).

## Validation

- `just --show release` parses; `bash -n` on the recipe body is clean
- Pre-commit clippy passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)