### PR TITLE
where_clause: enforce PRIVATE, resolve qualified member references (EXP-13, EXP-14)

### DIFF
--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -495,6 +495,24 @@ Areas where test coverage is reduced compared to ideal, with justification.
 - **Resolution:** select `schema_name` alongside and stamp `WHERE schema_name = ? AND name = ?`.
 - **Coverage:** `catalog::tests::upgrade_stamps_only_the_row_it_verified_not_its_namesakes_in_other_schemas` — two schemas holding a view of the same name, one upgradeable and one not; the verified row is stamped and the namesake is not. The pre-existing `upgrade_stamps_complete_rows_and_skips_incomplete` is retained unchanged as the single-schema control.
 
+### 47. ✅ `where_clause` bypassed PRIVATE and never resolved qualified member references (EXP-13 / EXP-14) — RESOLVED 2026-08-04
+
+- **Origin:** code review 2026-08-03 (`_notes/code-review-2026-08-03.md`, EXP-13, EXP-14). Both filed LOW; EXP-14 is materially worse than filed — see below.
+- **EXP-13 was:** `resolve_where_clause` built its member lookup from *all* of `def.dimensions` / `def.facts` with no `AccessModifier` check, so a PRIVATE fact that `resolve_names` refuses to let you select could still be named in a predicate — and its values probed by varying the filter and watching the result move. The queried-member path has enforced PRIVATE since Phase 43; the predicate path did not. Only facts are affected: `PRIVATE` on a dimension is rejected at CREATE (`body_parser::entries`), which is why `sql_gen`'s `Resolvable` impl carries `unreachable!("dimensions cannot be private")` — see PAR-4 for that divergence.
+- **EXP-14 was:** `scan_references` keys a dotted chain by the whole chain (`o.order_date`), but the member lookup was keyed by bare name only. A qualified reference therefore matched **nothing**.
+- **EXP-14's real severity — a fan-trap fence bypass, not just an unsubstituted reference.** The finding predicted a raw column that "fails loud at bind". It does worse. `ResolvedWhere::source_tables` is what feeds the predicate's tables into the fan-out check, and it is populated *only* for references that resolve. An unresolved qualified reference therefore removes its member from the fence's input entirely, so a predicate that reaches a fanning grain is silently accepted. Caught by the extended oracle, whose minimal counterexample is unambiguous:
+
+  ```sql
+  SELECT sum(u.uw) AS "su"
+  FROM "u" AS "u"
+  WHERE ((u.ucat) <= 1 AND t.ftd)
+  ```
+
+  `t.ftd` names a filter member on `t`. Pre-fix it resolved to nothing, `t` never entered `source_tables`, the fence never learned the predicate reached `t`, and the query was **accepted** with `t` not even joined. This is the same class as EXP-10, which was rated HIGH. It happens to bind-fail here only because `t.ftd` is not a real column; where a member name coincides with a real column on its own table, it binds and returns a wrong number with no error.
+- **Resolution:** every member is keyed both bare and by its own `source_table.name`, mirroring `expand::facts::insert_fact_keys` and the dotted-reference handling at the NA-dim and window sites (#28/#30). Keying by the member's **own** table is what keeps a *foreign* qualifier (`c.order_date`) an ordinary column per E-3. Metrics are keyed both ways too, so `o.revenue > 5` now raises `WhereClauseReferencesMetric` instead of slipping through. PRIVATE facts are deliberately kept *out* of the lookup and recorded separately, so a reference to one raises `PrivateFact` rather than falling through to "unknown reference" — which would have left it in the SQL as a raw column and leaked the very member PRIVATE withholds.
+- **Coverage:** seven unit tests, each confirmed red before the fix, plus controls (`a_public_fact_still_resolves_in_the_predicate`, `a_foreign_qualified_reference_is_left_as_a_raw_column` — the latter guarding against over-eager substitution). Randomized: `multi_hop_join_proptest`'s predicate generator now varies each member reference between bare and `<table>.<name>` spellings, with the oracle rendering unchanged so the comparison stays differential. Verified by reverting only the fix and watching the harness go red on the case above. `generator_reaches_both_where_clause_branches` gained an assertion that both spellings occur, so the flag cannot be silently pinned to `false` — the `where_clause: None` mistake (PBT-6) one level down.
+- **Not covered:** `differential_proptest` cannot host this — its members carry `source_table: None`, so a qualified spelling does not exist there. Left alone rather than restructured.
+
 ### 46. ✅ Three quote scanners each tracked a different subset of the quoting rules (EXP-16 / EXP-17 / PARSE-4) — RESOLVED 2026-08-04
 
 - **Origin:** code review 2026-08-03 (`_notes/code-review-2026-08-03.md`, EXP-16, EXP-17, PARSE-4).

--- a/_notes/code-review-2026-08-03.md
+++ b/_notes/code-review-2026-08-03.md
@@ -208,7 +208,7 @@ inner reference loses its grain in `metric_grain_tables` → `RootGrainFanTrap` 
 base-anchored `__sv_agg` CTE silently inflates while `window.rs` happily computes it. **These
 sites must migrate together.**
 
-### EXP-13 — LOW: `where_clause` bypasses access modifiers
+### EXP-13 — LOW: `where_clause` bypasses access modifiers — RESOLVED 2026-08-04 (TECH-DEBT #47)
 
 `src/expand/where_clause.rs:89-106`. `resolve_where_clause` builds its lookup from *all*
 `def.dimensions`/`def.facts` with no `AccessModifier` check, so a PRIVATE member that
@@ -216,7 +216,12 @@ sites must migrate together.**
 `where_clause := 'private_member = …'`. The queried-member path enforces PRIVATE (Phase 43); the
 predicate path does not.
 
-### EXP-14 — LOW: dotted member references in `where_clause` fall through to raw columns, unlike every other member-reference site
+### EXP-14 — LOW → **should have been HIGH**: dotted member references in `where_clause` fall through to raw columns, unlike every other member-reference site — RESOLVED 2026-08-04 (TECH-DEBT #47)
+
+**Severity correction (2026-08-04).** This entry predicted "fails loud at bind". It also silently bypasses the
+fan-trap fence: `source_tables` is populated only for references that *resolve*, so an unresolved
+qualified reference removes its member from the fence's input and a predicate reaching a fanning
+grain is accepted. Same class as EXP-10 (HIGH). See TECH-DEBT #47 for the counterexample.
 
 `src/expand/where_clause.rs:116-138`. `scan_references` keys a dotted chain as `"o.order_date"`
 (`expr_tokens.rs:38`), but the member lookup is keyed by bare name only, so

--- a/src/expand/where_clause.rs
+++ b/src/expand/where_clause.rs
@@ -86,29 +86,65 @@ pub(super) fn resolve_where_clause(
     // `expand::facts`, derived metrics in `expand::per_grain`) already wrap for
     // exactly this reason. Wrapping unconditionally keeps the three consistent;
     // a redundant `(o.region)` around a plain column is harmless.
+    // EXP-14: every member is keyed BOTH bare (`order_date`) and by its own
+    // `source_table.name` (`o.order_date`), because `scan_references` keys a
+    // dotted chain by the whole chain. Keying bare only meant a qualified
+    // reference matched nothing: it survived into the SQL as a raw column —
+    // silently filtering on different semantics than the member wherever a
+    // dimension's expression differs from a same-named physical column — and
+    // skipped the metric check entirely, so `o.revenue > 5` slipped past
+    // `WhereClauseReferencesMetric`. This mirrors `expand::facts::insert_fact_keys`
+    // and the dotted-reference handling at the NA-dim and window sites
+    // (TECH-DEBT #28/#30). Keying by the member's OWN table is what keeps a
+    // *foreign* qualifier (`c.order_date`) an ordinary column, per E-3.
+    let keys_for = |source_table: Option<&str>, name: &str| {
+        let mut keys = Vec::with_capacity(2);
+        if let Some(st) = source_table {
+            keys.push(normalize_ident_part(&format!("{st}.{name}")));
+        }
+        keys.push(normalize_ident_part(name));
+        keys
+    };
+
     let mut dim_exprs: HashMap<String, String> = HashMap::new();
     let mut member_tables: HashMap<String, Option<&str>> = HashMap::new();
     for dim in &def.dimensions {
-        let key = normalize_ident_part(&dim.name);
-        dim_exprs.insert(key.clone(), format!("({})", dim.expr));
-        member_tables.insert(key, dim.source_table.as_deref());
+        // Dimensions are never PRIVATE — `PRIVATE` on a dimension is rejected at
+        // CREATE (`body_parser::entries`), which is why `sql_gen`'s `Resolvable`
+        // impl has `unreachable!("dimensions cannot be private")`. So there is no
+        // access check to make here, only on facts below.
+        for key in keys_for(dim.source_table.as_deref(), &dim.name) {
+            dim_exprs.insert(key.clone(), format!("({})", dim.expr));
+            member_tables.insert(key, dim.source_table.as_deref());
+        }
     }
+    // EXP-13: a PRIVATE fact is deliberately NOT added to the lookup. It is
+    // recorded separately so a reference to one is rejected by name rather than
+    // falling through to "unknown reference", which would leave it in the SQL as
+    // a raw column and leak the very member PRIVATE withholds.
+    let mut private_facts: HashMap<String, &str> = HashMap::new();
     for fact in &def.facts {
-        let key = normalize_ident_part(&fact.name);
-        // A dimension and a fact may share a name; the dimension wins, matching
-        // the precedence the select-list resolution already uses.
-        dim_exprs
-            .entry(key.clone())
-            .or_insert_with(|| format!("({})", fact.expr));
-        member_tables
-            .entry(key)
-            .or_insert(fact.source_table.as_deref());
+        for key in keys_for(fact.source_table.as_deref(), &fact.name) {
+            if fact.access == crate::model::AccessModifier::Private {
+                private_facts.entry(key).or_insert(fact.name.as_str());
+                continue;
+            }
+            // A dimension and a fact may share a name; the dimension wins,
+            // matching the precedence the select-list resolution already uses.
+            dim_exprs
+                .entry(key.clone())
+                .or_insert_with(|| format!("({})", fact.expr));
+            member_tables
+                .entry(key)
+                .or_insert(fact.source_table.as_deref());
+        }
     }
-    let metric_names: HashMap<String, &str> = def
-        .metrics
-        .iter()
-        .map(|m| (normalize_ident_part(&m.name), m.name.as_str()))
-        .collect();
+    let mut metric_names: HashMap<String, &str> = HashMap::new();
+    for m in &def.metrics {
+        for key in keys_for(m.source_table.as_deref(), &m.name) {
+            metric_names.entry(key).or_insert(m.name.as_str());
+        }
+    }
 
     let mut source_tables: Vec<String> = Vec::new();
     let mut members: Vec<(String, Option<String>)> = Vec::new();
@@ -126,6 +162,16 @@ pub(super) fn resolve_where_clause(
                 members.push((r.raw.to_string(), table.map(str::to_ascii_lowercase)));
             }
             continue;
+        }
+        // EXP-13: a PRIVATE fact the predicate names. Checked after the member
+        // lookup so a public dimension sharing its name still resolves, and
+        // before the metric check for the same reason the metric check sits
+        // after the member lookup — the most specific match wins.
+        if let Some(fact_name) = private_facts.get(&key) {
+            return Err(ExpandError::PrivateFact {
+                view_name: view_name.to_string(),
+                name: (*fact_name).to_string(),
+            });
         }
         // Only reject a metric the predicate genuinely names. Checked after the
         // member lookup so a dimension sharing a metric's name still resolves.
@@ -175,6 +221,84 @@ mod tests {
     fn substitutes_a_fact_expression() {
         let r = resolve_where_clause("v", &def(), "net_price > 100").unwrap();
         assert_eq!(r.sql, "(o.price * (1 - o.discount)) > 100");
+    }
+
+    // EXP-13: the member lookup was built from *all* facts with no
+    // `AccessModifier` check, so a PRIVATE fact that `resolve_names` refuses to
+    // let you select could still be filtered on — and its values probed by
+    // varying the predicate. The queried-member path has enforced PRIVATE since
+    // Phase 43; the predicate path did not. (Only facts are affected: `PRIVATE`
+    // on a dimension is rejected at CREATE — see PAR-4.)
+
+    #[test]
+    fn a_private_fact_is_rejected_in_the_predicate() {
+        let def = SemanticViewDefinition::default()
+            .with_table("o", "orders", &["id"])
+            .with_private_fact("secret_margin", "o.price - o.cost", "o");
+        let err = resolve_where_clause("v", &def, "secret_margin > 0").unwrap_err();
+        assert!(
+            matches!(err, ExpandError::PrivateFact { ref name, .. } if name == "secret_margin"),
+            "expected PrivateFact, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_private_fact_is_rejected_through_a_qualified_reference_too() {
+        let def = SemanticViewDefinition::default()
+            .with_table("o", "orders", &["id"])
+            .with_private_fact("secret_margin", "o.price - o.cost", "o");
+        let err = resolve_where_clause("v", &def, "o.secret_margin > 0").unwrap_err();
+        assert!(
+            matches!(err, ExpandError::PrivateFact { ref name, .. } if name == "secret_margin"),
+            "expected PrivateFact, got {err:?}"
+        );
+    }
+
+    /// Control for EXP-13: a non-private fact of the same shape still resolves,
+    /// so the guard rejects on access rather than on being a fact at all.
+    #[test]
+    fn a_public_fact_still_resolves_in_the_predicate() {
+        let r = resolve_where_clause("v", &def(), "net_price > 100").unwrap();
+        assert_eq!(r.sql, "(o.price * (1 - o.discount)) > 100");
+    }
+
+    // EXP-14: `scan_references` keys a dotted chain as `o.order_date`, but the
+    // member lookup was keyed by bare name only. A qualified reference therefore
+    // matched nothing: it was left as a raw column (silently filtering on
+    // different semantics than the member wherever the two differ) and skipped
+    // the metric check entirely. Every other member-reference site resolves
+    // dotted references (#30/#28); this one did not.
+
+    #[test]
+    fn a_qualified_dimension_reference_is_substituted() {
+        let r = resolve_where_clause("v", &def(), "o.order_date > DATE '1995-01-01'").unwrap();
+        assert_eq!(r.sql, "(o.ordered_at) > DATE '1995-01-01'");
+        assert_eq!(r.source_tables, vec!["o"]);
+    }
+
+    #[test]
+    fn a_qualified_fact_reference_is_substituted() {
+        let r = resolve_where_clause("v", &def(), "o.net_price > 100").unwrap();
+        assert_eq!(r.sql, "(o.price * (1 - o.discount)) > 100");
+    }
+
+    #[test]
+    fn a_qualified_metric_reference_is_still_rejected() {
+        let err = resolve_where_clause("v", &def(), "o.revenue > 5").unwrap_err();
+        assert!(
+            matches!(err, ExpandError::WhereClauseReferencesMetric { ref metric_name, .. }
+                if metric_name == "revenue"),
+            "expected WhereClauseReferencesMetric, got {err:?}"
+        );
+    }
+
+    /// Control for EXP-14: a qualifier that is *not* the member's own table is a
+    /// column on another relation, not a member reference (the E-3 rule), so it
+    /// must stay untouched rather than being substituted.
+    #[test]
+    fn a_foreign_qualified_reference_is_left_as_a_raw_column() {
+        let r = resolve_where_clause("v", &def(), "c.order_date > DATE '1995-01-01'").unwrap();
+        assert_eq!(r.sql, "c.order_date > DATE '1995-01-01'");
     }
 
     /// A member whose expression is a compound of LOOSER-binding operators than

--- a/tests/multi_hop_join_proptest.rs
+++ b/tests/multi_hop_join_proptest.rs
@@ -75,8 +75,10 @@ const WMEMBERS: [(&str, &str, &str); 6] = [
     ("fwcat", "(w.wcat = 0 OR w.wcat = 2)", "w"),
 ];
 
-/// Indices into `WMEMBERS` that are bare columns (can carry a comparison) as
-/// opposed to self-contained boolean filter members.
+/// Indices into `WMEMBERS` that are plain columns (can carry a comparison) as
+/// opposed to self-contained boolean filter members. "Plain" is about the
+/// member's *expression*; it says nothing about the bare-vs-qualified spelling
+/// the predicate names it by, which is an independent axis (see [`member_ref`]).
 const COMPARABLE: [usize; 3] = [0, 1, 2];
 /// Indices into `WMEMBERS` that are filter members.
 const FILTERS: [usize; 3] = [3, 4, 5];
@@ -133,7 +135,12 @@ fn member_ref(m: usize, qualified: bool) -> String {
 
 impl Pred {
     /// The `where_clause` text: member NAMES, composites parenthesized so the
-    /// SQL parse matches this AST, filter members left BARE.
+    /// SQL parse matches this AST.
+    ///
+    /// Each reference is spelled bare (`ftd`) or qualified by its own table
+    /// (`t.ftd`) according to the generated flag — see [`member_ref`]. A filter
+    /// member is still emitted as a name rather than expanded, which is the
+    /// substitution/precedence surface; EXP-14 added the spelling axis on top.
     fn to_member_sql(&self) -> String {
         match self {
             Pred::Cmp(m, op, k, q) => format!("{} {op} {k}", member_ref(*m, *q)),

--- a/tests/multi_hop_join_proptest.rs
+++ b/tests/multi_hop_join_proptest.rs
@@ -85,12 +85,50 @@ const FILTERS: [usize; 3] = [3, 4, 5];
 #[derive(Debug, Clone)]
 enum Pred {
     /// `<member> <op> <literal>` for a comparable member (index into `WMEMBERS`).
-    Cmp(usize, &'static str, i64),
-    /// A bare filter member — the substitution/precedence surface.
-    Filter(usize),
+    /// The `bool` is EXP-14's surface: when true the member is named by its
+    /// `<table>.<name>` qualified form instead of bare.
+    Cmp(usize, &'static str, i64, bool),
+    /// A filter member — the substitution/precedence surface. The `bool` is the
+    /// same qualified/bare choice as `Cmp`.
+    Filter(usize, bool),
     And(Box<Pred>, Box<Pred>),
     Or(Box<Pred>, Box<Pred>),
     Not(Box<Pred>),
+}
+
+/// Whether this predicate names any member qualified, and whether any bare.
+/// Used by the anti-vacuity guard to prove the generator reaches both spellings.
+fn reference_spellings_of(p: &Pred, qualified: &mut bool, bare: &mut bool) {
+    match p {
+        Pred::Cmp(_, _, _, q) | Pred::Filter(_, q) => {
+            if *q {
+                *qualified = true;
+            } else {
+                *bare = true;
+            }
+        }
+        Pred::And(a, b) | Pred::Or(a, b) => {
+            reference_spellings_of(a, qualified, bare);
+            reference_spellings_of(b, qualified, bare);
+        }
+        Pred::Not(a) => reference_spellings_of(a, qualified, bare),
+    }
+}
+
+/// How a generated predicate names member `m`: bare (`ftd`) or qualified by the
+/// member's own table (`t.ftd`).
+///
+/// EXP-14: the qualified spelling was keyed nowhere, so it matched no member and
+/// survived into the emitted SQL as a raw column — never substituted, and never
+/// metric-checked. Both spellings denote the same member, so both must produce
+/// the same number as the oracle; that is what varying this flag tests.
+fn member_ref(m: usize, qualified: bool) -> String {
+    let (name, _, table) = WMEMBERS[m];
+    if qualified {
+        format!("{table}.{name}")
+    } else {
+        name.to_string()
+    }
 }
 
 impl Pred {
@@ -98,20 +136,27 @@ impl Pred {
     /// SQL parse matches this AST, filter members left BARE.
     fn to_member_sql(&self) -> String {
         match self {
-            Pred::Cmp(m, op, k) => format!("{} {op} {k}", WMEMBERS[*m].0),
-            Pred::Filter(m) => WMEMBERS[*m].0.to_string(),
+            Pred::Cmp(m, op, k, q) => format!("{} {op} {k}", member_ref(*m, *q)),
+            Pred::Filter(m, q) => member_ref(*m, *q),
             Pred::And(a, b) => format!("({} AND {})", a.to_member_sql(), b.to_member_sql()),
             Pred::Or(a, b) => format!("({} OR {})", a.to_member_sql(), b.to_member_sql()),
             Pred::Not(a) => format!("(NOT {})", a.to_member_sql()),
         }
     }
 
+    /// `(any_qualified, any_bare)` across this predicate's member references.
+    fn reference_spellings(&self) -> (bool, bool) {
+        let (mut q, mut b) = (false, false);
+        reference_spellings_of(self, &mut q, &mut b);
+        (q, b)
+    }
+
     /// The oracle's independent rendering: raw columns, filter members expanded,
     /// every operand explicitly parenthesized.
     fn to_raw_sql(&self) -> String {
         match self {
-            Pred::Cmp(m, op, k) => format!("({} {op} {k})", WMEMBERS[*m].1),
-            Pred::Filter(m) => format!("({})", WMEMBERS[*m].1),
+            Pred::Cmp(m, op, k, _) => format!("({} {op} {k})", WMEMBERS[*m].1),
+            Pred::Filter(m, _) => format!("({})", WMEMBERS[*m].1),
             Pred::And(a, b) => format!("({} AND {})", a.to_raw_sql(), b.to_raw_sql()),
             Pred::Or(a, b) => format!("({} OR {})", a.to_raw_sql(), b.to_raw_sql()),
             Pred::Not(a) => format!("(NOT {})", a.to_raw_sql()),
@@ -122,7 +167,7 @@ impl Pred {
     /// into whichever CTE evaluates it.
     fn tables(&self, out: &mut Vec<&'static str>) {
         match self {
-            Pred::Cmp(m, _, _) | Pred::Filter(m) => out.push(WMEMBERS[*m].2),
+            Pred::Cmp(m, _, _, _) | Pred::Filter(m, _) => out.push(WMEMBERS[*m].2),
             Pred::And(a, b) | Pred::Or(a, b) => {
                 a.tables(out);
                 b.tables(out);
@@ -135,7 +180,7 @@ impl Pred {
     fn references_filter(&self) -> bool {
         match self {
             Pred::Cmp(..) => false,
-            Pred::Filter(_) => true,
+            Pred::Filter(..) => true,
             Pred::And(a, b) | Pred::Or(a, b) => a.references_filter() || b.references_filter(),
             Pred::Not(a) => a.references_filter(),
         }
@@ -150,8 +195,9 @@ fn arb_pred() -> impl Strategy<Value = Pred> {
             comparable,
             prop_oneof![Just("<"), Just("<="), Just("="), Just("<>"), Just(">="), Just(">")],
             -1i64..=3,
-        ).prop_map(|(m, op, k)| Pred::Cmp(m, op, k)),
-        2 => filters.prop_map(Pred::Filter),
+            prop::bool::ANY,
+        ).prop_map(|(m, op, k, q)| Pred::Cmp(m, op, k, q)),
+        2 => (filters, prop::bool::ANY).prop_map(|(m, q)| Pred::Filter(m, q)),
     ];
     leaf.prop_recursive(3, 8, 2, |inner| {
         prop_oneof![
@@ -698,6 +744,8 @@ fn generator_reaches_both_where_clause_branches() {
     let mut with_pred = 0usize;
     let mut without_pred = 0usize;
     let mut with_filter = 0usize;
+    let mut qualified_ref = 0usize;
+    let mut bare_ref = 0usize;
     let mut pred_below_grain = 0usize;
     let mut pred_at_or_above_grain = 0usize;
     let mut multi_grain_with_pred = 0usize;
@@ -722,6 +770,9 @@ fn generator_reaches_both_where_clause_branches() {
                 if p.references_filter() {
                     with_filter += 1;
                 }
+                let (q, b) = p.reference_spellings();
+                qualified_ref += usize::from(q);
+                bare_ref += usize::from(b);
                 distinct.insert(p.to_member_sql());
                 if dim_below || case.sel_metrics.is_empty() {
                     continue;
@@ -761,6 +812,15 @@ fn generator_reaches_both_where_clause_branches() {
         with_filter > 0,
         "generator never referenced a filter member -- member substitution and \
          its parenthesization are untested"
+    );
+    // EXP-14 guard. `where_clause: None` in all five harnesses is how EXP-9/EXP-10
+    // reached main; a qualification flag pinned to `false` would be the same
+    // mistake one level down -- the field present, the generator never varying it.
+    assert!(
+        qualified_ref > 0 && bare_ref > 0,
+        "where_clause members must be named BOTH bare and <table>.<name> across \
+         cases (qualified={qualified_ref}, bare={bare_ref}); with either at zero \
+         the qualified-reference resolution EXP-14 fixed is untested"
     );
     assert!(
         pred_below_grain > 0,


### PR DESCRIPTION
Second of the remaining-mediums batches. Two findings, both `src/expand/where_clause.rs`, both the same shape: **the predicate path diverging from the queried-member path**.

Sequenced early on purpose — `where_clause` is unreleased, so fixing these before the v0.12.0 tag means no user ever sees the divergence.

## EXP-13 — the predicate ignored access modifiers

`resolve_where_clause` built its member lookup from *all* dimensions and facts with no `AccessModifier` check. A PRIVATE fact that `resolve_names` refuses to let you select could still be named in a predicate — and its values probed by varying the filter and watching the result move. The queried-member path has enforced PRIVATE since Phase 43; this one never did.

PRIVATE facts are now kept **out** of the lookup and recorded separately, so naming one raises `PrivateFact` rather than falling through to "unknown reference" — which would have left it in the emitted SQL as a raw column and leaked the very member PRIVATE withholds.

Only facts are affected: `PRIVATE` on a dimension is rejected at CREATE, which is why `sql_gen`'s `Resolvable` impl carries `unreachable!("dimensions cannot be private")`. That divergence is PAR-4, still open.

## EXP-14 — filed LOW; it is a fan-trap fence bypass

`scan_references` keys a dotted chain by the whole chain (`o.order_date`), but the lookup was keyed by bare name only, so a qualified reference matched **nothing**.

The review predicted a raw column that "fails loud at bind". It does worse than that. `ResolvedWhere::source_tables` is what feeds the predicate's tables into the fan-out check, and it is populated **only for references that resolve**. An unresolved qualified reference therefore removes its member from the fence's input entirely, so a predicate reaching a fanning grain is silently accepted.

The extended oracle's minimal counterexample:

```sql
SELECT sum(u.uw) AS "su"
FROM "u" AS "u"
WHERE ((u.ucat) <= 1 AND t.ftd)
```

`t.ftd` names a filter member on `t`. Pre-fix it resolved to nothing, `t` never entered `source_tables`, the fence never learned the predicate reached `t`, and the query was accepted with `t` **not even joined**. That is the same class as EXP-10, which was rated HIGH.

It happens to bind-fail here only because `t.ftd` is not a real column. Where a member name coincides with a real column on its own table, it binds and returns a wrong number with no error at all.

I've marked the severity correction in the review note rather than quietly fixing at the filed priority.

### Fix

Every member is keyed both bare and by its own `source_table.name`, mirroring `expand::facts::insert_fact_keys` and the dotted-reference handling at the NA-dim and window sites (TECH-DEBT #28/#30). Keying by the member's **own** table is what keeps a *foreign* qualifier (`c.order_date`) an ordinary column, per E-3. Metrics are keyed both ways too, so `o.revenue > 5` now raises `WhereClauseReferencesMetric` instead of slipping past it.

## Tests

**Seven unit tests, each confirmed red before the fix**, and separate so they report independently. Two are controls that were green throughout: a public fact still resolving (so the PRIVATE guard rejects on *access*, not on being a fact), and a foreign qualifier staying a raw column (guarding against over-eager substitution).

**Randomized coverage**, per CLAUDE.md — this changes what number a query returns, so fixed examples are not enough. `multi_hop_join_proptest`'s predicate generator now varies every member reference between bare and `<table>.<name>` spellings. The oracle rendering is untouched, so the comparison stays differential: both spellings denote the same member, so both must produce the oracle's number.

Verified the honest way — **reverted only the fix and watched the harness go red** on the case above.

`generator_reaches_both_where_clause_branches` gained an assertion that both spellings actually occur across generated cases. Without it a future change could pin the flag to `false` and the coverage would evaporate silently — exactly the `where_clause: None` mistake (PBT-6) one level down.

**Not covered, deliberately:** `differential_proptest` cannot host this. Its members carry `source_table: None`, so a qualified spelling does not exist there. Left alone rather than restructured for the sake of a checkbox.

## Gate

`cargo test` green — 1505 lib tests plus all integration and property tests. `cargo fmt --check` and the extension-feature clippy clean.

**Local sqllogictest again not run** — same container disk ceiling as #194; the C++ extension build does not fit alongside the warm Rust target dir. No `.test` files change here, but this does alter generated SQL, so CI's sqllogictest run is the real check.

Recorded as TECH-DEBT #47.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKAN2b8FcTg6pbpYZVThbV)_