### PR TITLE
docs: 2026-08-08 code review + proactive defect-discovery research

### DIFF
--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -128,7 +128,7 @@ Constraints inherent to the current approach that affect users or maintainers.
 
 Areas where test coverage is reduced compared to ideal, with justification.
 
-> **The live gaps are in [#66](#66--the-randomized-coverage-axis-ledger-is-not-maintained-and-three-axes-with-wrong-number-history-are-unrandomized-pbt-81011121-tc-1213--open).**
+> **The live gaps are in entry #66 below.**
 > The four entries in this section are pre-v0.5 items about *which harness type* covers a
 > feature; two are long resolved. They say nothing about the randomized-coverage axes that
 > have actually admitted wrong-number bugs (role-playing, FACTS requests, window/semi-additive

--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -128,6 +128,13 @@ Constraints inherent to the current approach that affect users or maintainers.
 
 Areas where test coverage is reduced compared to ideal, with justification.
 
+> **The live gaps are in [#66](#66--the-randomized-coverage-axis-ledger-is-not-maintained-and-three-axes-with-wrong-number-history-are-unrandomized-pbt-81011121-tc-1213--open).**
+> The four entries in this section are pre-v0.5 items about *which harness type* covers a
+> feature; two are long resolved. They say nothing about the randomized-coverage axes that
+> have actually admitted wrong-number bugs (role-playing, FACTS requests, window/semi-additive
+> generator pins), which is why review after review has had to rediscover them. New coverage
+> gaps go in the numbered ledger below, not here.
+
 ### 1. ❓ Iceberg integration test uses Python instead of SQLLogicTest
 
 - **Origin:** Phase 4 audit item; decision [04-03] python-ducklake-test
@@ -547,6 +554,57 @@ Areas where test coverage is reduced compared to ideal, with justification.
 - **What the target asserts now:** the invariant its header always described and that is unconditionally true — render is a **fixpoint on a parser-produced definition**. Stage 0 renders the arbitrary def and parses it back purely to LAND in the parser's image; a failure there is a skip, because an arbitrary `SemanticViewDefinition` is not in that image and never was. From `d1` onward there is no escape. The `render_ddl.rs` mirror test matches, and both carry the reasoning inline.
 - **What is given up, explicitly:** the implication "YAML-storable ⇒ renders to parseable DDL" is no longer machine-checked over random definitions. It is still *enforced* — `validate_ddl_representable` is unchanged and still runs at the YAML choke point — and still tested, by the unit tests in `src/model.rs` and `test/sql/cr20260806_yaml_ddl_contract.test`. What is lost is randomized search for the next rule the validator does not yet know.
 - **What would finish it:** a target that fuzzes DDL **text**, not a struct — feed arbitrary bytes to `parse_keyword_body`, skip on parse failure (arbitrary bytes legitimately are not DDL), and assert that anything that DOES parse re-renders and re-parses to a fixpoint. That needs no precondition, since everything it asserts on came from the parser, and it searches the direction this target structurally cannot: what the parser *accepts*. It would subsume this entry and **#59**.
+
+### 61. ❌ Schema identity in the catalog is byte-equal for writes and case-folded for reads (CAT-5/CAT-6) — OPEN
+
+- **Origin:** code review 2026-08-06 (`_notes/code-review-2026-08-06.md`, CAT-5/CAT-6); re-confirmed unfixed by the 2026-08-08 review (`_notes/code-review-2026-08-08.md` §8). Recorded here because the 2026-08-06 review asked for ledger entries "in the next change that touches the area" and #203–#209 have since touched adjacent areas without opening one.
+- **CAT-5 — what is wrong:** the conflict key that makes `CREATE OR REPLACE` replace rather than duplicate is the byte-equal primary key `(schema_name, name)` (`src/parse/native_sql.rs:345,454`), while every read predicate and existence guard folds case (`src/catalog/writes.rs:166`, `src/catalog/mod.rs:692`). Drop a schema and recreate it under a different spelling (`main` → `MAIN`) and `INSERT OR REPLACE` no longer conflicts, so a second row is inserted for what reads consider the same view; qualified lookups then take `rows[0]` (`mod.rs:926-928`) and can resolve the stale definition. DuckDB's case-insensitive identifier convention (see CLAUDE.md) makes the folding side correct, so the PK is the side that is wrong.
+- **CAT-6 — what is wrong:** `DROP SCHEMA … CASCADE` is never intercepted, so `_definitions` rows for views in that schema survive the schema itself. They are unreachable but not gone, and a later recreate of the schema resurrects them.
+- **What would finish it:** store a folded (normalized) schema-name column as the PK component while keeping the user's spelling in a display column — the same split the catalog already uses for view names — so writes and reads agree on identity by construction; and either intercept `DROP SCHEMA` or make reads join against `duckdb_schemas()` so orphans cannot resolve.
+- **Coverage:** none. Both shapes are reachable from ordinary SQL and neither has a test; a fix must add them test-first.
+
+### 62. ❌ Query-path robustness: bind-time recursion and existence-check ordering (QRY-1/QRY-2) — OPEN
+
+- **Origin:** code review 2026-08-06 (QRY-1/QRY-2), re-confirmed unfixed 2026-08-08.
+- **QRY-1:** the bind-time `LIMIT 0` probe (`src/query/table_function.rs:243-256`) runs on a fresh connection per level (`cpp/src/shim.cpp:2759,2834`), so a SQL view that has been replaced to select from a semantic view that reads it back recurses at bind time with no depth counter. Constructible, and the failure mode is stack exhaustion rather than a diagnostic. Finishing it means threading a depth/visited-set through the bind context, or refusing to re-enter the bind path re-entrantly.
+- **QRY-2:** `EmptyRequest` is checked before the view is looked up (`table_function.rs:170-172`, `explain.rs:167-171`), so `semantic_view('does_not_exist')` reports the empty-request error rather than the missing view — the less useful of the two diagnostics. Finishing it is a reordering plus a test.
+- **Coverage:** none for either.
+
+### 63. ❌ FFI/wire defence-in-depth residues (FF-12/FF-13/FF-14) — OPEN
+
+- **Origin:** code review 2026-08-06 (FF-12/13/14), re-confirmed unfixed 2026-08-08. None is reachable from ordinary SQL — they are hardening items, recorded so they are not rediscovered as "new" a fourth time.
+- **FF-12:** the C++ wire readers `reserve()` a count read from the buffer before validating it (`cpp/src/shim.cpp:1251,1334,2785`). The Rust encoders never emit a bad count, so this only matters against a corrupted or hostile payload, but the Rust side clamps and the C++ side does not — an asymmetry worth closing.
+- **FF-13:** `sv_serialise_string_list` hardcodes the `explain_semantic_view:` error prefix (`shim.cpp:2324-2326`) although it is shared by `semantic_view` and, via `sv_search_path_payload` (`:1436-1442`), every named-parameter table function — so a NULL list element in any of them is attributed to `explain_semantic_view`.
+- **FF-14:** `read_column_string` truncates at an interior NUL (`src/catalog/mod.rs:656-668`), so a hand-tampered catalog row silently loses everything after it rather than being rejected.
+- **What would finish it:** clamp reserves against remaining buffer length in C++ as Rust already does; pass the caller's function name into the serializer; and reject (not truncate) interior NULs when decoding a stored definition.
+
+### 64. ❌ Identifier-matching residues outside `ident_matches`, and the reference scanner's blind spots (IDENT-1..5, PARSE-9) — OPEN
+
+- **Origin:** code review 2026-08-06 (IDENT-1..5, PARSE-9), re-confirmed unfixed 2026-08-08. Same family as #25/#28: sites that compare or key identifiers without the project's case-insensitive rule, plus scanner positions that mis-classify text as a reference.
+- **IDENT-1:** `alias_to_table_map` is exact-string keyed (`src/model.rs:492-497`) while alias matching is case-insensitive everywhere else, so a qualifier `o` misses an alias declared `O`. Re-executed 2026-08-08: still misses.
+- **IDENT-2:** `expr_tokens::scan_chain` splits a qualified reference at a spaced (or comment-blanked) dot — `o . region` scans as two chains. Currently *pinned as desired* by `dotted_chain_is_not_split_by_whitespace`, so changing it means changing that test deliberately.
+- **IDENT-3:** the scanner has no `::` / `CAST(… AS …)` / `EXTRACT(… FROM …)` context awareness, so a member named `date` or `year` corrupts sibling expressions when inlined. (PARSE-12, fixed 2026-08-08, is the distinct *literal-prefix* sibling of this defect, not this one.)
+- **IDENT-4:** a quoted all-digit name (`"0"`) collides with numeric literals, which the scanner assumes "can never be a declared name" (`expr_tokens.rs:541`).
+- **IDENT-5:** `normalize_ident_part` re-joins parts with `.` (`ident.rs:407-417`), so a quoted-dot single identifier and a two-part qualified reference produce the same match key.
+- **PARSE-9:** name slots accept identifier garbage DuckDB would reject — `RENAME TO x,y` stores `x,y`.
+- **What would finish it:** route IDENT-1 through `ident_matches` (mechanical); give the scanner position-awareness for cast/EXTRACT slots (IDENT-3) and a quoted-name-aware literal rule (IDENT-4); make `normalize_ident_part` produce a structured key rather than a re-joined string (IDENT-5); tighten the name-slot grammar (PARSE-9). IDENT-2 needs a decision before a fix.
+
+### 65. ❌ `USING` role context is not threaded into grain CTEs for the ambiguous-dimension case — OPEN
+
+- **Origin:** promoted 2026-08-08 from the "Still declined, deliberately" bullets of **resolved** entry #36, per the CLAUDE.md rule that a degraded behaviour's record must not live only in a test comment — and must not live only inside an entry marked ✅, which reads as finished. `test/sql/per_grain_role_playing.test` (Test 3) pins the degraded outcome with the comment "this still errors until USING context is threaded into the grain CTEs"; that comment should reference this entry.
+- **What is degraded:** a dimension on a role-played table reachable by two relationships, with no co-queried metric carrying `USING` to disambiguate, errors with `fan trap detected` rather than being answered. Erroring is the correct conservative call — a grain CTE would otherwise pick an edge by declaration order, which is the silent mis-binding the fence exists to prevent — but it is a capability gap, not a neutral choice, and Snowflake answers these.
+- **Also still declined for the same reason:** a `where_clause` member on a role-played table, a metric whose own grain table is one, and any table reachable only *through* one; the window path stays strict because `__sv_agg`'s SELECT list gets no scoped-alias rewrite.
+- **What would finish it:** the machinery exists — `role_playing::find_using_context`, `expr_tokens::rewrite_qualifier`, and `ResolvedJoin`'s `scoped` / `emit_alias` fields, which `anchor_joins` currently hardcodes to the bare alias. What is missing is a way to name the intended role when no metric supplies `USING`, i.e. per-dimension role context in the request or the definition.
+
+### 66. ❌ The randomized-coverage axis ledger is not maintained, and three axes with wrong-number history are unrandomized (PBT-8/10/11/12, TC-12/13) — OPEN
+
+- **Origin:** code-review test audits 2026-08-06 (PBT-8..12, TC-12/13) and 2026-08-08 (PBT-13/14/15, TC-14/15). Recorded here because the "Test Coverage Gaps" section above lists only four pre-v0.5 items and none of the live gaps — the review's TC-15: the record of what is actually uncovered lives in `_notes/` review documents, which is the "record sits where nobody re-reads" shape this file exists to prevent.
+- **The axes with no randomized numeric coverage, ranked by demonstrated risk:**
+  - **PBT-10 — role-playing.** No harness generates two edges to one table (`tests/common/mod.rs:242-259` emits at most one join per non-base table, all targeting `t0`). The feature with the worst regression history (EXP-4/5, EXP-10, F-18/T-15) has the emptiest coverage row, unchanged across three review rounds. Its independent oracle is genuinely hard to formulate, which is why it keeps not happening — see `_notes/proactive-defect-discovery.md` §2.1 for the self-checking-oracle approach that removes that blocker.
+  - **PBT-8 — row-level FACTS queries.** `QueryRequest.facts` was pinned at `vec![]` in every harness; EXP-28/EXP-29 (2026-08-08) landed in exactly that cell.
+  - **PBT-11/12 — pinned generator fields and fixed topologies:** window `order_by`/`frame_clause`/`extra_args` and a self-referential inner metric; semi-additive `nulls`/single-NA-dim/single-table; `ManyToOne` and single-column keys everywhere; hostile identifiers never reaching a numeric oracle; sibling-fan / fan-in / diamond topologies fixed-example-only.
+- **The vacuity residues (TC-12):** assertion-free match arms in `tests/parse_proptest.rs:831-848` under a comment claiming an invariant; two empty-expectation `statement error` blocks in `test/sql/quick_260430_vdz_leading_comments.test:74-83`; a stale "not yet written" comment in `tests/expand_proptest.rs:326-331`; `src/expand/tests_fact_query.rs:33-44` asserting on SQL substrings rather than numbers.
+- **What would finish it:** keep the pinned-field matrix (reproduced per review round in `_notes/code-review-2026-08-*.md` §6/§7) as a checked-in artifact verified by a meta-test, so adding a field to `QueryRequest` without deciding its generator story fails CI; require a `// PIN: <reason>, TECH-DEBT #<n>` comment on any inert generator default. See `_notes/proactive-defect-discovery.md` §2.5.
 
 ### 57. ❌ An unqualified `where_clause` member excludes a query from every re-anchoring path (EXP-22) — OPEN
 

--- a/_notes/code-review-2026-08-08.md
+++ b/_notes/code-review-2026-08-08.md
@@ -1,0 +1,548 @@
+# Code Review — 2026-08-08
+
+**Scope:** Full codebase review at `57e38fd` (post-#209), on branch
+`claude/duckdb-semantic-views-review-ho1bm0`, working toward v0.12.0 (v0.10.4 released,
+v0.11.0 unreleased). Requested focus: the recurring bug areas — parser, extension/connection
+handling, generated SQL — and the test-gap / vacuous-test pattern behind them.
+
+**Method:** Five parallel review passes: (1) parsing layer (`body_parser/`, `parse/`,
+`expr_tokens.rs`, `sql_lit.rs`); (2) query expansion and SQL generation (`expand/`, `graph/`);
+(3) catalog, connection, FFI (`catalog/`, `ddl/`, `query/`, `lib.rs`, `ffi_util.rs`,
+`cpp/src/shim.cpp`); (4) identifiers, rendering, model (`ident.rs`, `render_ddl.rs`,
+`render_yaml.rs`, `model.rs`, YAML import path); (5) test-suite honesty audit (harness pins,
+new-test vacuity, TEST_LIST/fuzz/doc sync). Each pass audited the fix commits landed since the
+last review (#203–#209) for completeness **before** fresh hunting. **Verification level is
+stated per finding.** The expansion findings (EXP-25..29) were all *numerically confirmed*:
+generated SQL executed against the bundled in-memory DuckDB and the wrong values observed. The
+rendering/model findings (RT-7/8/9, MODEL-1) and parser findings (PARSE-10/11/12/13) were
+executed via temporary tests (since removed; working tree clean). Two of the fix commits'
+test sets (#204, #207) were confirm-the-red verified by actually reverting the fix hunks and
+watching exactly the new tests fail. No fixes have been applied — this is a review document.
+
+**Prior review:** `_notes/code-review-2026-08-06.md`. Its EXP-19..24, PARSE-5..8 and RT-5/6
+findings are confirmed landed (#203–#209) and audited below. Its CAT-5/6, QRY-1/2, FF-12/13/14,
+IDENT-1..5, PARSE-9, PBT-8..12 and TC-12/13 findings remain **open at this HEAD**; each was
+re-confirmed still-open (see §8) and none has yet been given a TECH-DEBT entry.
+
+---
+
+## 1. Executive summary
+
+The dominant lesson this round: **the last round's fixes need the same combinatorial scrutiny
+as new features.** Of the four worst findings, three sit *inside or adjacent to* the #203/#207
+fixes — the constant-argument fence's whitelist leaks four ways (EXP-25), the phantom-row
+hazard it fences has a much larger unfenced surface (EXP-26), and the EXP-23 fix converted a
+loud binder error into a silent 2× by adding a join without extending the fan-trap fence
+(EXP-27, a regression new in #207). Meanwhile the blind-spot → bug correlation held for the
+third consecutive round: EXP-28 sits exactly in the still-open PBT-8 cell (FACTS requests
+pinned at `vec![]` in every harness), EXP-26's shape in the new child-grain harness's
+constant-only metric list, and the brand-new harness itself re-introduced the canonical
+`where_clause: None` pin (PBT-13) two commits after CLAUDE.md enshrined it as the known-fatal
+shape.
+
+The second theme is a **YAML-ingress class** the RT-5/6 fix (#209) did not reach: the fix
+enumerated identifier *slots*, but fields that are not slots — member-expression comment
+markers (RT-8), the entire `WindowSpec` payload and materialization/NAB cross-references
+(MODEL-1), `output_type` (RT-7), keyword-colliding derived-metric names (RT-9) — still let a
+YAML-validated definition render GET_DDL that replays to a *different* model or none at all.
+
+| # | Cluster | Worst consequence | Where |
+|---|---------|-------------------|-------|
+| 1 | **EXP-25/26**: the SG-8 phantom-row fence is a leaking whitelist, and non-constant NULL-insensitive arguments have no fence at all | `COUNT(DISTINCT 1)`=1, `MIN(1)`=1, `SUM(COALESCE(li.qty,99))`=99 on a childless parent; a cross-table fact reference inflates a child-grain metric 25 vs 20 — all numerically confirmed | `src/expand/facts.rs:403,412,483,739` |
+| 2 | **EXP-27**: WHERE-member fact chains join fanning tables unfenced — **regression opened by #207** | Silent 2× (`rev` = 200 vs 100), where pre-#207 the same query was a loud binder error — numerically confirmed through both the fact and dimension branches | `src/expand/where_clause.rs:231-241`, `fan_trap.rs:657,719` |
+| 3 | **RT-8**: a `--` in a YAML member expr passes validation; GET_DDL replay silently merges two members into one | Dump/restore corrupts the model with no error anywhere — executed, 2 dims became 1 | `src/model.rs:747-775` vs `:595-611` |
+| 4 | **PARSE-10**: window-metric expression text outside `FUNC(args) OVER (...)` is silently discarded | `AVG(w) OVER (...) + 100` parses; queries compute without the `+ 100` — definition and behaviour disagree, executed end-to-end | `src/body_parser/window.rs:24-106`, `expand/window.rs:277` |
+| 5 | **MODEL-1**: YAML import bypasses every cross-reference validation living only in `parse_keyword_body` | Six YAML-valid shapes render GET_DDL its own parser rejects; a hostile `frame_clause` injects an extra metric into the replayed model | `body_parser/mod.rs:287-437` (checks with no YAML-path twin) |
+| 6 | **EXP-28/29**: FACTS queries and dims-only DISTINCT on child-table members emit a phantom NULL row per childless parent | Row-level results contain rows that don't exist — sits exactly in the open PBT-8 blind spot | `src/expand/sql_gen.rs:195,316-327,690` |
+| 7 | **PARSE-11/12/13**: nested resolving calls panic (→ silent no-injection); escape-string/typed-literal introducers scan as references; `--` comments don't terminate at bare `\r` | Search-path injection silently disabled; role-playing alias rewriter corrupts `e'...'` literals | `parse/search_path.rs:201-211`, `expr_tokens.rs:155-192`, `util.rs:388-395` |
+| 8 | **PBT-13/14**: the new child-grain harness re-pins `where_clause: None`; window-over-dependent-metric never reaches a number | The next EXP-9/EXP-10-shaped bug has a ready-made hiding place | `tests/child_grain_proptest.rs:268`, `semi_additive_proptest.rs:800,829-831` |
+
+Catalog/connection/FFI is the healthiest area this round: five LOW findings only, and the
+transaction, concurrency, reload-idempotence and FFI panic-safety architecture all verified
+clean (§5).
+
+---
+
+## 2. Audit of the #203–#209 fixes
+
+- **EXP-19/20 (#203) — clean.** `collect_transitive_metric_names` (`facts.rs:828`) is
+  genuinely transitive: window inners pushed unconditionally, recursion through derived
+  metrics. Executed probes: window→derived→semi-additive errors correctly; a derived metric
+  over **two** semi-additive bases with different NON ADDITIVE BY dims errors on the
+  still-active base when only one NA dim is queried. Controls pass.
+- **EXP-21 (#203) — holds for its stated scope, but the invariant is narrower than the
+  hazard.** COUNT(1)/SUM(1)/COUNT('x')/nested parens/FILTER all guarded; guard propagates
+  through derived-metric inlining (confirmed 102/100). The escapes are EXP-25/26 below, and
+  TECH-DEBT #56's DISTINCT rationale is factually wrong (see EXP-25).
+- **EXP-22 (#203) — clean.** All three re-anchor deciders take the qualification flag; the
+  facts path never re-anchors; single-grain/multi-grain/window/snapshot topologies all route
+  through them. Raw-column residual honestly recorded (TECH-DEBT #57).
+- **EXP-23/24 (#207) — FIND and INLINE now agree at every traced site** (`metric_keys`
+  mirrors `insert_fact_keys`; bare+qualified dual keying consistent). **But the EXP-23 join
+  was added without extending the fan fence — that is EXP-27, a regression.**
+- **PARSE-5 (#204) — complete.** All four scan sites in `inject_search_path` read the
+  blanked copy; splice offsets index the original; length-preservation asserted. No remaining
+  comment-blind injection/detection site found (`detect_ddl_kind`, `detect_near_miss`,
+  `plan_rewrite`, `plan_ddl` all blank first). Nested-block-comment semantics verified against
+  live DuckDB. Adjacent defects found in the same machinery: PARSE-11 (nested calls), PARSE-13
+  (bare-`\r` line endings).
+- **PARSE-6 (#204) — complete**, uniformly applied to COMMENT/LABELS/WITH, spaced dots
+  handled. Confirm-the-red verified by reverting the `annotation_boundary_before` hunk: the 3
+  new tests fail individually, the control passes.
+- **PARSE-7 (#205) — complete at the scanner level.** All four scanners route through the
+  shared `opens_escape_string`/`escaped_pair_end`; no fifth private scanner exists;
+  `COMMENT = e'...'` is rejected *loudly* (acceptable divergence, worth a TECH-DEBT line). The
+  gap the fix did not reach is upstream of the scanners: PARSE-12.
+- **PARSE-8 (#206) — complete in the parsing layer.** Every remaining `eq_ignore_ascii_case`
+  there is a keyword comparison. One production residue survives *outside* the parse layer:
+  `src/expand/wildcard.rs:53,69,71` compares wildcard-qualifier aliases quote-blind (EXP-30).
+- **RT-5/6 (#209) — real and well-built for identifier slots** (single YAML choke point,
+  emission quote-protection, fuzz oracle's second escape genuinely gone,
+  `roundtrip_proptest.rs` asserts strict per-clause equality). What the slot enumeration
+  missed: non-slot fields — RT-7 (`output_type` dropped), RT-8 (expr comment markers), MODEL-1
+  (WindowSpec payload + cross-references), RT-9 (keyword-colliding derived names).
+- **Confirm-the-red discipline:** #204 and #207 test sets verified red by hunk-revert (each
+  new test individually red, controls green). #203/#205/#206/#209 commit messages document
+  per-case red; #203's anti-vacuity generator guards and #207's `references_chained_fact`
+  guard are real. All six new `cr20260806_*.test` files are in TEST_LIST (list ↔ disk sync
+  exact at 106/106).
+
+---
+
+## 3. Query expansion — correctness findings
+
+All five findings numerically confirmed: model structs mirroring parser output, `expand()`
+driven directly, generated SQL executed against in-memory DuckDB. Shared fixture for
+25/26/28/29: base `o(id, region, rate)` rows (1,'E',10),(2,'N',5); child `li(id, order_id,
+qty)` rows (1,1,2),(2,1,3); `li(order_id) REFERENCES o`, both PKs declared. Order 2 is
+childless, so the base-anchored `FROM "o" LEFT JOIN "li"` NULL-extends it.
+
+### EXP-25 — HIGH: three escapes of the EXP-21 constant-argument guard
+
+`src/expand/facts.rs:403` (`MULTIPLICITY_SENSITIVE_AGGS`), `:412` (`is_constant_literal`),
+`:483` (`constant_aggregate_arg`); TECH-DEBT #56.
+
+- **`COUNT(DISTINCT 1)`** on `li`, dims `[region]` → 1, expected **0**. TECH-DEBT #56's claim
+  that `COUNT(DISTINCT <constant>)` "needs nothing" because it is multiplicity-invariant is
+  wrong: it is multiplicity-invariant but *existence*-sensitive. The phantom row is not a
+  duplicate; it is a row that should not exist.
+- **`COUNT(1+0)`** → 1, expected **0**. A constant *expression* is not a literal, so it fails
+  `is_constant_literal` and escapes exactly as `COUNT(1)` did pre-#203.
+- **`MIN(1)`** → 1, expected **NULL**. MIN/MAX/AVG were excluded on the same
+  multiplicity-invariance rationale — correct for duplicates, wrong for empty groups. #203's
+  own CHANGELOG argues empty-group semantics are part of the contract; MIN/MAX/AVG/ANY_VALUE
+  violate it identically.
+
+**Fix direction:** the per-spelling whitelist keeps leaking. The guard
+`AGG(x) → AGG([DISTINCT ]CASE WHEN <pk> IS NOT NULL THEN x END)` is semantically neutral on
+real rows for *any* argument (pk non-null there), so apply it to every aggregate argument of a
+non-base metric instead of only recognized constants — which also fixes EXP-26.
+
+### EXP-26 — HIGH: non-constant NULL-insensitive aggregate arguments count the phantom row — no fence exists at all
+
+Emission at `facts.rs:739` runs only `guard_constant_arg_aggregates`.
+
+- **`SUM(COALESCE(li.qty, 99))`** on `li` → 99, expected **NULL**. Any NULL-insensitive
+  expression over the child's own columns (`COALESCE`, `CASE`, `x IS NULL`) resurrects the
+  phantom row.
+- **Cross-table fact reference:** fact `orate AS o.rate` on `o`, metric `m AS SUM(orate)` on
+  `li` → emitted `SUM((o.rate))` over `FROM o LEFT JOIN li`: total **25 vs 20**, grouped
+  **5 vs NULL** — the childless order contributes its parent-side value to a line-item-grain
+  metric. This is the exact mirror of PAR-6's tested direction and sits in the child-grain
+  harness's blind spot (constant args and `SUM(li.amount)` only).
+  `check_referenced_fact_fan_traps` passes because `li→o` doesn't fan.
+
+**Fix direction:** the generalized PK guard from EXP-25; extend `child_grain_proptest` with a
+COALESCE metric and a parent-fact metric.
+
+### EXP-27 — HIGH: a WHERE-member's fact chain reaching a fanning table joins it unfenced — silent 2×, regression opened by #207
+
+`src/expand/where_clause.rs:63,80` (`member_fact_tables`), `:231-241` (added to
+`source_tables`); missing fence: `fan_trap.rs:657` (`check_where_clause_fan_traps` checks only
+the member's *own* table, `:673-676`) and `:719` (`check_referenced_fact_fan_traps` never sees
+WHERE members).
+
+- Model: base `o(id, region, amount)`=(1,'E',100); child `li`=(1,1,5),(2,1,6); fact
+  `liq AS li.qty` on `li`; fact `of AS li.liq * 2` on `o`; metric `rev AS SUM(o.amount)` on
+  `o`. Query dims `[region]`, metrics `[rev]`, `where_clause := 'of > 0'` → emits
+  `FROM o LEFT JOIN li WHERE ((li.qty) * 2) > 0` → **`rev` = 200, expected 100**. Same
+  through the *dimension* branch (`band AS CASE WHEN li.liq > 0 ...` on `o`). Both
+  numerically confirmed.
+- Before #207 both shapes were a loud binder error (`li` unjoined); #207 added the join
+  without extending the fence — loud → silent-wrong.
+
+**Fix direction:** fence each WHERE member's `member_fact_tables` (the exact set EXP-23
+computes) through `fanning_edge_on_path`, mirroring how `check_referenced_fact_fan_traps`
+treats queried members.
+
+### EXP-28 — MEDIUM: FACTS query on a child-table fact returns a phantom row per childless parent
+
+`src/expand/sql_gen.rs:195` (`expand_facts` always anchors at the base table, `:316-327`).
+Fact `liqty AS li.qty` on `li`, `facts := ['liqty']` → `SELECT li.qty FROM o LEFT JOIN li` →
+**3 rows `[2, 3, NULL]`, expected 2** — a spurious all-NULL fact row at line-item grain.
+Numerically confirmed. Sits precisely in the PBT-8 blind spot. **Fix direction:** anchor the
+fact query at the queried facts' common grain table (joining *up* for dimensions is fan-free),
+or filter `WHERE <child pk> IS NOT NULL` when all queried facts live on one non-base table.
+
+### EXP-29 — LOW: dims-only DISTINCT on a child dimension emits a join-manufactured NULL row
+
+Same root, dims-only branch (`sql_gen.rs:690`, `distinct = true`). Dim `qty AS li.qty`,
+`dimensions := ['qty']` → `[2, 3, NULL]`, expected `[2, 3]`; the NULL is indistinguishable
+from a genuine data NULL. Numerically confirmed. Same fix as EXP-28.
+
+### EXP-30 — LOW: wildcard qualifier alias comparison is quote-blind (PARSE-8's surviving sibling)
+
+`src/expand/wildcard.rs:53,69,71` — `t.alias.eq_ignore_ascii_case(alias)` in production code,
+so `'"O".*'` fails against alias `o` with "unknown table alias". Loud, not silent; same class
+PARSE-8 closed elsewhere. Code-trace. **Fix:** `ident_matches`.
+
+### Fence-ordering note (speculative, code-trace)
+
+`try_route_materialization` (`sql_gen.rs:400-406`) runs before the EXP-19
+`SemiAdditiveThroughDependency` fence, so a materialization naming a derived-over-semi-additive
+metric routes without the error. Materialized contents are user-supplied, so no wrong number is
+generated by us — flagged as fence-ordering awareness only.
+
+### Examined and not flawed (expansion)
+
+Two-child-fact-table fan trap (per-grain FULL OUTER, correct incl. NULL-group asymmetry);
+derived ratio across two grains; WHERE member on base with parent-grain metric and
+semi-additive + WHERE-on-child both loudly fenced; predicate placement pre-aggregation in
+snapshot/window/per-grain CTEs; `fanning_edge_on_path` orientation; SG-16 role-playing
+worst-case cardinality; where_clause metric-reference rejection incl. qualified; PRIVATE fact
+fencing; wildcard PRIVATE/dedup; ordinal-GROUP-BY E-1 defense; `__sv_*` CTE names cannot
+collide with user aliases.
+
+---
+
+## 4. Parsing layer — correctness findings
+
+### PARSE-10 — HIGH: window-metric expression text outside `FUNC(args) OVER (...)` is silently discarded
+
+`src/body_parser/window.rs:24-106`: after `cur.take_parens()` consumes the OVER body (line
+45), remaining tokens are never checked; `func_part = expr[..over_tok.start]` accepts an
+arbitrary prefix whose text before the first `(` becomes `window_function` verbatim. Emission
+rebuilds solely from the spec (`src/expand/window.rs:277`).
+
+Executed end-to-end: `t.m AS AVG(w) OVER (PARTITION BY d) + 100` parses cleanly; emitted SQL
+is `AVG("w") OVER (PARTITION BY "d")` — the **`+ 100` vanishes**, so `m` returns a number 100
+smaller than its (valid-DuckDB) definition text. Variants: `1 + AVG(w) OVER (...)` stores
+`window_function == "1 + AVG"`; `AVG(w) OVER (...) - SUM(w) OVER (...)` silently drops the
+second term. GET_DDL round-trips the stored text while queries compute from the spec —
+definition and behaviour disagree.
+
+**Fix direction:** after taking the OVER parens, error on any remaining token; require
+`func_part` to be exactly one identifier chain immediately followed by the argument parens —
+the same P-2/F-3 "reject, don't discard" rule already applied to USING/NAB residues.
+
+### PARSE-11 — MEDIUM: `inject_search_path` panics on nested resolving calls; the caught panic silently disables all injection
+
+`src/parse/search_path.rs:201-211` — `insert_at` is collected in *head order*, but a resolving
+call nested inside another's parens closes **before** the outer close, so offsets descend and
+`&sql[prev..close]` slices start > end → panic (observed at `:207`). Executed:
+`SELECT * FROM semantic_view((SELECT view_name FROM show_semantic_dimensions('x') LIMIT 1))`
+panics; in production both FFI hooks `catch_unwind` → rc=2 → the statement executes with **no
+search-path injection for either call** — the PARSE-5 consequence resurfacing, plus a
+swallowed panic on every execution. **Fix:** sort `insert_at` ascending (offsets index the
+original text); pin idempotence for the nested shape.
+
+### PARSE-12 — MEDIUM: escape-string / typed-literal introducers scan as identifier references
+
+`src/expr_tokens.rs:155-192`: at `e'\''` the `e` is an ident byte, so `scan_chain` emits a
+one-byte Reference chain before the string skipper sees the quote; same for `DATE'2020-01-01'`
+→ reference `date`. Executed at the exact primitives expansion calls:
+- with a declared member named `e`, `inline_references` corrupts `count_if(x = e'\'')` into
+  `count_if(x = (o.something)'\'')` (query-time syntax error from a valid definition), and
+  FIND reports a phantom dependency — which since PAR-6 changes join topology;
+- `rewrite_qualifier("e.name || e'a'", "e", "e__dep")` → `e__dep.name || e__dep'a'` — the
+  role-playing alias rewriter corrupts the literal when an alias is named `e`;
+- a fact named `date` corrupts `o.ts > DATE'2020-01-01'` the same way.
+
+Distinct mechanism from the known IDENT-3 family: the *prefix-abutting-a-quote* shape, newly
+relevant because PARSE-7 made `e'...'` first-class. **Fix:** in `scan_chains`, when a chain is
+immediately followed by `'` (the `opens_escape_string` adjacency rule), do not emit it as a
+reference — treat it as the literal introducer. One rule fixes `e'...'`, `E'...'` and all
+typed-literal prefixes.
+
+### PARSE-13 — LOW: `blank_sql_comments` does not terminate `--` comments at bare `\r`; DuckDB does
+
+`src/util.rs:388-395` blanks until `\n` only. Both sides executed: DuckDB ends the line
+comment at `\r` (PG scanner rule); our blanker blanks the `\r` **and following code**.
+Consequence: `-- note\rSELECT * FROM semantic_view('v')` blanks entirely → no search-path
+injection while DuckDB executes the query; on the DDL side a clause after `-- c\r` silently
+vanishes from the body. Bare-CR endings are rare — one-condition fix (terminate at `\r`,
+keeping the byte).
+
+### INFO (parsing, not defects)
+
+`SHOW ... LIKE'x%'` (no space) rejected loudly — dialect nit (`show_clauses.rs:365-455`).
+`COMMENT = e'...'` rejected loudly — consistent-but-narrower than host dialect; worth a
+TECH-DEBT line if E-strings are in scope for annotation values.
+
+---
+
+## 5. Catalog, connection, FFI
+
+The healthiest area this round — five LOW findings, none silent-wrong-number.
+
+### CAT-7 — LOW: fixed `/tmp` filenames in file-backed unit tests collide across concurrent `cargo test` processes
+
+`src/catalog/mod.rs:1829-1835, 1857-1861, 1898-1903, 1941-1944, 1986-1989`;
+`src/lib.rs:832`. Observed live during this review: 4 tests failed on a conflicting-lock
+error from a sibling test process, passed in isolation. Each test also `remove_file`s the
+path up front, so one run can delete another's live database. **Fix:** the pid+nanos unique
+naming `tc6_restart_persistence_survives_reopen` already uses (`catalog/mod.rs:2047-2062`).
+
+### CAT-8 — LOW: read-only open of a v0.1.0 companion-file database silently loses all views
+
+`src/catalog/mod.rs:61-75` — the RO branch checks only `definitions_is_legacy_shape`; the
+companion-file detection (`:104-171`) is unreachable read-only. The analogous legacy-*table*
+case refuses loudly with actionable wording; the companion-file case resolves every view as
+nonexistent with no hint. Code-trace; narrow population. **Fix:** probe for the companion
+file in the RO branch and refuse with the same wording.
+
+### FF-15 — LOW: `__sv_compute_create_from_yaml` bind lacks the FF-4 NULL-argument guards every other TF received
+
+`cpp/src/shim.cpp:948-950` (contrast the guards at `:1459-1462, :1494-1499, :2729-2732`).
+`GetValue<string>()` on a NULL Value renders the string `"NULL"` (verified against bundled
+DuckDB source), so NULL args become a file literally named `NULL` / a view named `NULL`.
+**Fix:** the same up-front `IsNull()` → `BinderException` guard.
+
+### FF-16 — LOW: a panic in the parser-hook Rust code reports as "not ours" — an internal bug surfaces as the user's syntax error
+
+`src/parse/ffi.rs:193, :334` (`result.unwrap_or(2)`): a panic in `rewrite_to_native_sql`
+yields rc=2 from both hooks → DuckDB's generic `syntax error at or near "SEMANTIC"` with zero
+trace of the extension's failure — indistinguishable from "extension not loaded". Contrast
+the 17 read dispatchers, whose panics surface as `internal error: panic inside <name>`.
+**Fix direction:** panic arm writes a diagnostic into `error_out` and returns rc=1 from
+`sv_parse_function_rust` (the `DISPLAY_EXTENSION_ERROR` channel exists); the override side
+stays rc=2.
+
+### LIFE-2 — LOW: a failed LOAD leaves the extension half-active, with no rollback
+
+`src/lib.rs:518-533` — first registration failure returns `Err`, but the parser hooks +
+`allow_parser_override_extension` setting (`shim.cpp:3063-3089`) and the catalog schema
+(`lib.rs:499`) are already committed. DDL half-works while read TFs are absent, until a retry
+LOAD (which does heal — WR-09 dedup + `ALTER_ON_CONFLICT`). Extraordinary failure, hence LOW;
+cheap improvement: register the parser hook *last*.
+
+### INFO (catalog/FFI)
+
+`test/sql/extension_reload.test:1-12` header describes the retired pre-WR-09 architecture —
+stale doc in exactly the file meant to pin reload semantics (test itself still valid).
+`shim.cpp:2316,2331` unchecked `static_cast<uint32_t>` asymmetry vs the Rust `wire_len`
+discipline (bounded; Rust decoder rejects desync). `src/ddl/list.rs:74-76` stale comment
+(noted 2026-08-06, still present).
+
+### Verified clean (catalog/connection/FFI)
+
+Write-path SQL builders (every name/schema/path/comment slot SqlLit-escaped exactly once;
+writes and reads share `resolve_in_search_path` branch-for-branch); transactional DDL incl.
+rolled-back `CREATE OR REPLACE` byte-identical restore; concurrency posture (DuckDB PK/MVCC
+serializes; outcome shapes pinned by the three `test_concurrent_*.py` suites); reload
+idempotence (WR-09 dedup wraps both registration and allocation); FFI memory safety
+(`catch_unwind` on all dispatchers, char-boundary error truncation, both-or-drop publish
+contract, wire formats bounds/trailing/count-checked both sides); lifecycle (FF-3 primary-db
+resolution, no long-lived connection, interrupt forwarding preserves the bare `Interrupted!`
+contract); search_path ↔ catalog interplay (PARSE-5 fix verified in place; write-side
+`resolved_schema_expr` evaluates the identical `SEARCH_PATH_SQL` on the caller's connection).
+Executed: `cargo test` 1654 passed; the only 4 failures were the CAT-7 cross-process
+collisions, green in isolation.
+
+---
+
+## 6. Identifiers, rendering, model
+
+### RT-8 — HIGH: `member_expr` omits the `blank_sql_comments` check `slot_common` has — a `--` in a YAML expr silently merges/destroys members on replay
+
+`src/model.rs:747-775` (`member_expr` checks trim-empty + `column_roundtrips_verbatim` only;
+`slot_common` at `:595-611` additionally rejects comment markers; `column_roundtrips_verbatim`
+has no comment awareness, as `model.rs:1013-1015` itself documents).
+
+Executed: YAML `dimensions: [{name: d1, expr: 'o.a -- x', ...}, {name: d2, expr: o.b, ...}]`
+passes the full YAML gate. GET_DDL renders `o.d1 AS o.a -- x,\n    o.d2 AS o.b`; replay
+through the front door (which blanks comments before parsing) blanks from `--` through the
+member-separating comma: **parse succeeds, 2 dimensions become 1**, with d2's definition
+swallowed into d1's expression. Silent model corruption. (A `--` before COMMENT/SYNONYMS
+annotations likewise eats them.) **Fix:** the same `blank_sql_comments(expr) != expr`
+rejection in `member_expr` (and window `frame_clause`/`order_by.expr`/`extra_args` if MODEL-1
+is fixed by validation).
+
+### MODEL-1 — MEDIUM/HIGH: YAML import bypasses every semantic cross-reference validation that lives in `parse_keyword_body` — GET_DDL then emits DDL its own parser rejects
+
+Checks live only in `src/body_parser/mod.rs` (window inner metric `:355-372`,
+PARTITION/ORDER BY dims `:287-348`, materialization refs `:392-437`, materialization
+duplicate names `:378-390`, at-least-one-of-DIMENSIONS/METRICS); the YAML path runs only
+`validate_ddl_representable` + the graph validators, none of which touch `window_spec`,
+`non_additive_by` existence, or `materializations` (grep-verified).
+
+All executed — each passes the full YAML gate, then replay of its own GET_DDL **fails**:
+`non_additive_by: [{dimension: ghost}]`; `window_spec: {window_function: AVG, inner_metric:
+ghost}`; materialization referencing `ghost`; materializations named `m1`/`M1`; materialization
+with no dimensions and no metrics. **Model-changing variant:** `frame_clause: 'ROWS BETWEEN 1
+PRECEDING AND CURRENT ROW) , junk AS ('` → replay **parses to 3 metrics** — a metric injected
+out of a frame-clause string. The window-spec *syntactic* slots are emitted raw by
+`emit_window_expr` (`render_ddl.rs:319-371`) and never validated — squarely the RT-6 slot
+class, not the "semantic cross-reference" class TECH-DEBT #60 consciously deferred. #60's
+statement that the YAML-storable ⇒ parseable-DDL implication "is still enforced" is false for
+all six shapes; the entry under-records what was given up.
+
+**Fix direction:** syntactic slots → extend `validate_yaml_members`/`..._materializations`
+with the existing slot predicates + comment/roundtrip checks for
+`frame_clause`/`order_by.expr`/`extra_args`; semantic cross-refs → hoist the body-parser's
+checks into shared functions called from both `parse_keyword_body` and
+`enrich_definition_for_create`.
+
+### RT-7 — MEDIUM: GET_DDL silently drops `output_type` — a query-semantics-bearing field only YAML can set
+
+No emit site anywhere in `render_ddl.rs` (`emit_dimensions` `:260-276`, `emit_metrics`
+`:374-407`, `emit_facts` `:238-257`); field defined `model.rs:62-67,195-200`; semantic effect
+(CAST wrapping) at `expand/materialization.rs:124,133`, `expand/per_grain.rs:1002,1139`.
+Executed: a YAML dimension with `output_type: VARCHAR(10)` passes the gate; rendered DDL
+carries no trace; replay parses cleanly with `output_type: None` — the replayed view loses
+the CAST, so queries return different types/values. Neither TECH-DEBT #51 nor #58 records
+that GET_DDL (the documented dump/restore path) drops it, and `validate_ddl_representable`
+doesn't reject it — so a definition is "YAML-storable" yet not DDL-representable,
+contradicting #58's contract statement. **Fix:** reject at `validate_yaml_members` until DDL
+grammar can carry it (matching the USING/NAB/OVER-on-derived precedent), or add DDL syntax +
+renderer support; at minimum a TECH-DEBT entry per the degraded-state rule.
+
+### RT-9 — LOW: a YAML derived metric named `private` renders bare and its GET_DDL cannot be replayed
+
+`render_ddl.rs:128-134` quote-protects on lexing grounds only; the parser peels entry-initial
+`PRIVATE` as the access modifier. Executed: YAML metric `{name: private, expr: total * 2}`
+renders `private AS total * 2`; replay fails "Missing metric name". YAML-only ingress (DDL
+can't create the bare shape); quoted `"private"` round-trips fine; only derived metrics
+exposed. **Fix:** quote a bare entry-initial name matching `PRIVATE` on emission, or reject in
+`validate_yaml_members`.
+
+### IDENT-6 — LOW: `SHOW ... STARTS WITH` treats `_` / `%` in the prefix as wildcards
+
+`src/parse/show_clauses.rs:112-115` — `name LIKE '{escaped}%'` with `SqlLit::escape` doubling
+only `'`. Views `a_b` and `axb`: `STARTS WITH 'a_b'` returns both. The function's own doc
+identifies exactly this hazard for IN SCHEMA and chose equality there. Snowflake's STARTS WITH
+is a literal prefix. **Fix:** escape `%`/`_` + `ESCAPE` clause, or `starts_with(name, ...)`.
+
+### Model invariants verified clean
+
+Case-folded duplicate member names rejected on both paths (`graph/names.rs:36-56`; the
+*materialization*-name gap is MODEL-1's); `validate_yaml_structure` covers empty member
+lists except per-materialization; forward compat is non-destructive — upgrades and ALTER SET
+COMMENT rewrite stored JSON only via `json_merge_patch` (unknown-field-preserving), RENAME
+touches only the name column, no path rewrites stored JSON through the typed struct. Also
+clean: `ident.rs` internals, `sql_lit.rs`, `render_yaml.rs` (pure serde, strips exactly the
+four runtime fields), comment/synonyms/labels escaping, header quoting, IN SCHEMA/IN DATABASE
+predicates, fuzz roundtrip target post-RT-5.
+
+---
+
+## 7. Test-suite audit
+
+### PBT-13 — HIGH: the brand-new sixth numeric harness re-introduces `where_clause: None`
+
+`tests/child_grain_proptest.rs:268`, landed in #203 — *after* PBT-6 closed exactly this pin
+in all five prior harnesses and CLAUDE.md enshrined it as the canonical blind-spot shape. No
+justifying comment; no filter members in its `build_def`. Concrete bug shape left open: a
+pre-aggregation predicate interacting with the SG-8 `CASE WHEN <child pk> IS NOT NULL` guard —
+a predicate that empties a child set turns a real parent into a childless one at filter time,
+precisely where the phantom-row rewrite must hold (and where EXP-25/26 now show the guard
+family is fragile). **Fix:** mirror the other harnesses — `Option<Pred>` over base dims +
+filter members, WHERE in the correlated-subquery oracle, extend
+`generator_produces_childless_base_rows` (`:329`) with predicate-branch counts.
+
+### PBT-14 — MEDIUM: the window half of the dependent-metric property never reaches a number
+
+`tests/semi_additive_proptest.rs:800` + `:829-831`: `if pick_window { return Ok(()); }` skips
+the numeric comparison, deferring to `window_metric_proptest` — whose inner metric is always
+the self-referential `"w"` (`window_metric_proptest.rs:340`). A window wrapping a *different*
+(here semi-additive-classified) inner metric has numeric coverage nowhere randomized — the
+surviving half of EXP-20's cell. Also `where_clause: None` in this property. **Fix:** oracle
+`wbal` with the same correlated-subquery formulation window_metric uses (partition key is
+fixed — mechanical), or generate a non-self-referential inner in window_metric_proptest.
+
+### PBT-15 — LOW: no anti-vacuity count for `dsv` selection in star_schema_proptest
+
+`tests/star_schema_proptest.rs:735-780`: the guard counts only predicate branches; nothing
+asserts `sel_metrics` ever includes `dsv`/`svf` (contrast differential's
+`references_chained_fact`). The file's own doctrine is to assert reach, not assume it.
+
+### TC-14 — LOW: silent early-return escape in the CI-crash replay test
+
+`tests/fuzz_render_roundtrip_regression.rs:63-65`: `let Ok(kb1) = parse_keyword_body(...)
+else { return; }` — a future parser change flipping this fixed input to unparseable evaporates
+the assertion with no signal (the RT-5 escape shape). **Fix:** pin the parse-ok branch
+explicitly.
+
+### TC-15 — LOW (doc-sync): TECH-DEBT.md "Test Coverage Gaps" is stale
+
+Lines 127-163 contain four ancient entries; none of the live gaps with wrong-number history
+(PBT-8 FACTS path, PBT-10 role-playing, window/semi pins) has a TECH-DEBT home — they live
+only in `_notes/` review docs, the documented "record sits where nobody re-reads" expiry
+shape. Suggest one entry per open PBT axis, referenced from harness comments.
+
+### Status of prior test findings
+
+- **PBT-8 — UNTOUCHED.** Every `QueryRequest` literal in every harness still pins
+  `facts: vec![]` (8 sites, grep-verified); the row-level FACTS path is guarded only by
+  substring unit tests. EXP-28 landed in exactly this cell this round.
+- **PBT-9 — PARTIALLY CLOSED.** `dbal`/`dsv` now reach numeric oracles (#203/#207); still
+  open: derived expressions fixed at `* 2`, no derived-over-derived, no derived metric in
+  multi_hop/child_grain, window-over-derived numeric cell (PBT-14).
+- **PBT-10 — UNTOUCHED.** No harness generates two edges to one table
+  (`tests/common/mod.rs:242-259`); the feature with the worst regression history (EXP-4/5,
+  EXP-10, F-18/T-15) still has zero randomized coverage. Highest-value open investment.
+- **PBT-11 — MOSTLY UNTOUCHED.** Window pins (`order_by`/`frame_clause`/`extra_args`/
+  self-referential inner/`["w"]`-only requests), semi pins (`nulls` default/1 NA dim/1 table),
+  cardinality pins (M:1, 1-col keys), YAML `output_type: None` ×3 + `resolution_schema_name`
+  reset — all unchanged. Closed sub-items: relationship names now generated (RT-5), `arb_expr`
+  now emits escape strings (PARSE-7).
+- **PBT-12 — hostile-identifiers × numeric untouched; topology partially improved**
+  (child_grain adds the downward-LEFT-JOIN axis; sibling-fan/fan-in/diamond remain
+  fixed-example-only).
+- **TC-12 — all four sub-items untouched** (assertion-free `test_semicolon_in_name` arms;
+  two empty-expectation `statement error` blocks in `quick_260430_vdz_leading_comments.test`;
+  stale "not yet written" comment in expand_proptest; tests_fact_query substring assertions).
+- **TC-13 — untouched.** `per_grain_role_playing.test:104` still pins degraded behaviour whose
+  only record sits inside **resolved** TECH-DEBT #36; the sibling `phase39` site was correctly
+  converted to reference open #51, so the rule is known — this one site was missed.
+
+### Verified clean (test suite)
+
+TEST_LIST ↔ disk exact (106/106) with `check-test-list`/`check-fuzz-list` wired into
+`just ci`; all 9 fuzz targets carry real oracles or documented no-panic contracts (no
+return-without-asserting remains post-RT-5); all 18 `src/expand/tests_*.rs` wired into
+`mod.rs`; no `#[ignore]`; no tautological assertion shapes; `proptest-regressions` all match
+live generators; `_excluded/` rationales recorded with named alternate coverage; MAINTAINER.md
+fuzz-table/src-tree/oracle-paragraph current — doc-sync discipline held through #203–#209.
+
+---
+
+## 8. Still-open ledger (from 2026-08-06, re-confirmed at this HEAD)
+
+CAT-5 (case-respelled schema defeats byte-equal PK; reads take `rows[0]`), CAT-6
+(`DROP SCHEMA CASCADE` orphans definitions), QRY-1 (unbounded bind-time recursion via replaced
+SQL view), QRY-2 (`EmptyRequest` before existence), FF-12 (unclamped `reserve()`), FF-13
+(hardcoded `explain_semantic_view:` prefix in shared serializer), FF-14 (interior-NUL
+truncation), IDENT-1 (exact-string `alias_to_table_map` — re-executed, still misses `O` vs
+`o`), IDENT-2..5, PARSE-9. **None has a TECH-DEBT entry yet**, despite the 2026-08-06 review
+calling for entries "in the next change that touches the area" — and #203–#209 touched
+adjacent areas. Recording them is a one-commit task and should precede or accompany the next
+fix round.
+
+---
+
+## 9. Suggested priority order
+
+1. **EXP-25/26/27** — one generalized-PK-guard change plausibly clears 25+26; 27 is a
+   regression from the current unreleased line and should not ship in v0.12.0.
+2. **RT-8 + MODEL-1 + RT-7** — one validation-hoisting change at the YAML choke point covers
+   all three (plus RT-9 as a rider); these corrupt models silently through the documented
+   dump/restore path.
+3. **PARSE-10** — silent wrong number from a valid definition; small parser fix.
+4. **EXP-28/29 + PBT-13/PBT-8** — fix the facts/dims-only anchoring *with* the harness
+   coverage that would have caught it (facts generation + where_clause in child_grain), per
+   the numeric-oracle rule.
+5. **PARSE-11/12** — silent injection-disable and literal corruption; both small.
+6. **PBT-10** (role-playing randomization) — the largest remaining predicted blind spot.
+7. The LOW/INFO tail (CAT-7/8, FF-15/16, LIFE-2, IDENT-6, PARSE-13, EXP-30, TC-14/15) and
+   the TECH-DEBT ledger entries for §8.

--- a/_notes/proactive-defect-discovery.md
+++ b/_notes/proactive-defect-discovery.md
@@ -1,0 +1,247 @@
+# Proactive defect discovery — research & proposal (2026-08-08)
+
+**Status:** proposal for discussion — nothing here is adopted yet. Companion to
+`_notes/code-review-2026-08-08.md`. The question it answers: five review rounds have each
+found silent wrong-number bugs and the test gaps that admitted them — what could find these
+*before* a review round does, and what would stop the recurring classes structurally?
+
+---
+
+## 1. Diagnosis — why bugs keep escaping
+
+Every escape from the last five rounds falls into one of five classes. The classes, not the
+individual bugs, are the target.
+
+| Class | Shape | Representative escapes |
+|---|---|---|
+| **A. Combination-cell wrong numbers** | The engine is correct in every cell a harness randomizes and wrong in a cell pinned at an inert default | EXP-9/10 (`where_clause: None`), EXP-19/20 (derived-over-semi-additive), EXP-26 (COALESCE args), EXP-28 (FACTS requests), PBT-13 (new harness re-pins) |
+| **B. Scanner divergence** | N hand-rolled scanners disagree on quotes/comments/escapes; the (N+1)th site is written fresh and wrong | EXP-16/17, PARSE-4/5/7/12/13, IDENT-2 |
+| **C. Multi-ingress contract violations** | Two paths into the same model (DDL parse, YAML import) validate differently; renderers assume the stricter path | RT-5/6/7/8/9, MODEL-1 |
+| **D. Vacuous / self-disabling tests** | Assertions that cannot fail, early-return escapes, first-failure masking, degraded pins whose ledger entry expired | TC-12/13/14, RT-5's fuzz oracle, the `data_type` column |
+| **E. Whitelist patches** | A fix enumerates the spellings of a hazard instead of guarding the class; the next spelling walks through | EXP-21→25/26 (constant whitelist), EXP-12→PARSE-8→EXP-30 (`eq_ignore_ascii_case` sweeps), EXP-23→27 (join added, fence not consulted) |
+
+Two structural observations drive everything below:
+
+1. **Hand-formulated oracles don't scale to the combination space.** The differential
+   harnesses work — every numeric oracle we've written has held — but each oracle must be
+   *hand-derived per feature*, so coverage grows linearly while the feature matrix grows
+   combinatorially. Role-playing (PBT-10) has stayed uncovered for three rounds not out of
+   neglect but because its independent oracle is genuinely hard to formulate. The fix is a
+   class of oracle that doesn't need formulating (§2.1).
+2. **Discipline that lives in review vigilance decays; discipline that lives in CI doesn't.**
+   Confirm-the-red held in #203–#209 *because agents followed CLAUDE.md*, yet PBT-13 landed in
+   the same commits — the same authors, the same week, the rule already written down. Rules
+   that survive are the ones a machine checks (TEST_LIST sync via `just check-test-list` has
+   never regressed since it became a CI check).
+
+## 2. Proposed techniques
+
+Ordered within each subsection by leverage. §3 gives the adoption sequence.
+
+### 2.1 Self-checking (metamorphic) oracles — the highest-leverage addition
+
+The insight from the SQLancer line of work (TLP, NoREC, PQS — see
+https://github.com/sqlancer/sqlancer and the TLP paper,
+https://www.manuelrigger.at/preprints/TLP.pdf): you can detect logic bugs **without knowing
+the correct answer**, by checking that two query formulations that *must* agree, do. Because
+no hand-formulated oracle is needed, generation is unconstrained — these harnesses can range
+over role-playing, hostile identifiers, arbitrary topologies and every request-shape
+combination, exactly the cells our differential harnesses cannot reach. Four families, in
+order of fit:
+
+**(a) Definition algebra** — for any derived metric `d = f(m1, …, mk)`, querying `d` must
+equal computing `f` over the separately-queried `m1…mk` (same dimensions). Likewise a window
+metric vs. its inner metric's per-partition aggregate, and a metric queried alone vs. queried
+alongside others. This is pure self-consistency — `double_balance == 2 × balance` — and it
+catches the EXP-19/20/24 class *generically*: any place where inlining, snapshot routing, or
+re-anchoring treats a composed metric differently from its components. Cheap to implement
+(drive `expand()` twice, compare in DuckDB), applies to every generated model.
+
+**(b) Roll-up consistency** — for additive metrics, the total-query result must equal the
+sum over any grouped query's rows (`SUM(m) over all == Σ groups of (m BY d)`), and COUNTs must
+add. Any fan-out duplication, phantom row, or grain-substitution error breaks additivity
+somewhere; this catches the EXP-11/21/25/26 class without knowing the right number, only that
+the two aggregations must agree. (Semi-additive metrics assert the same *within* the allowed
+dimensions.)
+
+**(c) TLP over `where_clause`** — partition any generated predicate `p` into `p`,
+`NOT p`, `p IS NULL`: the three filtered results must recombine to the unfiltered result
+(sums add, counts add). This exercises predicate placement in every CTE topology — the
+EXP-13/14/22/27 class — with the predicate itself randomly generated rather than mirrored
+into a hand-written oracle.
+
+**(d) Data metamorphism** — mutate the *data* in ways with a known effect and assert the
+delta: inserting a childless parent row must leave every child-grain metric and every FACTS
+result unchanged (this is *precisely* the EXP-21/25/26/28/29 invariant); duplicating a
+dimension row that nothing joins to must change nothing; inserting a NULL-keyed child row
+must change only NULL-group cells. Each such rule is one generator tweak plus one assertion.
+
+Concretely: one new harness, `tests/metamorphic_proptest.rs`, generating models over the
+existing `tests/common` builders (crucially *without* the oracle-imposed pins — role-playing
+edges, hostile identifiers, and FACTS requests become generatable on day one), running
+families (a)–(d) as separate properties. Rough effort: (a)+(b) a day or two; (c) another
+day; (d) incremental afterwards. Would have caught, by inspection of the historical list:
+EXP-9/10/11/19/20/21/22/24/25/26/27/28/29 — thirteen of the wrong-number findings across
+three rounds.
+
+### 2.2 One conformance pipeline for the multi-ingress contract (class C)
+
+Today the round-trip oracles each cover a segment (`roundtrip_proptest` parses via
+`parse_keyword_body` directly; `yaml_proptest` checks serde symmetry; the fuzz target checks
+render→parse). RT-7/8 and MODEL-1 lived in the seams *between* segments — front-door comment
+blanking, fields with no DDL emission, validations run on one path only.
+
+Proposal: a single canonical property — from **either** ingress (generated DDL or generated
+YAML), build the model, then assert the full loop: `model → render_ddl → front-door parse
+(including `blank_sql_comments` preprocessing, i.e. the *real* CREATE path) → model′ ≡ model`,
+and `model → render_yaml → yaml import → model″ ≡ model`. Run it as both a proptest and a
+fuzz target (the corpus transfers). Any field added to `model.rs` is then automatically under
+contract: forget the emit site or the validation twin and the property fails. This
+structurally closes class C rather than patching its instances — and it is the check that
+makes MODEL-1-style "validated on one path only" impossible to reintroduce silently.
+
+### 2.3 Mutation testing for vacuous-test detection (class D)
+
+`cargo-mutants` (https://mutants.rs/, `--in-diff` documented at
+https://mutants.rs/in-diff.html and https://mutants.rs/pr-diff.html) injects source mutations
+and reports every mutant no test kills — which is exactly a machine-checked version of the
+confirm-the-red rule, run continuously instead of at fix time. A surviving mutant in
+`facts.rs`'s guard predicate *is* the "this test would pass anyway" signal that TC-12's
+assertion-free arms and TC-14's early-return escape embody.
+
+Practical shape for this codebase (~60k lines, slow proptests):
+- **PR gate:** `cargo mutants --in-diff <base-diff>` so only changed code is mutated —
+  minutes, not hours; a missed mutant in the diff is a review flag, not necessarily a merge
+  block at first.
+- **Nightly/weekly:** full run scoped to the correctness core (`--file src/expand/*.rs
+  --file src/parse/*.rs --file src/body_parser/*.rs ...`), with `PROPTEST_CASES` lowered
+  (e.g. 16) via `[mutants]` config so the proptest suites stay useful as killers without
+  dominating runtime; publish the outcome list as an artifact and triage new survivors.
+- Calibrate timeouts once (`--timeout-multiplier`); exclude FFI-gated code that can't run
+  under `cargo test`.
+
+### 2.4 Hazard-pattern lints (classes B and E)
+
+The project keeps re-fixing the same *pattern* at new sites. Ban the pattern mechanically:
+
+- **clippy `disallowed-methods`** (clippy.toml): `str::eq_ignore_ascii_case` disallowed with
+  the message "identifier comparison must go through `ident::ident_matches`; keyword
+  comparison sites get `#[allow]` with a comment". This turns the PARSE-8/EXP-12/EXP-30
+  whack-a-mole into a compile-time rule; the existing keyword sites get explicit,
+  greppable allows.
+- **Scanner-routing meta-test:** a unit test that greps `src/` for the byte-level scanning
+  primitives (`b'\''`, `b'"'`, `b'$'` adjacency loops) outside the four blessed scanner
+  modules, failing with "route through `QuoteState`/`blank_sql_comments`" — the same
+  mechanism as `no_long_lived_conn.rs`'s allow-list, which has worked. New scanners can
+  still be written; they just can't be written *silently*.
+- Same mechanism for `format!("... LIKE '{}'", …)`-shaped predicate splicing (IDENT-6's
+  class) and FFI `unwrap_or(<rc>)` panic swallowing (FF-16's class).
+
+### 2.5 Generator-axis ledger and pin waivers (class A's recurrence)
+
+PBT-13 shows the pin pattern re-enters through new files. Two cheap guards:
+
+- **Pin waivers:** a CI grep (a unit test in `tests/common`) over `tests/*_proptest.rs` for
+  the known-inert literals (`where_clause: None`, `facts: vec![]`, `output_type: None`, …)
+  requiring a `// PIN: <reason>, TECH-DEBT #<n>` on the same line. A pin is then a *decision
+  with a ledger entry*, not a default. (The grep is crude but the false-positive cost is one
+  comment; precision can come later.)
+- **Axis ledger:** promote the review's pinned-field matrix into a checked-in table
+  (TECH-DEBT.md "Test Coverage Gaps" — currently stale per TC-15) regenerated or at least
+  verified by that same meta-test, so "which harness varies which axis" is a maintained
+  artifact rather than something each review reconstructs. Adding a field to `QueryRequest`
+  without touching the ledger fails the meta-test (an exhaustive struct-literal in the test
+  makes the compiler enforce field-awareness).
+
+### 2.6 Fix-audit checklist (class E, the EXP-27 lesson)
+
+EXP-27 happened because a fix *added a capability* (a new joinable table source) without
+enumerating the invariant guards that assume the old capability set. One paragraph in
+CLAUDE.md's discipline section:
+
+> **When a change adds a capability, list the fences.** Any change that makes a new table
+> reachable (join emission, reference inlining, source_tables), accepts new syntax, or adds
+> an ingress path must name, in the PR description, each existing guard that assumes the old
+> set (fan-trap checks, scanner set, validation choke points) and say for each: extended, or
+> why not applicable. "The fence didn't know about the new edge" is now the second fix-round
+> regression (EXP-23→27; PARSE-7→12) — the checklist is cheaper than the round-trip.
+
+Process text, not tooling — but it's the class E counterpart of confirm-the-red, and it costs
+nothing.
+
+### 2.7 sqllogictest halt-masking (class D)
+
+The runner stops a file at its first failure, so N cases yield one observed red (documented
+in CLAUDE.md, still relies on care). Mitigations, cheapest first: (i) convention — regression
+`.test` files hold one scenario each (the `cr*` files are already close); (ii) a
+`just confirm-red <test> <ref>` recipe that checks out `<ref>`'s `src/` into a temp worktree,
+builds, and runs the named test expecting failure — mechanizing the revert-and-watch step the
+#204/#207 audits did by hand; (iii) if the runner is ours, a continue-on-error mode with
+per-statement reporting (worth a look at what `sqllogictest-rs` upstream supports before
+building anything).
+
+### 2.8 Catalog DDL state-machine testing (CAT class)
+
+`proptest-state-machine` (part of the proptest project) drives random operation sequences
+against a system under test with a reference model. A model of "map from (schema, name) to
+definition" with operations CREATE / CREATE OR REPLACE / ALTER RENAME / DROP / DROP SCHEMA /
+re-open, checked against the real catalog after every step, would have caught CAT-5 (case
+respelling), CAT-6 (schema-drop orphans) and CAT-8 (RO companion-file) as invariant
+violations rather than review finds. Medium effort; needs the file-backed harness the
+catalog unit tests already use.
+
+### 2.9 Snowflake parity fixtures (reference-differential)
+
+No emulator covers semantic views: fakesnow and the Go/DuckDB emulators mock
+warehouse/DDL surface, not `CREATE SEMANTIC VIEW` (checked 2026-08-08 — no evidence of
+support; unsurprising given the feature's age). Pragmatic path: a curated, versioned fixture
+set — real Snowflake DDL + `SEMANTIC_VIEW()` queries + captured results over tiny data —
+run manually against a trial account when parity questions arise, replayed in CI against us
+always. This converts "Snowflake does X" from a research task during review into a pinned
+test, one fixture at a time, starting with the behaviours TECH-DEBT already records as
+divergences.
+
+### 2.10 Coverage in CI — supporting signal only
+
+`cargo-llvm-cov` region coverage with a diff-coverage report on PRs ("changed lines with no
+test execution") is cheap to add and catches the grossest gaps, but note that **coverage
+would not have caught most of this project's escapes** — the wrong-number bugs execute fine
+under tests that assert the wrong thing or nothing. Useful as a floor, not as the strategy;
+mutation testing (§2.3) is the version of this signal that actually matches our failure mode.
+
+## 3. Suggested adoption order
+
+| Step | What | Effort | Classes | Would have caught (historical) |
+|---|---|---|---|---|
+| 1 | §2.6 fix-audit checklist + §2.4 lints + §2.5 pin waivers | hours | B, E, A-recurrence | EXP-27, EXP-30, PARSE-12 (lint sweep), PBT-13 |
+| 2 | §2.1(a)+(b) definition-algebra + roll-up metamorphic harness | 1–2 days | A | EXP-9/10/11/19/20/21/24/25/26 |
+| 3 | §2.3 `cargo mutants --in-diff` on PRs | ~1 day | D | TC-12/14 shapes, future vacuous fixes |
+| 4 | §2.2 conformance pipeline property + fuzz target | 2–3 days | C | RT-5/6/7/8/9, MODEL-1 |
+| 5 | §2.1(c)+(d) TLP + data metamorphism | 1–2 days | A | EXP-13/14/22/27/28/29 |
+| 6 | §2.7 confirm-red automation; §2.3 nightly full mutants | 1–2 days | D | — (hardens process) |
+| 7 | §2.8 catalog state machine; §2.9 parity fixtures | ~1 wk each | CAT, parity | CAT-5/6/8, PAR-* |
+
+Steps 1–3 fit alongside the current fix round; step 2 is the single highest bugs-per-effort
+item on the list and is the one that finally gives role-playing (PBT-10) and hostile-identifier
+numerics (PBT-12) randomized coverage, because self-checking oracles don't need the
+hand-formulated oracle those cells were waiting on.
+
+## 4. What already works — keep it
+
+The differential-oracle harness family (every hand-written oracle has held; harness gaps, not
+oracle errors, admitted the bugs), confirm-the-red as written, the anti-vacuity counter
+pattern, TEST_LIST/fuzz-list CI sync, the multi-agent review cadence (five rounds, every
+round paying for itself), and the TECH-DEBT ledger *when entries actually land* — the
+process gap there is recording latency, which step 1's waiver rule addresses at the test
+layer and §2.6 at the fix layer.
+
+## Sources
+
+- SQLancer (TLP / NoREC / PQS): https://github.com/sqlancer/sqlancer;
+  TLP paper: https://www.manuelrigger.at/preprints/TLP.pdf;
+  PQS paper: https://www.usenix.org/system/files/osdi20-rigger.pdf
+- cargo-mutants: https://mutants.rs/ (diff-scoped runs: https://mutants.rs/in-diff.html,
+  https://mutants.rs/pr-diff.html; repo: https://github.com/sourcefrog/cargo-mutants)
+- Snowflake emulators surveyed for semantic-view support (none found):
+  https://github.com/nnnkkk7/snowflake-emulator and fakesnow (PyPI) — warehouse-surface
+  mocks only.

--- a/_notes/proactive-defect-discovery.md
+++ b/_notes/proactive-defect-discovery.md
@@ -226,6 +226,35 @@ item on the list and is the one that finally gives role-playing (PBT-10) and hos
 numerics (PBT-12) randomized coverage, because self-checking oracles don't need the
 hand-formulated oracle those cells were waiting on.
 
+## 3a. Operational note: parallel agents must not share `CARGO_TARGET_DIR`
+
+Recorded from the 2026-08-08 fix round, where five agents worked in separate git worktrees
+against one shared target directory. It produced three distinct false signals, two of which
+were caught only because the agent re-verified by hand:
+
+- **A false green** — an integration test linked a `libsemantic_views` that predated the
+  agent's own source edit, reporting a validator returning `Ok` for input an in-crate test
+  proved it rejected.
+- **A false red** — a proptest failed with SQL visibly from a *sibling's* fence-reverted
+  verification build; the same case passed 60/60 in fresh processes.
+- **A stale-path panic** — `CARGO_MANIFEST_DIR` is baked in at compile time, so a lib-test
+  binary built inside a worktree kept pointing at it; removing the merged worktree made
+  `duckdb_version_pins_agree` fail with "No such file or directory" on a file that was
+  present. Nothing was wrong with the code or the file.
+
+None of these is a defect in the project, and all three are indistinguishable from real
+results at a glance — which is the point: a test run you cannot trust is worse than no test
+run, because it launders a guess into a reported fact. Give each worktree its own
+`CARGO_TARGET_DIR` (disk permitting), or serialize the agents that run tests. If a shared
+directory is unavoidable, treat any single anomalous result as suspect, force a rebuild
+(`touch src/lib.rs`), and confirm the `Compiling semantic_views … (<this worktree>)` line
+belongs to you before believing the outcome.
+
+Corollary for disk: the amalgamation build needs several GB of scratch, and `ld` fails with a
+bus error rather than a clear message when `/tmp` fills. `target/debug/{deps,incremental}` are
+the safe things to reclaim — they rebuild without the ~10-minute C++ step that
+`target/debug/build` holds.
+
 ## 4. What already works — keep it
 
 The differential-oracle harness family (every hand-written oracle has held; harness gaps, not


### PR DESCRIPTION
Documentation only — no code changes. First of a stack of 8 PRs from the 2026-08-08 review round (mirrors #202's role in the previous round).

## What's here

**`_notes/code-review-2026-08-08.md`** — full review at `57e38fd`, five parallel passes (parsing, expansion/SQL generation, catalog/connection/FFI, identifiers/rendering/model, test-suite audit). Each pass audited the #203–#209 fixes for completeness *before* hunting fresh. Verification level is stated per finding: the expansion findings were numerically confirmed (generated SQL executed against bundled DuckDB, wrong values observed); the rendering/model and parser findings were executed via temporary tests.

The headline: **the previous round's fixes needed the same combinatorial scrutiny as new features.** Three of the four worst findings sit inside or adjacent to the #203/#207 fixes — the constant-argument fence leaks four ways, the phantom-row hazard it fences has a much larger unfenced surface, and #207 added a join without extending the fan-trap fence, converting a loud error into a silent 2×.

**`_notes/proactive-defect-discovery.md`** — research and proposal for catching these classes earlier. Diagnoses the five recurring escape classes, then proposes: self-checking (metamorphic) oracles, a single ingress-conformance property, `cargo-mutants` in CI, hazard-pattern lints, generator-pin waivers, and a fix-audit checklist. Includes an operational note on the shared-`CARGO_TARGET_DIR` hazard observed while running this round's fixes in parallel worktrees (a false green, a false red, and a stale baked-in-path panic).

**`TECH-DEBT.md` #61–#66** — ledger entries for findings carried across previous rounds with no home: catalog schema identity (CAT-5/6), query-path robustness (QRY-1/2), FFI wire hardening (FF-12/13/14), identifier-matching residues (IDENT-1..5, PARSE-9), plus two promotions worth noting:

- **#65** pulls the "USING not threaded into grain CTEs" degradation out of **resolved** entry #36, where a passing test was pinning degraded behaviour whose only record sat under a ✅ — the expiry pattern CLAUDE.md warns about.
- **#66** becomes the home for the randomized-coverage axes, and the stale "Test Coverage Gaps" section now points at it instead of implying coverage is understood.

## Review notes

Nothing here executes, so CI risk is nil. The findings themselves are addressed in the rest of the stack (PRs 2–8); this lands first so the analysis has a permanent home regardless of how long the fixes take to review.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PT3CfUdQoRfc2SnvdzrbB)_