### PR TITLE
Fence WHERE-member fact chains against fan traps (EXP-27)

### DIFF
--- a/src/expand/fan_trap.rs
+++ b/src/expand/fan_trap.rs
@@ -4,6 +4,7 @@ use crate::model::{Cardinality, Metric, SemanticViewDefinition};
 
 use super::facts::{collect_derived_metric_grain, collect_referenced_facts};
 use super::types::{ExpandError, FanTrapError, MetricFanTrapError, ReferencedFactFanTrapError};
+use super::where_clause::WhereMember;
 
 /// Cardinality map: `(from_lower, to_lower)` -> (worst-case cardinality,
 /// name of a relationship carrying that cardinality).
@@ -654,10 +655,22 @@ fn fanning_edge_on_path(path: &[String], card_map: &CardMap) -> Option<String> {
 /// Skipped on the per-grain path for the same reason [`check_fan_traps`] skips
 /// its base-anchored-only checks there — though today the per-grain strategy
 /// rejects a `where_clause` outright, so this is belt and braces.
+///
+/// # What counts as "the member's table"
+///
+/// EXP-27 (code-review 2026-08-08). A member forces a join not only of the
+/// table it is *declared* on but of every table its expression reaches through
+/// a fact reference ([`WhereMember::fact_tables`], the set #207 added to
+/// `source_tables` for exactly that reason). Both are joined on the member's
+/// behalf and both multiply the metric's rows if the path fans, so both are
+/// walked here. Checking only the declared table meant `of AS li.liq * 2` on
+/// the base — whose expression lives entirely on a child table — passed the
+/// fence while its child table was joined anyway, doubling every base-grain
+/// metric. That shape was a loud binder error before #207 joined the table.
 pub(super) fn check_where_clause_fan_traps(
     view_name: &str,
     def: &SemanticViewDefinition,
-    where_members: &[(String, Option<String>)],
+    where_members: &[WhereMember],
     resolved_mets: &[&Metric],
 ) -> Result<(), ExpandError> {
     if def.joins.is_empty() || where_members.is_empty() {
@@ -669,26 +682,32 @@ pub(super) fn check_where_clause_fan_traps(
     let root = graph.root.clone();
 
     for met in resolved_mets {
+        // The metric's own grain is the anchor, not the member's table: a
+        // metric already AT the child grain is not multiplied by joining the
+        // child, so the same predicate is sound for it. This is why the fence
+        // is per-metric rather than a view-wide member check.
         let met_tables = metric_grain(met, def).anchored(&root);
-        for (member_name, member_table) in where_members {
-            let Some(member_table) = member_table else {
-                continue; // Unqualified member: base-table grain, nothing to fan.
-            };
-            for met_table in &met_tables {
-                if met_table == member_table {
-                    continue;
-                }
-                let Some(path) = find_path(met_table, member_table, &adjacency) else {
-                    continue; // Not connected (legacy joins carrying no FK metadata).
-                };
-                if let Some(rel_name) = fanning_edge_on_path(&path, &card_map) {
-                    return Err(ExpandError::WhereClauseFanTrap {
-                        view_name: view_name.to_string(),
-                        metric_name: met.name.clone(),
-                        member_name: member_name.clone(),
-                        member_table: member_table.clone(),
-                        relationship_name: rel_name,
-                    });
+        for member in where_members {
+            // A member declared without a table is base-table grain, so it
+            // forces no join of its own — but its fact chain still can.
+            let joined_tables = member.table.iter().chain(member.fact_tables.iter());
+            for member_table in joined_tables {
+                for met_table in &met_tables {
+                    if met_table == member_table {
+                        continue;
+                    }
+                    let Some(path) = find_path(met_table, member_table, &adjacency) else {
+                        continue; // Not connected (legacy joins carrying no FK metadata).
+                    };
+                    if let Some(rel_name) = fanning_edge_on_path(&path, &card_map) {
+                        return Err(ExpandError::WhereClauseFanTrap {
+                            view_name: view_name.to_string(),
+                            metric_name: met.name.clone(),
+                            member_name: member.name.clone(),
+                            member_table: member_table.clone(),
+                            relationship_name: rel_name,
+                        });
+                    }
                 }
             }
         }

--- a/src/expand/role_playing.rs
+++ b/src/expand/role_playing.rs
@@ -171,17 +171,17 @@ pub(super) fn check_fact_role_playing_path(
 pub(super) fn check_where_clause_role_playing_path(
     view_name: &str,
     def: &SemanticViewDefinition,
-    where_members: &[(String, Option<String>)],
+    where_members: &[super::where_clause::WhereMember],
 ) -> Result<(), ExpandError> {
-    for (member_name, member_table) in where_members {
-        let Some(member_table) = member_table else {
+    for member in where_members {
+        let Some(member_table) = member.table.as_ref() else {
             continue; // Unqualified member: base-table grain, no role to pick.
         };
         if let Some(rp) = role_playing_on_path(view_name, def, member_table)? {
             let available_relationships = relationships_to_table(def, &rp);
             return Err(ExpandError::AmbiguousWhereClausePath {
                 view_name: view_name.to_string(),
-                member_name: member_name.clone(),
+                member_name: member.name.clone(),
                 member_table: member_table.to_ascii_lowercase(),
                 role_playing_table: rp,
                 available_relationships,

--- a/src/expand/sql_gen.rs
+++ b/src/expand/sql_gen.rs
@@ -436,7 +436,7 @@ pub fn expand(
     // so without this the deciders could not see it at all.
     let where_has_unqualified_member = resolved_where
         .as_ref()
-        .is_some_and(|w| w.members.iter().any(|(_, table)| table.is_none()));
+        .is_some_and(|w| w.members.iter().any(|m| m.table.is_none()));
     let grain_plan = super::per_grain::plan(
         def,
         &resolved_dims,

--- a/src/expand/tests_fan_trap.rs
+++ b/src/expand/tests_fan_trap.rs
@@ -5,7 +5,7 @@
 //! archaeology. `use super::*` resolves against `crate::expand`'s re-exports.
 
 use super::*;
-use crate::expand::test_helpers::minimal_def;
+use crate::expand::test_helpers::{minimal_def, TestFixtureExt};
 use crate::model::{Cardinality, Dimension, Join, Metric, SemanticViewDefinition, TableRef};
 
 fn fan_trap_three_table_def() -> SemanticViewDefinition {
@@ -755,4 +755,202 @@ fn window_quoted_inner_metric_contributes_its_grain_to_the_fence() {
              {reference}, got {grains:?}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// EXP-27 (code-review 2026-08-08): a `where_clause` member whose FACT CHAIN
+// reaches a fanning table had that table joined with no fan fence at all.
+//
+// #207 (EXP-23) taught `resolve_where_clause` to contribute the tables a
+// predicate member reaches THROUGH its fact references to `source_tables`, so
+// the join resolver joins them and the inlined expression binds. That is right
+// for the parent direction (`s -> c`), which is the case EXP-23 was about. It
+// is wrong without a fence for the CHILD direction: neither fan check sees the
+// pair. `check_where_clause_fan_traps` walks only the member's OWN table
+// (`fan_trap.rs`, `member_table`), and `check_referenced_fact_fan_traps` is
+// handed the QUERIED dimensions and metrics -- a `where_clause` member is
+// neither. So the fanning join is emitted and the metric silently doubles.
+//
+// Pre-#207 both shapes below were a loud binder error (`li` was never joined),
+// so this is a loud -> silent-wrong regression, not a pre-existing gap.
+// ---------------------------------------------------------------------------
+
+/// base `o`, child `li` (`li.order_id REFERENCES o.id`, so `o -> li` fans).
+/// Fact `liq` lives on the CHILD; fact `of` lives on the base and reaches it.
+fn exp27_def() -> SemanticViewDefinition {
+    SemanticViewDefinition::default()
+        .with_table("o", "exp27_o", &["id"])
+        .with_table("li", "exp27_li", &["id"])
+        .with_dimension("region", "o.region", Some("o"))
+        .with_fact("liq", "li.qty", "li")
+        .with_fact("of", "li.liq * 2", "o")
+        .with_metric("rev", "SUM(o.amount)", Some("o"))
+        .with_pkfk_join("li_to_o", "li", "o", &["order_id"], &["id"])
+}
+
+fn exp27_req(where_clause: &str) -> QueryRequest {
+    QueryRequest {
+        where_clause: Some(where_clause.to_string()),
+        facts: vec![],
+        dimensions: vec![DimensionName::new("region")],
+        metrics: vec![MetricName::new("rev")],
+    }
+}
+
+/// The FACT branch: the predicate names a fact on the base whose expression
+/// reaches a fact on the child table.
+#[test]
+fn exp27_where_member_fact_chain_to_a_fanning_table_is_fenced() {
+    let def = exp27_def();
+    match expand("v", &def, &exp27_req("of > 0")) {
+        Err(ExpandError::WhereClauseFanTrap {
+            metric_name,
+            member_name,
+            member_table,
+            relationship_name,
+            ..
+        }) => {
+            assert_eq!(metric_name, "rev");
+            assert_eq!(member_name, "of");
+            assert_eq!(
+                member_table, "li",
+                "the table joined on the member's behalf"
+            );
+            assert_eq!(relationship_name, "li_to_o");
+        }
+        Err(other) => panic!("expected WhereClauseFanTrap, got: {other}"),
+        Ok(sql) => panic!(
+            "EXP-27: the fanning child table was joined for a where_clause fact \
+             chain with no fence -- SUM(o.amount) is aggregated over multiplied \
+             rows.\nemitted SQL:\n{sql}"
+        ),
+    }
+}
+
+/// The DIMENSION branch: the predicate names a *dimension* on the base whose
+/// expression reaches the same child-table fact. TECH-DEBT #54 made dimension
+/// expressions fact-inlined, so this reaches the identical join with an
+/// identical absence of fencing.
+#[test]
+fn exp27_where_member_dimension_reaching_a_fanning_fact_is_fenced() {
+    let def = exp27_def().with_dimension(
+        "band",
+        "CASE WHEN li.liq > 0 THEN 'hi' ELSE 'lo' END",
+        Some("o"),
+    );
+    match expand("v", &def, &exp27_req("band = 'hi'")) {
+        Err(ExpandError::WhereClauseFanTrap {
+            metric_name,
+            member_name,
+            member_table,
+            ..
+        }) => {
+            assert_eq!(metric_name, "rev");
+            assert_eq!(member_name, "band");
+            assert_eq!(member_table, "li");
+        }
+        Err(other) => panic!("expected WhereClauseFanTrap, got: {other}"),
+        Ok(sql) => panic!(
+            "EXP-27 (dimension branch): a where_clause DIMENSION whose expression \
+             reaches a child-table fact joined the fanning table \
+             unfenced.\nemitted SQL:\n{sql}"
+        ),
+    }
+}
+
+/// Transitivity: `member_fact_tables` walks the chain, so a two-hop chain that
+/// only reaches the fanning table at its far end must be fenced too. A fence
+/// that looked at the directly-named fact alone would miss this.
+#[test]
+fn exp27_transitive_fact_chain_to_a_fanning_table_is_fenced() {
+    let def = exp27_def().with_fact("of2", "of + 1", "o");
+    match expand("v", &def, &exp27_req("of2 > 0")) {
+        Err(ExpandError::WhereClauseFanTrap { member_name, .. }) => {
+            assert_eq!(member_name, "of2");
+        }
+        Err(other) => panic!("expected WhereClauseFanTrap, got: {other}"),
+        Ok(sql) => panic!(
+            "EXP-27 (transitive): `of2 -> of -> liq@li` reached the fanning table \
+             through two hops unfenced.\nemitted SQL:\n{sql}"
+        ),
+    }
+}
+
+/// CONTROL 1 -- the legitimate EXP-23 shape must keep working: a fact chain
+/// that reaches a PARENT table crosses the many-to-one edge forwards, which
+/// does not fan, so the join is joined and the query expands. This is the
+/// `cr0806i_cross` fixture from `cr20260806_inlining_gaps.test` in miniature.
+#[test]
+fn exp27_control_non_fanning_parent_fact_chain_still_expands() {
+    let def = SemanticViewDefinition::default()
+        .with_table("s", "exp27_sales", &["id"])
+        .with_table("c", "exp27_cust", &["id"])
+        .with_dimension("sid", "s.id", Some("s"))
+        .with_fact("cust_rate", "c.rate", "c")
+        .with_fact("weighted", "s.amount * cust_rate", "s")
+        .with_metric("total", "SUM(s.amount)", Some("s"))
+        .with_pkfk_join("s_to_c", "s", "c", &["cust_id"], &["id"]);
+    let req = QueryRequest {
+        where_clause: Some("weighted > 25".to_string()),
+        facts: vec![],
+        dimensions: vec![DimensionName::new("sid")],
+        metrics: vec![MetricName::new("total")],
+    };
+    let sql = expand("v", &def, &req).expect("a parent-direction fact chain must still expand");
+    assert!(
+        sql.contains("exp27_cust"),
+        "the table reached through the fact chain must still be joined: {sql}"
+    );
+}
+
+/// CONTROL 2 -- the fence is anchored at the METRIC's grain, not at the
+/// member's own table, exactly like the existing where-clause fan check. A
+/// metric already at the child grain is not multiplied by joining the child, so
+/// the same predicate must still expand.
+#[test]
+fn exp27_control_child_grain_metric_is_not_fenced() {
+    let def = exp27_def().with_metric("li_qty", "SUM(li.qty)", Some("li"));
+    let req = QueryRequest {
+        where_clause: Some("of > 0".to_string()),
+        facts: vec![],
+        dimensions: vec![],
+        metrics: vec![MetricName::new("li_qty")],
+    };
+    let sql = expand("v", &def, &req)
+        .expect("a metric at the child grain is not inflated by joining the child");
+    assert!(sql.contains("exp27_li"), "{sql}");
+}
+
+/// The data-level statement of what the fence prevents: with one order and two
+/// line items, joining `li` doubles `SUM(o.amount)`. Kept as an executable
+/// oracle so the fixture cannot drift into one where the join is harmless and
+/// the fence tests above become vacuous.
+#[cfg(not(feature = "extension"))]
+#[test]
+fn exp27_the_fanning_join_really_does_double_the_metric() {
+    let con = duckdb::Connection::open_in_memory().expect("in-memory DuckDB");
+    con.execute_batch(
+        "CREATE TABLE exp27_o (id INTEGER, region VARCHAR, amount INTEGER);
+         INSERT INTO exp27_o VALUES (1, 'E', 100);
+         CREATE TABLE exp27_li (id INTEGER, order_id INTEGER, qty INTEGER);
+         INSERT INTO exp27_li VALUES (1, 1, 5), (2, 1, 6);",
+    )
+    .expect("setup");
+    let one = |sql: &str| {
+        con.query_row(sql, [], |r| r.get::<_, i64>(0))
+            .expect("query")
+    };
+    assert_eq!(
+        one("SELECT SUM(o.amount) FROM exp27_o o"),
+        100,
+        "the un-joined answer is the correct one"
+    );
+    assert_eq!(
+        one("SELECT SUM(o.amount) FROM exp27_o o \
+             LEFT JOIN exp27_li li ON li.order_id = o.id \
+             WHERE ((li.qty) * 2) > 0"),
+        200,
+        "joining the child table for the predicate doubles the metric -- this \
+         is the 2x EXP-27 emitted silently"
+    );
 }

--- a/src/expand/where_clause.rs
+++ b/src/expand/where_clause.rs
@@ -43,10 +43,34 @@ pub(super) struct ResolvedWhere {
     /// table at all requires joining it, and that join multiplies the metric's
     /// rows exactly as a grouping join would.
     pub(super) source_tables: Vec<String>,
-    /// `(member name, source table)` for each declared member the predicate
-    /// named, in first-reference order. Fed to the fan-trap check so its error
-    /// can name the member the user actually wrote.
-    pub(super) members: Vec<(String, Option<String>)>,
+    /// Each declared member the predicate named, in first-reference order. Fed
+    /// to the fan-trap check so its error can name the member the user actually
+    /// wrote.
+    pub(super) members: Vec<WhereMember>,
+}
+
+/// One declared member a predicate named.
+///
+/// Carries everything the fences downstream need to decide whether resolving
+/// this member forces an unsound join: the name as the user wrote it, the table
+/// it is declared on, and — EXP-27 — the tables its expression reaches through
+/// fact references. The last is the per-member half of what
+/// [`ResolvedWhere::source_tables`] accumulates view-wide; kept per member so a
+/// fan-trap error can name the member responsible for the join rather than just
+/// the table.
+#[derive(Debug)]
+pub(super) struct WhereMember {
+    /// The reference as written in the predicate (`of`, `o.of`, `"OF"`).
+    pub(super) name: String,
+    /// The table the member is declared on, lowercased. `None` for a member
+    /// declared without one, which is base-table grain.
+    pub(super) table: Option<String>,
+    /// Lowercased aliases of the tables this member reaches TRANSITIVELY
+    /// through fact references (EXP-23's set, per member). Resolving the member
+    /// splices those tables' columns into the predicate, so the query must join
+    /// them — and a join that fans relative to a metric's grain inflates that
+    /// metric, which is what EXP-27 was.
+    pub(super) fact_tables: Vec<String>,
 }
 
 /// The member lookup tables a predicate is resolved against.
@@ -217,7 +241,7 @@ pub(super) fn resolve_where_clause(
     }
 
     let mut source_tables: Vec<String> = Vec::new();
-    let mut members: Vec<(String, Option<String>)> = Vec::new();
+    let mut members: Vec<WhereMember> = Vec::new();
     let mut seen_members: HashSet<String> = HashSet::new();
     for r in scan_references(raw) {
         let key = r.key();
@@ -231,16 +255,26 @@ pub(super) fn resolve_where_clause(
             // EXP-23: plus every table the member reaches through a fact
             // reference, so the join resolver sees what the spliced expression
             // will actually name.
-            if let Some(reached) = member_fact_tables.get(&key) {
-                for t in reached {
-                    let lowered = t.to_ascii_lowercase();
-                    if !source_tables.contains(&lowered) {
-                        source_tables.push(lowered);
-                    }
+            let reached: Vec<String> = member_fact_tables
+                .get(&key)
+                .map(|reached| reached.iter().map(|t| t.to_ascii_lowercase()).collect())
+                .unwrap_or_default();
+            for lowered in &reached {
+                if !source_tables.contains(lowered) {
+                    source_tables.push(lowered.clone());
                 }
             }
             if seen_members.insert(key.clone()) {
-                members.push((r.raw.to_string(), table.map(str::to_ascii_lowercase)));
+                // EXP-27: the reached set travels WITH the member, not just
+                // into the view-wide `source_tables`. Those tables get joined
+                // on this member's behalf, so the fan fence has to see the pair
+                // — before #207 an unjoined table failed loudly at bind time,
+                // and the join that replaced that error arrived unfenced.
+                members.push(WhereMember {
+                    name: r.raw.to_string(),
+                    table: table.map(str::to_ascii_lowercase),
+                    fact_tables: reached,
+                });
             }
             continue;
         }
@@ -366,6 +400,21 @@ mod tests {
             r.source_tables.contains(&"c".to_string()),
             "the table reached THROUGH the fact reference must be joined: {:?}",
             r.source_tables
+        );
+        // EXP-27: the same reach must also travel WITH the member, not only
+        // into the view-wide `source_tables`. The fan fence walks per member,
+        // so a reach recorded only view-wide is a reach it cannot see — which
+        // is how the join this test pins arrived unfenced.
+        let member = r
+            .members
+            .iter()
+            .find(|m| m.name == "adjusted")
+            .expect("the named member is recorded");
+        assert_eq!(member.table.as_deref(), Some("o"));
+        assert_eq!(
+            member.fact_tables,
+            vec!["c".to_string()],
+            "the per-member reach feeds the fan fence"
         );
     }
 

--- a/test/sql/TEST_LIST
+++ b/test/sql/TEST_LIST
@@ -104,3 +104,4 @@ test/sql/cr20260806_yaml_ddl_contract.test
 test/sql/cat4_read_foreign_database.test
 test/sql/par6_cross_table_fact_join.test
 test/sql/member_reference_scoping.test
+test/sql/cr20260808_where_member_fan_fence.test

--- a/test/sql/cr20260808_where_member_fan_fence.test
+++ b/test/sql/cr20260808_where_member_fan_fence.test
@@ -1,0 +1,167 @@
+# Code review 2026-08-08, EXP-27: a `where_clause` member whose FACT CHAIN
+# reaches a fanning table had that table joined with no fan fence at all.
+#
+# #207 (EXP-23) taught `resolve_where_clause` to contribute the tables a
+# predicate member reaches THROUGH its fact references to `source_tables`, so
+# the join resolver joins them and the inlined expression binds. Correct for the
+# PARENT direction; unfenced for the CHILD direction. Neither fan check saw the
+# pair: `check_where_clause_fan_traps` walked only the member's own declared
+# table, and `check_referenced_fact_fan_traps` is handed the QUERIED dimensions
+# and metrics -- a `where_clause` member is neither.
+#
+# Numerically confirmed in the review and reproduced at the unit layer: with one
+# order and two line items, `rev = SUM(o.amount)` returned 200 instead of 100
+# because the emitted SQL was `FROM o LEFT JOIN li WHERE ((li.qty) * 2) > 0`.
+# Before #207 the same query was a loud binder error (`li` was never joined), so
+# this was a loud -> silent-wrong regression.
+#
+# The runner halts a file at its first failing statement, so the per-case red
+# proof lives at the unit layer (`expand::tests_fan_trap::exp27_*`, three cases
+# each individually observed failing) and in `star_schema_proptest`, whose
+# generator gained a parent-declared member reaching a child-side fact and was
+# verified to fail with the fence reverted.
+
+require semantic_views
+
+statement ok
+CREATE TABLE cr0808_o (id INTEGER PRIMARY KEY, region VARCHAR, amount INTEGER);
+
+statement ok
+INSERT INTO cr0808_o VALUES (1, 'east', 100);
+
+statement ok
+CREATE TABLE cr0808_li (id INTEGER PRIMARY KEY, order_id INTEGER, qty INTEGER);
+
+statement ok
+INSERT INTO cr0808_li VALUES (1, 1, 5), (2, 1, 6);
+
+# ============================================================
+# EXP-27 fact branch: a fact on the base whose expression reaches a fact on
+# the child table.
+# ============================================================
+
+statement ok
+CREATE SEMANTIC VIEW cr0808_fan AS
+TABLES (
+    o AS cr0808_o PRIMARY KEY (id),
+    li AS cr0808_li PRIMARY KEY (id)
+)
+RELATIONSHIPS (li_to_o AS li(order_id) REFERENCES o)
+FACTS (
+    li.liq AS li.qty,
+    o.o_fact AS li.liq * 2
+)
+DIMENSIONS (
+    o.region AS o.region,
+    o.band AS CASE WHEN li.liq > 0 THEN 1 ELSE 0 END
+)
+METRICS (
+    o.rev AS SUM(o.amount),
+    li.li_qty AS SUM(li.qty)
+);
+
+# Control first: with no predicate the base-grain metric is the un-multiplied
+# 100, so the 200 below really is the join's doing.
+query I
+SELECT rev FROM semantic_view('cr0808_fan', metrics := ['rev']);
+----
+100
+
+# The fact branch. `o_fact` is declared on `o` but its expression lives entirely on
+# `li`, so resolving it joins the child and doubles SUM(o.amount) to 200.
+statement error
+SELECT rev FROM semantic_view(
+  'cr0808_fan',
+  dimensions := ['region'],
+  metrics := ['rev'],
+  where_clause := 'o_fact > 0'
+);
+----
+fan trap detected
+
+# The DIMENSION branch: same child-table fact, reached from a dimension's
+# expression instead of a fact's (TECH-DEBT #54 made dimension expressions
+# fact-inlined, so this hits the identical join).
+statement error
+SELECT rev FROM semantic_view(
+  'cr0808_fan',
+  dimensions := ['region'],
+  metrics := ['rev'],
+  where_clause := 'band = 1'
+);
+----
+fan trap detected
+
+# Anchored at the METRIC's grain, not the member's table: a metric already at
+# the child grain is not multiplied by joining the child, so the same predicate
+# is sound for it. Both line items have qty > 0, so li_qty = 5 + 6 = 11.
+query I
+SELECT li_qty FROM semantic_view(
+  'cr0808_fan',
+  metrics := ['li_qty'],
+  where_clause := 'o_fact > 0'
+);
+----
+11
+
+statement ok
+DROP SEMANTIC VIEW cr0808_fan
+
+# ============================================================
+# Control: the legitimate EXP-23 shape (#207's actual use case) must keep
+# working -- a fact chain reaching a PARENT table crosses the many-to-one edge
+# forwards, which does not fan, so the join is emitted and the query runs.
+# ============================================================
+
+statement ok
+CREATE TABLE cr0808_cust (id INTEGER PRIMARY KEY, rate DOUBLE);
+
+statement ok
+INSERT INTO cr0808_cust VALUES (1, 1.0), (2, 2.0);
+
+statement ok
+CREATE TABLE cr0808_sales (id INTEGER PRIMARY KEY, cust_id INTEGER, amount INTEGER);
+
+statement ok
+INSERT INTO cr0808_sales VALUES (1, 1, 10), (2, 2, 20), (3, 1, 30);
+
+statement ok
+CREATE SEMANTIC VIEW cr0808_safe AS
+TABLES (
+    s AS cr0808_sales PRIMARY KEY (id),
+    c AS cr0808_cust PRIMARY KEY (id)
+)
+RELATIONSHIPS (s_to_c AS s(cust_id) REFERENCES c)
+FACTS (
+    c.cust_rate AS c.rate,
+    s.weighted AS s.amount * cust_rate
+)
+DIMENSIONS (s.sid AS s.id)
+METRICS (s.total AS SUM(s.amount));
+
+# weighted per row: 10*1=10, 20*2=40, 30*1=30. Filtering weighted > 25 keeps
+# rows 2 and 3, so total = 20 + 30 = 50 -- unchanged from
+# cr20260806_inlining_gaps.test, which is the point.
+query I
+SELECT total FROM semantic_view(
+  'cr0808_safe',
+  metrics := ['total'],
+  where_clause := 'weighted > 25'
+);
+----
+50
+
+statement ok
+DROP SEMANTIC VIEW cr0808_safe
+
+statement ok
+DROP TABLE cr0808_sales
+
+statement ok
+DROP TABLE cr0808_cust
+
+statement ok
+DROP TABLE cr0808_li
+
+statement ok
+DROP TABLE cr0808_o

--- a/tests/star_schema_proptest.rs
+++ b/tests/star_schema_proptest.rs
@@ -89,6 +89,15 @@ enum WMember {
     Ftd,
     /// Filter member on the parent: `u.ucat = 0 OR u.ucat = 2`.
     Fucat,
+    /// EXP-27: a filter member declared on the **parent** whose expression
+    /// reaches a fact declared on the **child** — `fchain AS tv1 > 0` over
+    /// `t.tv1 AS t.v + 1`. Its declared table does not fan, but resolving it
+    /// splices in the child's columns, so the query has to join the child
+    /// anyway. That join is what #207 started emitting and what no fence
+    /// looked at: `check_where_clause_fan_traps` walked only the member's
+    /// declared table (`u`, safe) and `check_referenced_fact_fan_traps` is
+    /// handed the queried members, never the predicate's.
+    Fchain,
 }
 
 impl WMember {
@@ -99,6 +108,7 @@ impl WMember {
             WMember::Ucat => "ucat",
             WMember::Ftd => "ftd",
             WMember::Fucat => "fucat",
+            WMember::Fchain => "fchain",
         }
     }
 
@@ -109,21 +119,35 @@ impl WMember {
             WMember::Ucat => "u.ucat",
             WMember::Ftd => "(t.d = 0 OR t.d = 2)",
             WMember::Fucat => "(u.ucat = 0 OR u.ucat = 2)",
+            // The fact written out independently, parenthesized at the
+            // reference site exactly as the splice must parenthesize it.
+            WMember::Fchain => "((t.v + 1) > 0)",
         }
     }
 
-    /// Whether the member lives on the CHILD table. A predicate touching the
-    /// child cannot be evaluated inside the parent-grain CTE without joining
-    /// `t` into it — which fans `u` — so such a query must be rejected when the
-    /// parent metric is selected.
+    /// Whether resolving the member forces the CHILD table into the query. A
+    /// predicate touching the child cannot be evaluated inside the parent-grain
+    /// CTE without joining `t` into it — which fans `u` — so such a query must
+    /// be rejected when the parent metric is selected.
+    ///
+    /// EXP-27: `Fchain` counts here even though it is *declared* on the parent.
+    /// What matters is which tables the resolved predicate names, not where the
+    /// member's name was written down — that mismatch is the whole bug.
     fn is_child_side(self) -> bool {
-        matches!(self, WMember::Td | WMember::Ftd)
+        matches!(self, WMember::Td | WMember::Ftd | WMember::Fchain)
     }
 
     /// Whether the member is a bare column reference (so it can carry a
     /// comparison operator) as opposed to a self-contained boolean filter.
     fn is_comparable(self) -> bool {
         matches!(self, WMember::Td | WMember::Ucat)
+    }
+
+    /// Whether the member reaches its tables through a FACT reference (EXP-27)
+    /// rather than naming them itself — the generator-coverage guard for the
+    /// new arm.
+    fn is_fact_chain(self) -> bool {
+        matches!(self, WMember::Fchain)
     }
 }
 
@@ -181,6 +205,18 @@ impl Pred {
             Pred::Not(a) => a.references_filter(),
         }
     }
+
+    /// Whether any named member reaches its table through a fact chain
+    /// (EXP-27) — the generator-coverage guard for the `Fchain` arm.
+    fn references_fact_chain(&self) -> bool {
+        match self {
+            Pred::Cmp(m, _, _) | Pred::Filter(m) => m.is_fact_chain(),
+            Pred::And(a, b) | Pred::Or(a, b) => {
+                a.references_fact_chain() || b.references_fact_chain()
+            }
+            Pred::Not(a) => a.references_fact_chain(),
+        }
+    }
 }
 
 fn arb_pred() -> impl Strategy<Value = Pred> {
@@ -191,6 +227,9 @@ fn arb_pred() -> impl Strategy<Value = Pred> {
             -1i64..=3,
         ).prop_map(|(m, op, k)| Pred::Cmp(m, op, k)),
         2 => prop_oneof![Just(WMember::Ftd), Just(WMember::Fucat)].prop_map(Pred::Filter),
+        // EXP-27: the fact-chain member gets its own weight so it appears in a
+        // healthy share of predicates rather than only inside deep compounds.
+        1 => Just(Pred::Filter(WMember::Fchain)),
     ];
     leaf.prop_recursive(3, 8, 2, |inner| {
         prop_oneof![
@@ -336,6 +375,19 @@ fn build_def() -> SemanticViewDefinition {
             synonyms: vec![],
             is_filter: true,
         },
+        // EXP-27: declared on the PARENT, but its expression names a fact on
+        // the CHILD. Resolving it joins `t`, which fans `u` — so a predicate
+        // naming it must be rejected alongside the parent-grain metric even
+        // though nothing about the member's own table says so.
+        Dimension {
+            name: "fchain".to_string(),
+            expr: "tv1 > 0".to_string(),
+            source_table: Some("u".to_string()),
+            output_type: None,
+            comment: None,
+            synonyms: vec![],
+            is_filter: true,
+        },
     ];
     let base_metric = |name: &str, expr: &str, source: Option<&str>| Metric {
         name: name.to_string(),
@@ -373,16 +425,31 @@ fn build_def() -> SemanticViewDefinition {
         dimensions,
         metrics,
         joins,
-        facts: vec![Fact {
-            name: "uw1".to_string(),
-            expr: "u.w + 1".to_string(),
-            source_table: Some("u".to_string()),
-            output_type: None,
-            comment: None,
-            synonyms: vec![],
-            is_filter: false,
-            access: AccessModifier::Public,
-        }],
+        facts: vec![
+            Fact {
+                name: "uw1".to_string(),
+                expr: "u.w + 1".to_string(),
+                source_table: Some("u".to_string()),
+                output_type: None,
+                comment: None,
+                synonyms: vec![],
+                is_filter: false,
+                access: AccessModifier::Public,
+            },
+            // EXP-27: the CHILD-side fact the parent-declared `fchain` member
+            // reaches. Compound, so a splice that loses the parentheses
+            // (`t.v + 1 > 0` vs `(t.v + 1) > 0`) would show up as a diff too.
+            Fact {
+                name: "tv1".to_string(),
+                expr: "t.v + 1".to_string(),
+                source_table: Some("t".to_string()),
+                output_type: None,
+                comment: None,
+                synonyms: vec![],
+                is_filter: false,
+                access: AccessModifier::Public,
+            },
+        ],
         materializations: vec![],
         created_on: None,
         database_name: None,
@@ -741,9 +808,15 @@ fn generator_reaches_both_where_clause_branches() {
     let mut with_pred = 0usize;
     let mut without_pred = 0usize;
     let mut with_filter = 0usize;
+    let mut with_fact_chain = 0usize;
     // The two branches the property treats differently under a predicate.
     let mut parent_metric_child_pred = 0usize;
     let mut parent_metric_parent_only_pred = 0usize;
+    // EXP-27 specifically: the fact-chain member alongside the parent metric,
+    // which is the pair the new fence rejects. Without this the `Fchain` arm
+    // could be generated only in accepted queries and the fence stay untested.
+    let mut parent_metric_fact_chain_pred = 0usize;
+    let mut accepted_fact_chain_pred = 0usize;
     let mut distinct: HashSet<String> = HashSet::new();
 
     for _ in 0..400 {
@@ -760,6 +833,12 @@ fn generator_reaches_both_where_clause_branches() {
                 if p.references_filter() {
                     with_filter += 1;
                 }
+                if p.references_fact_chain() {
+                    with_fact_chain += 1;
+                    if !(selects_parent_metric && selects_child_dim) && !selects_parent_metric {
+                        accepted_fact_chain_pred += 1;
+                    }
+                }
                 distinct.insert(p.to_member_sql());
                 // The dim-based fence branch takes precedence in the property,
                 // so only count cases that actually reach the where-clause one.
@@ -768,6 +847,9 @@ fn generator_reaches_both_where_clause_branches() {
                         parent_metric_child_pred += 1;
                     } else {
                         parent_metric_parent_only_pred += 1;
+                    }
+                    if p.references_fact_chain() {
+                        parent_metric_fact_chain_pred += 1;
                     }
                 }
             }
@@ -793,6 +875,24 @@ fn generator_reaches_both_where_clause_branches() {
         parent_metric_parent_only_pred > 0,
         "no case reached the parent-metric + parent-only-predicate branch; the \
          per-grain predicate oracle is never compared"
+    );
+    assert!(
+        with_fact_chain > 0,
+        "generator never referenced the EXP-27 fact-chain member -- a \
+         where_clause member reaching another table THROUGH a fact has no \
+         randomized coverage"
+    );
+    assert!(
+        parent_metric_fact_chain_pred > 0,
+        "no case paired the fact-chain member with the parent metric; the \
+         EXP-27 fence is never exercised and its assertion is vacuous \
+         (present={with_fact_chain})"
+    );
+    assert!(
+        accepted_fact_chain_pred > 0,
+        "the fact-chain member only ever appeared in REJECTED cases, so the \
+         non-fanning half -- that resolving it still produces the right number \
+         -- is never oracled"
     );
     assert!(
         distinct.len() > 50,


### PR DESCRIPTION
**Fixes a regression introduced by #207.** Stacked on #213.

## The defect

#207 (EXP-23) taught a `where_clause` member to reach facts on other tables, and joined those tables so the predicate could bind. Neither fan-trap fence was told: `check_where_clause_fan_traps` checks only the member's *own* table, and `check_referenced_fact_fan_traps` never sees WHERE members at all.

So a filter whose fact chain reaches a fanning table joins it unfenced, and every metric at the parent grain inflates. Before #207 the same query was a loud binder error — the fix converted loud-wrong into silent-wrong.

**Numerically confirmed.** Base `o`, child `li`, fact `liq AS li.qty` on `li`, fact `of AS li.liq * 2` on `o`, metric `rev AS SUM(o.amount)`:

| shape | emitted | `rev` |
|---|---|---|
| `where_clause := 'of > 0'` | `FROM o LEFT JOIN li WHERE ((li.qty) * 2) > 0` | **200** (expected 100) |
| dimension branch (`band AS CASE WHEN li.liq > 0 …`) | same join | **200** (expected 100) |
| transitive (`of2 AS of + 1`) | same join | **200** (expected 100) |

## The fix

The reached-table set now travels *with* the member instead of only into the view-wide `source_tables`: `ResolvedWhere::members` becomes `Vec<WhereMember>` (`name` / `table` / `fact_tables`), and `check_where_clause_fan_traps` walks the member's declared table **and** its transitively-reached fact tables against each metric's grain. Anchoring stays at the metric's grain, so the fence fires per-metric and a child-grain metric is not falsely fenced. Error variant unchanged (`WhereClauseFanTrap`).

The `table: None` early-`continue` became an iterator chain, so an unqualified member's fact chain is now walked too — it previously skipped entirely.

## Coverage

Each of the three shapes is a unit test, individually confirmed red pre-fix. Two controls pin that the legitimate non-fanning chain still expands (no regression on #207's actual fix) and that a child-grain metric is not fenced; both passed pre-fix, so they are genuine controls.

**The fence had zero randomized coverage** — `differential_proptest`'s chained-fact member is single-table, so it could never reach a fanning topology. `star_schema_proptest` now generates the EXP-27 shape (fact `tv1` on the child, filter member `fchain` declared on the parent), with three anti-vacuity counters asserting the arm is generated, paired with the parent metric, and reaches the oracled path. Verified non-vacuous by reverting the fence — the harness reds with shrunk SQL.

`test/sql/cr20260808_where_member_fan_fence.test` covers it end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PT3CfUdQoRfc2SnvdzrbB)_