### PR TITLE
Fix four parser defects: PARSE-10, PARSE-11, PARSE-12, PARSE-13

### DIFF
--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -589,6 +589,14 @@ Areas where test coverage is reduced compared to ideal, with justification.
 - **PARSE-9:** name slots accept identifier garbage DuckDB would reject — `RENAME TO x,y` stores `x,y`.
 - **What would finish it:** route IDENT-1 through `ident_matches` (mechanical); give the scanner position-awareness for cast/EXTRACT slots (IDENT-3) and a quoted-name-aware literal rule (IDENT-4); make `normalize_ident_part` produce a structured key rather than a re-joined string (IDENT-5); tighten the name-slot grammar (PARSE-9). IDENT-2 needs a decision before a fix.
 
+### 73. ❌ A typed literal separated from its introducer by whitespace still scans as a reference (PARSE-12 residual) — OPEN
+
+- **Origin:** PARSE-12's fix (code review 2026-08-08), narrowed during review of that change. Recorded per the rule that a knowingly-partial behaviour gets an entry in the same change.
+- **What the fix does:** `expr_tokens::scan_chains` no longer emits an identifier chain as a *reference* when the chain is immediately followed by `'` — the adjacency rule `util::opens_escape_string` already uses. That covers `e'…'`, `E'…'` and the adjacent typed-literal form `DATE'2020-01-01'`, so a member named `e` or `date` can no longer corrupt those expressions.
+- **What is therefore missing:** DuckDB also accepts a typed literal with whitespace between the type name and the string — `DATE '2020-01-01'`, `INTERVAL '1 day'`, `TIMESTAMP '…'` — and the rule is adjacency-only, so the introducer is still scanned as a reference there. A view declaring a member named `date` or `interval` therefore still risks the inline corruption PARSE-12 closed for the adjacent spelling.
+- **Why it shipped narrow:** suppressing *every* identifier followed by whitespace and a string literal over-reaches badly — `SELECT foo 'bar'` is an alias, and ordinary expressions put identifiers before quoted text routinely. Doing it correctly needs a type-name registry so only real type introducers are suppressed, which is a larger change than the defect being fixed and carries its own false-positive risk.
+- **What would finish it:** a small set of recognized type-name introducers (the SQL standard's plus DuckDB's aliases) consulted when a chain is followed by optional ASCII whitespace and `'`. Guard with a pinned unit test for the spaced form, alongside PARSE-12's adjacent-form tests.
+
 ### 65. ❌ `USING` role context is not threaded into grain CTEs for the ambiguous-dimension case — OPEN
 
 - **Origin:** promoted 2026-08-08 from the "Still declined, deliberately" bullets of **resolved** entry #36, per the CLAUDE.md rule that a degraded behaviour's record must not live only in a test comment — and must not live only inside an entry marked ✅, which reads as finished. `test/sql/per_grain_role_playing.test` (Test 3) pins the degraded outcome with the comment "this still errors until USING context is threaded into the grain CTEs"; that comment should reference this entry.

--- a/src/body_parser/window.rs
+++ b/src/body_parser/window.rs
@@ -1,6 +1,7 @@
 //! Window-metric OVER clause parsing and the shared ORDER-BY modifier loop.
 
 use super::cursor::Cursor;
+use super::lexer::TokenKind;
 use super::scan::{is_ident_continuation, is_quoting_balanced};
 use super::split_at_depth0_commas;
 use crate::errors::ParseError;
@@ -49,6 +50,26 @@ pub(super) fn parse_window_over_clause(
         });
     };
 
+    // PARSE-10 (code-review 2026-08-08): everything after the OVER body's `)`
+    // used to be dropped on the floor. Emission rebuilds the SQL from the
+    // `WindowSpec` alone (`expand::window`), so `AVG(w) OVER (...) + 100`
+    // computed without the `+ 100` while `GET_DDL` round-tripped the text that
+    // still had it — definition and behaviour disagreeing, with no diagnostic.
+    // Same "reject, don't discard" rule as the USING / NON ADDITIVE BY residues
+    // (P-2 / F-3). Composition around a window function is rejected rather than
+    // supported — see TECH-DEBT "window-metric composition".
+    if let Some(residue_tok) = cur.peek() {
+        let residue = expr[residue_tok.start..].trim_end();
+        return Err(ParseError {
+            message: format!(
+                "Unexpected text '{residue}' after the OVER clause in expression '{expr}'. \
+                 A window metric must be exactly FUNC(args) OVER (...); combining it with \
+                 other expressions is not supported."
+            ),
+            position: Some(base_offset + residue_tok.start),
+        });
+    }
+
     // The function call before OVER: `FUNC(inner_metric[, extra_args...])`.
     let mut fcur = Cursor::new(func_part, base_offset);
     let Some(fparen) = fcur.find_symbol(b'(') else {
@@ -60,6 +81,21 @@ pub(super) fn parse_window_over_clause(
         });
     };
     let window_function = func_part[..fparen.start].trim().to_string();
+    // PARSE-10: the text before the first `(` became `window_function`
+    // VERBATIM, so `1 + AVG(w) OVER (...)` stored the function name
+    // `"1 + AVG"` and emitted `1 + AVG(...) OVER (...)`-shaped nonsense (or, in
+    // the qualified-metric paths, an arbitrary prefix silently reinterpreted).
+    // The name must be exactly one identifier chain.
+    if !is_identifier_chain(&window_function) {
+        return Err(ParseError {
+            message: format!(
+                "Window function before OVER must be a plain function call, found \
+                 '{func_part}'. A window metric must be exactly FUNC(args) OVER (...); \
+                 combining it with other expressions is not supported."
+            ),
+            position: Some(base_offset),
+        });
+    }
     let paren_start = fparen.start;
     fcur.advance_past_byte(paren_start);
     let Some(func_args_content) = fcur.take_parens() else {
@@ -103,6 +139,31 @@ pub(super) fn parse_window_over_clause(
             frame_clause,
         }),
     ))
+}
+
+/// Is `text` exactly ONE identifier chain — a bare or double-quoted name,
+/// optionally qualified (`avg`, `main.avg`, `"my func"`, `main."my func"`)?
+///
+/// The shape test for a window function's name (PARSE-10). Anything else — an
+/// operator, a literal, a second call, a leading term — makes the text an
+/// *expression*, and this parser only models a bare `FUNC(args) OVER (...)`.
+/// Whitespace between the name and its argument parens is fine (`AVG (x)` is
+/// legal `DuckDB`); what is rejected is another TOKEN sitting in the name
+/// position.
+fn is_identifier_chain(text: &str) -> bool {
+    let mut cur = Cursor::new(text, 0);
+    loop {
+        if !matches!(cur.bump(), Some(t) if matches!(t.kind, TokenKind::Ident { .. })) {
+            return false;
+        }
+        if cur.peek().is_none() {
+            return true;
+        }
+        if !cur.peek_is_symbol(b'.') {
+            return false;
+        }
+        cur.bump();
+    }
 }
 
 /// Parsed components of an OVER clause.
@@ -437,3 +498,106 @@ pub(super) fn parse_order_by_modifiers(
 // migration: dims/order regions are now sliced between keyword TOKEN offsets
 // (`content[dims_start..dims_end]`), which are exact by construction, so the
 // uppercase-twin offset bookkeeping the helper served is gone.
+
+#[cfg(test)]
+mod tests {
+    use super::parse_window_over_clause;
+
+    /// Parse at a non-zero base offset so every caret assertion below also
+    /// proves the error position is anchored in the ORIGINAL query, not in the
+    /// re-sliced expression.
+    const BASE: usize = 100;
+
+    fn err(expr: &str) -> (String, Option<usize>) {
+        match parse_window_over_clause(expr, BASE) {
+            Ok((_, spec)) => panic!("expected a ParseError, got Ok({spec:?}) for {expr:?}"),
+            Err(e) => (e.message, e.position),
+        }
+    }
+
+    // PARSE-10 (code-review 2026-08-08): text AFTER the OVER body's `)` was
+    // never inspected, so `+ 100` vanished — the stored definition text kept it
+    // while the emitted SQL (rebuilt from the WindowSpec) dropped it, and the
+    // metric silently returned a number 100 too small.
+    #[test]
+    fn trailing_arithmetic_after_the_over_clause_is_rejected() {
+        let (msg, pos) = err("AVG(w) OVER (PARTITION BY d) + 100");
+        assert!(msg.contains("+ 100"), "{msg}");
+        assert!(
+            msg.contains("Unexpected text") && msg.contains("after the OVER clause"),
+            "{msg}"
+        );
+        // Caret at the `+`, which is byte 29 of the expression.
+        assert_eq!(pos, Some(BASE + 29));
+    }
+
+    // PARSE-10: `func_part` was everything before OVER and its text before the
+    // first `(` became `window_function` verbatim, so this stored the function
+    // name `"1 + AVG"`.
+    #[test]
+    fn an_expression_prefix_before_the_window_function_is_rejected() {
+        let (msg, pos) = err("1 + AVG(w) OVER (PARTITION BY d)");
+        assert!(msg.contains("must be a plain function call"), "{msg}");
+        assert_eq!(pos, Some(BASE), "caret at the start of the function part");
+    }
+
+    // PARSE-10: a second `FUNC(...) OVER (...)` term was dropped wholesale —
+    // only the first OVER is parsed and the rest was residue.
+    #[test]
+    fn a_second_over_term_is_rejected() {
+        let (msg, _) = err("AVG(w) OVER (PARTITION BY d) - SUM(w) OVER (PARTITION BY d)");
+        assert!(msg.contains("Unexpected text"), "{msg}");
+        assert!(msg.contains("SUM(w)"), "{msg}");
+    }
+
+    /// Control: a plain window metric still parses, with the spec intact.
+    #[test]
+    fn a_plain_window_metric_still_parses() {
+        let (expr, spec) =
+            parse_window_over_clause("AVG(qty) OVER (PARTITION BY EXCLUDING d ORDER BY t)", BASE)
+                .expect("valid window metric");
+        assert_eq!(expr, "AVG(qty) OVER (PARTITION BY EXCLUDING d ORDER BY t)");
+        let spec = spec.expect("a WindowSpec");
+        assert_eq!(spec.window_function, "AVG");
+        assert_eq!(spec.inner_metric, "qty");
+        assert_eq!(spec.excluding_dims, vec!["d".to_string()]);
+        assert_eq!(spec.order_by.len(), 1);
+    }
+
+    /// Control: the accepted function-part shapes — a qualified name, a quoted
+    /// name, extra arguments, and whitespace before the argument parens (which
+    /// `DuckDB` accepts) — must all keep parsing. The new rule is "one identifier
+    /// chain then the arg list", not "no whitespace anywhere".
+    #[test]
+    fn qualified_quoted_and_spaced_function_names_still_parse() {
+        for (expr, want_fn) in [
+            ("main.avg(qty) OVER (PARTITION BY d)", "main.avg"),
+            ("\"my func\"(qty) OVER (PARTITION BY d)", "\"my func\""),
+            ("AVG (qty) OVER (PARTITION BY d)", "AVG"),
+            ("lead(qty, 1) OVER (PARTITION BY d ORDER BY t)", "lead"),
+        ] {
+            let (_, spec) = parse_window_over_clause(expr, BASE)
+                .unwrap_or_else(|e| panic!("{expr:?} must parse, got {}", e.message));
+            assert_eq!(spec.expect("a WindowSpec").window_function, want_fn);
+        }
+    }
+
+    /// Control: an expression with no OVER at all is returned untouched (this
+    /// is the non-window metric path — every ordinary metric expression flows
+    /// through here and must NOT be subjected to the function-call shape rule).
+    #[test]
+    fn an_expression_without_over_is_untouched() {
+        let (expr, spec) = parse_window_over_clause("SUM(revenue) - SUM(cost) + 100", BASE)
+            .expect("a non-window expression is not a window metric");
+        assert_eq!(expr, "SUM(revenue) - SUM(cost) + 100");
+        assert!(spec.is_none());
+    }
+
+    /// Control: the pre-existing "no parenthesized arguments" error still fires
+    /// for a bare name before OVER.
+    #[test]
+    fn a_window_function_without_arguments_is_still_rejected() {
+        let (msg, _) = err("row_number OVER (PARTITION BY d)");
+        assert!(msg.contains("parenthesized arguments"), "{msg}");
+    }
+}

--- a/src/expr_tokens.rs
+++ b/src/expr_tokens.rs
@@ -170,6 +170,25 @@ fn scan_chains(expr: &str, kind: ChainKind) -> Vec<IdentRef<'_>> {
             }
             _ if b == b'"' || crate::util::is_ident_byte(b) => {
                 let end = scan_chain(bytes, i);
+                // PARSE-12 (code-review 2026-08-08): a chain IMMEDIATELY
+                // followed by `'` is a literal's introducer, not a name — the
+                // escape-string forms `e'…'` / `E'…'` (PARSE-7 made them
+                // first-class) and every typed literal (`DATE'2020-01-01'`, and
+                // the qualified / quoted type names DuckDB also accepts:
+                // `main.date'…'`, `"date"'…'`). Emitting it as a reference let
+                // a member named `e` or `date` be substituted OVER the
+                // introducer, turning a valid definition into a query-time
+                // syntax error, and reported a phantom dependency that (since
+                // PAR-6) changes join topology. The literal starts here, so the
+                // string skipper runs from the quote — and it derives the
+                // backslash rules from the SAME adjacency test
+                // (`util::opens_escape_string`), which is what makes `e'\''`
+                // (backslash escapes) and `DATE'…'` (backslash is data) both
+                // come out right.
+                if bytes.get(end) == Some(&b'\'') {
+                    i = skip_single_quoted(bytes, end);
+                    continue;
+                }
                 let is_head = followed_by_open_paren(bytes, end);
                 let want = if is_head {
                     ChainKind::FunctionHead
@@ -715,6 +734,91 @@ mod tests {
         assert_eq!(rewrite_qualifier("b.city", "a", "a__dep"), "b.city");
     }
 
+    // ----- PARSE-12: a chain abutting a `'` introduces a LITERAL -----
+    //
+    // (code-review 2026-08-08) `e` / `E` / `DATE` / any type name immediately
+    // before a quote is the literal's introducer, not a name: the `e` in
+    // `e'\''` is an ident byte, so `scan_chain` emitted a one-byte Reference
+    // and the string skipper only saw the quote afterwards. DuckDB parses all
+    // of these as one literal token — including the qualified and quoted type
+    // names (`main.date'…'`, `"date"'…'`), verified against DuckDB — so the
+    // whole chain is suppressed, not just a bare `e`.
+
+    #[test]
+    fn an_escape_string_introducer_is_not_a_reference() {
+        // `count_if(x = e'\'')`
+        let expr = "count_if(x = e'\\'')";
+        assert_eq!(keys(expr), vec!["x"], "the `e` introduces the literal");
+        // FIND: a member named `e` is NOT a dependency of this expression
+        // (a phantom one changes join topology since PAR-6).
+        assert!(!references_ref(expr, "e", None));
+    }
+
+    #[test]
+    fn inlining_does_not_corrupt_an_escape_string_literal() {
+        // With a declared member named `e`, INLINE spliced the replacement over
+        // the introducer: `count_if(x = (o.something)'\'')` — a query-time
+        // syntax error produced from a valid definition.
+        let expr = "count_if(x = e'\\'')";
+        let mut m: HashMap<String, &str> = HashMap::new();
+        m.insert("e".to_string(), "(o.something)");
+        assert_eq!(inline_references(expr, &m), expr);
+    }
+
+    #[test]
+    fn rewriting_a_qualifier_does_not_corrupt_an_escape_string_literal() {
+        // The role-playing alias rewriter turned `e'a'` into `e__dep'a'`
+        // whenever the rewritten alias happened to be named `e`.
+        assert_eq!(
+            rewrite_qualifier("e.name || e'a'", "e", "e__dep"),
+            "e__dep.name || e'a'"
+        );
+        // Uppercase introducer, same rule.
+        assert_eq!(
+            rewrite_qualifier("e.name || E'a'", "e", "e__dep"),
+            "e__dep.name || E'a'"
+        );
+    }
+
+    #[test]
+    fn a_typed_literal_prefix_is_not_a_reference() {
+        // A fact named `date` corrupted `o.ts > DATE'2020-01-01'`.
+        let expr = "o.ts > DATE'2020-01-01'";
+        assert_eq!(keys(expr), vec!["o.ts"]);
+        assert!(!references_ref(expr, "date", None));
+        let mut m: HashMap<String, &str> = HashMap::new();
+        m.insert("date".to_string(), "(o.day)");
+        assert_eq!(inline_references(expr, &m), expr);
+        // DuckDB accepts a qualified and a quoted type name in this position
+        // (`main.date'…'` / `"date"'…'` both parse), so the whole chain is the
+        // introducer — not just its last part.
+        assert!(scan_references("main.date'2020-01-01'").is_empty());
+        assert!(scan_references("\"date\"'2020-01-01'").is_empty());
+    }
+
+    #[test]
+    fn a_chain_not_abutting_a_quote_still_scans() {
+        // Controls for the suppression rule — it is ADJACENCY-based (the same
+        // rule `util::opens_escape_string` uses), so an ordinary reference near
+        // a literal is untouched.
+        assert_eq!(keys("x + e"), vec!["x", "e"]);
+        assert_eq!(keys("e || 'a'"), vec!["e"]);
+        assert_eq!(keys("\"e\" + 1"), vec!["e", "1"]);
+        assert!(references_ref("e + 1", "e", None));
+        // The literal's own content is still skipped, and the reference after
+        // it still scans.
+        assert_eq!(keys("e'a' + cost"), vec!["cost"]);
+    }
+
+    #[test]
+    fn a_suppressed_introducer_is_not_a_function_head_either() {
+        // The two scans partition the chains; a suppressed chain belongs to
+        // neither (it is part of a literal token).
+        assert!(scan_function_heads("count_if(x = e'\\'')")
+            .iter()
+            .all(|h| h.key() != "e"));
+    }
+
     // ----- generative proptests -----
 
     /// A quoted-identifier part whose inner content is arbitrary (including
@@ -730,6 +834,17 @@ mod tests {
             r#""[a-zA-Z0-9 .,()]{0,6}""#,
             // single-quoted string literals with identifier-looking content
             "'[a-zA-Z0-9 .]{0,8}'",
+            // PARSE-12: a chain ABUTTING a quote introduces a literal — escape
+            // strings (`e'…'`, `E'…'`, whose backslash rules differ) and typed
+            // literals (`DATE'…'`, and the qualified / quoted type names DuckDB
+            // also accepts). Generated, not just pinned by fixed examples, so
+            // the tiling / disjointness / FIND-INLINE-agree properties below
+            // exercise the shape too.
+            "[eE]'[a-zA-Z0-9 ]{0,4}'",
+            Just("e'a\\'b'".to_string()),
+            "[a-z]{1,4}'[a-zA-Z0-9 :.-]{0,8}'",
+            Just("main.date'2020-01-01'".to_string()),
+            Just("\"date\"'2020-01-01'".to_string()),
             // dollar-quoted strings
             Just("$$a.b revenue$$".to_string()),
             // operators / punctuation / whitespace
@@ -788,6 +903,27 @@ mod tests {
             m.insert(inner.clone(), "REPL");
             prop_assert_eq!(inline_references(&lit, &m), lit.clone());
             prop_assert_eq!(inline_references(&dollar, &m), dollar);
+        }
+
+        /// PARSE-12: an identifier chain IMMEDIATELY followed by `'` is the
+        /// introducer of a literal, so it is neither found as a reference nor
+        /// substituted — for any prefix, not just the `e` / `DATE` examples.
+        #[test]
+        fn a_chain_abutting_a_quote_is_never_a_reference(
+            prefix in "[a-zA-Z_][a-zA-Z0-9_]{0,4}",
+            inner in "[a-zA-Z0-9 ]{0,6}",
+        ) {
+            // The left-hand reference is a QUOTED name containing a space, so
+            // no generated `prefix` can collide with it.
+            let expr = format!("\"lhs col\" = {prefix}'{inner}'");
+            prop_assert!(!references_ref(&expr, &prefix, None), "expr={expr:?}");
+            let mut m: HashMap<String, &str> = HashMap::new();
+            let key = crate::ident::normalize_ident_part(&prefix);
+            m.insert(key, "<R>");
+            prop_assert_eq!(inline_references(&expr, &m), expr.clone());
+            // Anti-vacuity: the scan really ran — the ordinary reference before
+            // the literal is still found (so "nothing scans" cannot pass this).
+            prop_assert!(references_ref(&expr, "lhs col", None), "expr={expr:?}");
         }
 
         /// FIND and INLINE agree: a name is reported as referenced iff inlining

--- a/src/parse/search_path.rs
+++ b/src/parse/search_path.rs
@@ -201,6 +201,15 @@ pub(crate) fn inject_search_path(sql: &str) -> Cow<'_, str> {
     if insert_at.is_empty() {
         return Cow::Borrowed(sql);
     }
+    // PARSE-11 (code-review 2026-08-08): the offsets are collected in call-HEAD
+    // order, but a resolving call NESTED inside another's argument list closes
+    // BEFORE the outer one — so head order is not close order, and the splice
+    // below (which walks `prev -> close` forward) sliced start > end and
+    // panicked. Both FFI hooks `catch_unwind`, so the panic surfaced only as
+    // "injection silently did not happen, for every call in the statement".
+    // Sorting is enough: every offset indexes the ORIGINAL text and each call
+    // has its own distinct close paren.
+    insert_at.sort_unstable();
     let mut out = String::with_capacity(sql.len() + insert_at.len() * 64);
     let mut prev = 0usize;
     for close in insert_at {
@@ -508,6 +517,62 @@ mod tests {
         assert!(
             got.contains("search_path := list_concat"),
             "a commented-out argument is not a real one: {got}"
+        );
+    }
+
+    /// The nested-call statement of PARSE-11 (code-review 2026-08-08).
+    const NESTED_CALLS: &str =
+        "SELECT * FROM semantic_view((SELECT view_name FROM show_semantic_dimensions('x') LIMIT 1))";
+
+    // PARSE-11: `insert_at` was collected in HEAD order, but a resolving call
+    // nested inside another's parens CLOSES first, so the offsets descended and
+    // `&sql[prev..close]` sliced start > end -> panic. Both FFI hooks
+    // `catch_unwind`, so in production the panic was swallowed and the
+    // statement ran with NO injection for either call (the PARSE-5 consequence,
+    // silently, on every execution).
+    #[test]
+    fn nested_resolving_calls_do_not_panic_and_both_get_injected() {
+        let got = inject_search_path(NESTED_CALLS);
+        assert_eq!(
+            got.matches("search_path :=").count(),
+            2,
+            "both the inner and the outer call must be injected: {got}"
+        );
+        // The inner call's argument lands inside the inner parens, the outer's
+        // after the subquery — i.e. the spliced text is well-formed, not just
+        // present twice.
+        assert_eq!(
+            got,
+            format!(
+                "SELECT * FROM semantic_view((SELECT view_name FROM show_semantic_dimensions('x'{inner}) LIMIT 1){outer})",
+                inner = suffix(),
+                outer = suffix()
+            ),
+            "{got}"
+        );
+    }
+
+    #[test]
+    fn injection_is_idempotent_for_the_nested_shape() {
+        // AR-5 re-runs `plan_rewrite` on already-rewritten text; the nested
+        // shape must survive that as the flat one does.
+        let once = inject_search_path(NESTED_CALLS).into_owned();
+        let twice = inject_search_path(&once).into_owned();
+        assert_eq!(once, twice, "second pass changed the statement");
+    }
+
+    // PARSE-13: `blank_sql_comments` ended a `--` comment only at `\n`, but
+    // DuckDB's scanner ends it at a bare `\r` too. The whole statement was
+    // therefore blanked, so no call was found and the query ran with no path
+    // while DuckDB happily executed it.
+    #[test]
+    fn a_leading_line_comment_ended_by_a_bare_carriage_return_does_not_defeat_injection() {
+        let sql = "-- note\rSELECT * FROM semantic_view('v')";
+        let got = inject_search_path(sql);
+        assert_eq!(
+            got,
+            format!("-- note\rSELECT * FROM semantic_view('v'{})", suffix()),
+            "a CR-terminated comment must not swallow the statement"
         );
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -290,9 +290,8 @@ impl QuoteState {
 ///
 /// Every byte of a comment — `-- ...` to end of line (the line-ending byte
 /// itself is kept; a bare `\r` ends the comment as well as `\n`, matching
-/// `DuckDB`'s scanner — PARSE-13), and `/* ... */` including the delimiters — is
-/// replaced with a
-/// space. Block comments NEST, matching `PostgreSQL`/`DuckDB` semantics (the SQL
+/// `DuckDB`'s scanner, PARSE-13), and `/* ... */` including the delimiters — is
+/// replaced with a space. Block comments NEST, matching `PostgreSQL`/`DuckDB` semantics (the SQL
 /// standard): `/* a /* b */ c */` is one comment. An unterminated block
 /// comment blanks to end of input.
 ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -288,8 +288,10 @@ impl QuoteState {
 
 /// Blank SQL comments out of `input`, byte-for-byte length-preserving.
 ///
-/// Every byte of a comment — `-- ...` to end of line (the newline itself is
-/// kept), and `/* ... */` including the delimiters — is replaced with a
+/// Every byte of a comment — `-- ...` to end of line (the line-ending byte
+/// itself is kept; a bare `\r` ends the comment as well as `\n`, matching
+/// `DuckDB`'s scanner — PARSE-13), and `/* ... */` including the delimiters — is
+/// replaced with a
 /// space. Block comments NEST, matching `PostgreSQL`/`DuckDB` semantics (the SQL
 /// standard): `/* a /* b */ c */` is one comment. An unterminated block
 /// comment blanks to end of input.
@@ -386,9 +388,15 @@ pub fn blank_sql_comments(input: &str) -> std::borrow::Cow<'_, str> {
                     }
                 }
                 b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
-                    // Line comment: blank to (not including) the newline.
+                    // Line comment: blank to (not including) the line ending.
+                    // PARSE-13: a bare `\r` ends the comment too — DuckDB
+                    // inherits the PostgreSQL scanner rule, and blanking past
+                    // it swallowed live code (a clause after `-- c\r`, or the
+                    // whole statement after a `-- note\r` prefix) while DuckDB
+                    // itself executed it. Both line-ending bytes are KEPT, so
+                    // the pass stays length-preserving.
                     let buf = out.get_or_insert_with(|| bytes.to_vec());
-                    while i < bytes.len() && bytes[i] != b'\n' {
+                    while i < bytes.len() && bytes[i] != b'\n' && bytes[i] != b'\r' {
                         buf[i] = b' ';
                         i += 1;
                     }
@@ -737,6 +745,29 @@ mod tests {
         // must still be blanked.
         let out = blank_sql_comments("WHERE x = $1 -- c");
         assert_eq!(out, "WHERE x = $1     ");
+    }
+
+    // PARSE-13 (code-review 2026-08-08): DuckDB's scanner (the PostgreSQL rule)
+    // ends a `--` comment at a bare `\r` as well as at `\n`. Blanking only to
+    // `\n` swallowed the CODE after a CR-terminated comment: DuckDB executed
+    // `b` while every downstream scanner saw spaces, so a clause after
+    // `-- c\r` vanished from a parsed body and a `-- note\r` prefix disabled
+    // search-path injection for the statement that followed.
+    #[test]
+    fn blank_comments_line_comment_ends_at_a_bare_carriage_return() {
+        let input = "a -- c\rb";
+        let out = blank_sql_comments(input);
+        assert_eq!(out, "a     \rb");
+        // Length preservation is load-bearing (error carets / raw re-slices).
+        assert_eq!(out.len(), input.len());
+    }
+
+    #[test]
+    fn blank_comments_line_comment_ends_at_crlf_keeping_both_bytes() {
+        let input = "a -- c\r\nb";
+        let out = blank_sql_comments(input);
+        assert_eq!(out, "a     \r\nb");
+        assert_eq!(out.len(), input.len());
     }
 
     #[test]

--- a/test/sql/TEST_LIST
+++ b/test/sql/TEST_LIST
@@ -105,3 +105,4 @@ test/sql/cat4_read_foreign_database.test
 test/sql/par6_cross_table_fact_join.test
 test/sql/member_reference_scoping.test
 test/sql/cr20260808_where_member_fan_fence.test
+test/sql/cr20260808_parser_fixes.test

--- a/test/sql/cr20260808_parser_fixes.test
+++ b/test/sql/cr20260808_parser_fixes.test
@@ -1,0 +1,161 @@
+# Code review 2026-08-08, PARSE-10 and PARSE-12: two parser defects that turned
+# a valid definition into a wrong (or unbindable) query, end-to-end through the
+# extension-load -> DDL -> query path.
+#
+# PARSE-10 -- `parse_window_over_clause` never looked at the text AFTER the
+# OVER body's `)`, and took everything before the first `(` as the window
+# function's NAME. Emission rebuilds the SQL from the parsed WindowSpec alone,
+# so `AVG(w) OVER (...) + 100` computed without the `+ 100` while GET_DDL
+# round-tripped the text that still had it: definition and behaviour disagreed,
+# silently. Composition around a window function is now REJECTED rather than
+# silently dropped (the P-2/F-3 "reject, don't discard" rule) -- it is not
+# supported; see TECH-DEBT "window-metric composition".
+#
+# PARSE-12 -- an identifier chain immediately followed by `'` is a literal's
+# introducer (`e'...'`, `DATE'...'`), but the reference scanner emitted it as a
+# name. A declared member called `e` or `date` was then substituted OVER the
+# introducer, so a valid definition reached DuckDB as `(q.s)'...'`.
+#
+# The runner halts a file at its first failing statement, so the per-case red
+# proof lives at the unit layer (`body_parser::window::tests`,
+# `expr_tokens::tests`, `parse::search_path::tests`, `util::tests`), each of
+# which was individually watched failing before the fix. This file covers the
+# whole pipeline.
+
+require semantic_views
+
+statement ok
+CREATE TABLE cr0808_sales (
+    id INTEGER PRIMARY KEY,
+    store VARCHAR,
+    d DATE,
+    qty INTEGER
+);
+
+statement ok
+INSERT INTO cr0808_sales VALUES
+    (1, 'a', DATE '2020-01-01', 10),
+    (2, 'a', DATE '2021-01-01', 20),
+    (3, 'b', DATE '2021-06-01', 30);
+
+# ============================================================
+# PARSE-10: residue after the OVER clause.
+# ============================================================
+
+# `+ 100` was silently discarded: the metric returned a number 100 too small.
+statement error
+CREATE SEMANTIC VIEW cr0808_w1 AS
+TABLES (s AS cr0808_sales PRIMARY KEY (id))
+DIMENSIONS (s.store AS s.store, s.d AS s.d)
+METRICS (
+    s.total AS SUM(s.qty),
+    s.w AS AVG(total) OVER (PARTITION BY store) + 100
+)
+----
+Unexpected text '+ 100' after the OVER clause
+
+# A prefix before the window function was stored VERBATIM as the function name
+# (`window_function == "1 + AVG"`).
+statement error
+CREATE SEMANTIC VIEW cr0808_w2 AS
+TABLES (s AS cr0808_sales PRIMARY KEY (id))
+DIMENSIONS (s.store AS s.store)
+METRICS (
+    s.total AS SUM(s.qty),
+    s.w AS 1 + AVG(total) OVER (PARTITION BY store)
+)
+----
+Window function before OVER must be a plain function call
+
+# A second OVER term was dropped wholesale.
+statement error
+CREATE SEMANTIC VIEW cr0808_w3 AS
+TABLES (s AS cr0808_sales PRIMARY KEY (id))
+DIMENSIONS (s.store AS s.store)
+METRICS (
+    s.total AS SUM(s.qty),
+    s.w AS AVG(total) OVER (PARTITION BY store) - SUM(total) OVER (PARTITION BY store)
+)
+----
+Unexpected text
+
+# Control: a plain window metric still creates and still computes. Per store:
+# store `a` totals 10 + 20 = 30 and store `b` totals 30, and each partition
+# holds one row, so the windowed sum is the store total itself.
+statement ok
+CREATE SEMANTIC VIEW cr0808_ok AS
+TABLES (s AS cr0808_sales PRIMARY KEY (id))
+DIMENSIONS (s.store AS s.store)
+METRICS (
+    s.total AS SUM(s.qty),
+    s.w AS SUM(total) OVER (PARTITION BY store)
+);
+
+query TI
+SELECT store, w FROM semantic_view(
+  'cr0808_ok',
+  dimensions := ['store'],
+  metrics := ['w']
+) ORDER BY store;
+----
+a	30
+b	30
+
+# Control: the window definition still round-trips through GET_DDL.
+query I
+SELECT count(*) FROM (SELECT GET_DDL('SEMANTIC_VIEW', 'cr0808_ok') AS d) WHERE d LIKE '%OVER (%'
+----
+1
+
+# ============================================================
+# PARSE-12: a member named like a literal introducer.
+# ============================================================
+
+statement ok
+CREATE TABLE cr0808_quoted (id INTEGER PRIMARY KEY, s VARCHAR, d DATE, amount INTEGER);
+
+statement ok
+INSERT INTO cr0808_quoted VALUES
+    (1, 'plain', DATE '2019-01-01', 10),
+    (2, '''',    DATE '2021-01-01', 20);
+
+# A FACT named `e` sitting next to an escape string. Before the fix the `e` of
+# `e'\''` scanned as a reference to that fact, so the inliner produced
+# `count_if(q.s = (q.s)'\'')` -- a query-time syntax error from a valid
+# definition -- and FIND reported a phantom dependency on it.
+statement ok
+CREATE SEMANTIC VIEW cr0808_e AS
+  TABLES (q AS cr0808_quoted PRIMARY KEY (id))
+  FACTS (q.e AS q.s)
+  DIMENSIONS (q.s AS q.s)
+  METRICS (
+    q.n_quote AS count_if(q.s = e'\''),
+    q.total AS SUM(q.amount)
+  );
+
+query II
+SELECT n_quote, total FROM semantic_view(
+  'cr0808_e',
+  metrics := ['n_quote', 'total']
+);
+----
+1	30
+
+# The same shape with a typed literal and a fact named `date`.
+statement ok
+CREATE SEMANTIC VIEW cr0808_date AS
+  TABLES (q AS cr0808_quoted PRIMARY KEY (id))
+  FACTS (q.date AS q.d)
+  DIMENSIONS (q.s AS q.s)
+  METRICS (
+    q.recent AS count_if(q.d > DATE'2020-01-01'),
+    q.total AS SUM(q.amount)
+  );
+
+query II
+SELECT recent, total FROM semantic_view(
+  'cr0808_date',
+  metrics := ['recent', 'total']
+);
+----
+1	30


### PR DESCRIPTION
Stacked on #214. **Contains one breaking change (PARSE-10) — see below.**

## PARSE-10 (HIGH) — window-metric expression text outside `FUNC(args) OVER (...)` was silently discarded

⚠️ **Breaking: DDL that previously created will now error.** That is the intended minimum-correct behaviour, because what it previously did was compute the wrong number.

After `take_parens()` consumed the OVER body, remaining tokens were never checked, and `func_part` accepted an arbitrary prefix whose text before the first `(` became `window_function` verbatim. Emission rebuilds the expression from the spec alone, so anything else was dropped:

- `AVG(w) OVER (PARTITION BY d) + 100` → parsed fine, emitted `AVG("w") OVER (PARTITION BY "d")`, returned a number **100 short of the definition text** (which is valid DuckDB SQL)
- `1 + AVG(w) OVER (...)` → stored `window_function == "1 + AVG"`
- `AVG(w) OVER (...) - SUM(w) OVER (...)` → second term silently dropped

Now: residue after the OVER parens errors with position, and the function-name slot must be a plain identifier chain. Whitespace (`AVG (x)`) and qualified/quoted names (`main.avg`, `"my func"`) still parse — pinned by controls, as is the no-OVER passthrough path every ordinary metric flows through.

**Compatibility:** persisted definitions are not re-parsed on open, so existing catalogs keep working. But a view created this way *before* the fix renders DDL that no longer re-creates; recreate it with the arithmetic moved into the inner metric. Nothing in-repo used the shape (grepped).

## PARSE-11 (MEDIUM) — nested resolving calls panicked, silently disabling search-path injection

`insert_at` was collected in head order, but a call nested inside another's parens closes *before* the outer close, so offsets descended and the splice sliced with `start > end`. Both FFI hooks `catch_unwind`, so the panic became rc=2 and the statement executed with **no injection for either call** — the PARSE-5 consequence resurfacing, plus a swallowed panic on every execution. Fix: sort ascending. Idempotence pinned for the nested shape.

## PARSE-12 (MEDIUM) — escape-string and typed-literal introducers scanned as identifier references

At `e'\''` the `e` is an ident byte, so `scan_chain` emitted a one-byte Reference *before* the string skipper saw the quote; same for `DATE'2020-01-01'` → reference `date`. With a member named `e` or `date` this corrupts generated SQL and registers a phantom dependency that changes join topology (since PAR-6).

Fix: a chain immediately followed by `'` is a literal introducer, not a reference — scanning resumes via `skip_single_quoted`, which derives backslash rules from the same `opens_escape_string` adjacency test, so `e'\''` (backslash escapes) and `DATE'…'` (backslash is data) are both handled. Verified against live DuckDB that `main.date'…'` and `"date"'…'` are valid typed literals.

**New randomized coverage:** the `expr_tokens` generator now emits escape-string and typed-literal atoms, plus a property asserting a chain abutting a quote is never a reference — with an anti-vacuity assertion that a quoted reference in the same expression *is* still found, so "the scanner returned nothing" cannot pass it.

## PARSE-13 (LOW) — `--` comments did not end at a bare `\r`

DuckDB's scanner ends a line comment at `\r` (PG rule, verified live); ours blanked the `\r` *and the following code*. So `-- note\rSELECT * FROM semantic_view('v')` blanked entirely → no search-path injection while DuckDB executed the query.

## Coverage

Each case is a unit test watched failing individually pre-fix (three for PARSE-10, two for PARSE-11, six for PARSE-12, two for PARSE-13), plus controls. `test/sql/cr20260808_parser_fixes.test` covers PARSE-10's rejections and PARSE-12 end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PT3CfUdQoRfc2SnvdzrbB)_