### PR TITLE
Small findings: IDENT-6, EXP-30, EXP-31, CAT-7, CAT-8, PBT-14, PBT-15, TC-14

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -21,6 +21,27 @@ pub(crate) mod writes;
 // companion file is deleted and this constant is never referenced again at runtime.
 const V010_COMPANION_EXT: &str = "semantic_views";
 
+/// Path of the v0.1.0 companion file that would sit alongside `db_path`, or
+/// `None` for an in-memory database (which never has one).
+///
+/// The one place this shape is computed. Both readers of it — the writable
+/// import pass in [`init_catalog`] and the read-only refusal above it (CAT-8) —
+/// must agree byte-for-byte, or the read-only branch would refuse for a file
+/// the import pass would not have looked at (or, worse, stay silent for one it
+/// would).
+fn v010_companion_path(db_path: &str) -> Option<PathBuf> {
+    if db_path == ":memory:" {
+        return None;
+    }
+    let mut p = PathBuf::from(db_path);
+    let ext = match p.extension() {
+        Some(e) => format!("{}.{V010_COMPANION_EXT}", e.to_string_lossy()),
+        None => V010_COMPANION_EXT.to_string(),
+    };
+    p.set_extension(ext);
+    Some(p)
+}
+
 /// A unique temp-file path for a file-backed unit test (CAT-7).
 ///
 /// File-backed tests used to hardcode a fixed name under `std::env::temp_dir()`.
@@ -94,6 +115,26 @@ pub fn init_catalog(
                     .into(),
             );
         }
+        // CAT-8: the v0.1.0 companion-file import below is equally unreachable
+        // read-only — it INSERTs. Left unchecked the two un-migrated shapes
+        // behaved differently: the legacy *table* refused loudly (above), while
+        // a companion file was simply never looked at, so every view in it
+        // resolved as "does not exist" with no hint that a whole catalog was
+        // sitting unimported next to the database. Refuse with the same
+        // actionable wording instead.
+        if let Some(companion) = v010_companion_path(db_path) {
+            if companion.exists() {
+                return Err(format!(
+                    "semantic_views: this database has a v0.1.0 companion file \
+                     '{}' whose semantic views have not been imported yet, and \
+                     the database is open read-only, so it cannot be migrated. \
+                     Open it writable once (any LOAD will import it), then \
+                     reopen read-only.",
+                    companion.display()
+                )
+                .into());
+            }
+        }
         return Ok(());
     }
     // FF-10: `definition` is `NOT NULL`. A SQL-NULL definition is an
@@ -124,16 +165,7 @@ pub fn init_catalog(
 
     // One-time migration: if a v0.1.0 companion file exists alongside the database,
     // import its contents into the table then delete the file.
-    if db_path != ":memory:" {
-        let migration_path: PathBuf = {
-            let mut p = PathBuf::from(db_path);
-            let ext = match p.extension() {
-                Some(e) => format!("{}.{V010_COMPANION_EXT}", e.to_string_lossy()),
-                None => V010_COMPANION_EXT.to_string(),
-            };
-            p.set_extension(ext);
-            p
-        };
+    if let Some(migration_path) = v010_companion_path(db_path) {
         if migration_path.exists() {
             let contents = std::fs::read_to_string(&migration_path).map_err(|e| {
                 format!(
@@ -1840,6 +1872,109 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    /// Bootstrap a valid, empty DuckDB file at `db_path` so it can be reopened
+    /// read-only (`open_with_flags` will not create a file in read-only mode).
+    #[cfg(not(feature = "extension"))]
+    fn bootstrap_empty_db_file(db_path: &str) {
+        let con = Connection::open(db_path).expect("open writable to create the file");
+        con.execute_batch("CREATE TABLE cat8_bootstrap(x INTEGER);")
+            .expect("write something so the file has real content");
+        con.execute_batch("CHECKPOINT;").expect("flush to disk");
+    }
+
+    #[cfg(not(feature = "extension"))]
+    fn open_read_only(db_path: &str) -> Connection {
+        let cfg = duckdb::Config::default()
+            .access_mode(duckdb::AccessMode::ReadOnly)
+            .expect("set access_mode");
+        Connection::open_with_flags(db_path, cfg).expect("open read-only")
+    }
+
+    /// CAT-8 (code-review 2026-08-08): a read-only open of a database that
+    /// still has an unimported v0.1.0 companion file used to succeed silently
+    /// — the companion detection lives *below* the `is_read_only` early return,
+    /// so it was unreachable, and every view in the file then resolved as
+    /// "does not exist" with nothing pointing at the un-migrated catalog next
+    /// to the database. The sibling un-migrated shape (a legacy `_definitions`
+    /// *table*) has always refused loudly; this makes the two agree.
+    #[cfg(not(feature = "extension"))]
+    #[test]
+    fn cat8_read_only_open_refuses_an_unimported_companion_file() {
+        let db_path_buf = unique_temp_db_path("test_cat8_ro_companion");
+        let db_path = db_path_buf.to_str().expect("temp dir is UTF-8");
+        let companion = PathBuf::from(format!("{db_path}.{V010_COMPANION_EXT}"));
+
+        bootstrap_empty_db_file(db_path);
+        std::fs::write(
+            &companion,
+            r#"{"orders": "{\"base_table\":\"orders\",\"dimensions\":[],\"metrics\":[]}"}"#,
+        )
+        .unwrap();
+
+        let con = open_read_only(db_path);
+        let err = init_catalog(&con, db_path, true)
+            .expect_err("an unimported companion file must be refused, not ignored");
+        let msg = err.to_string();
+        for expected in [
+            "v0.1.0 companion file",
+            "read-only",
+            "Open it writable once",
+        ] {
+            assert!(
+                msg.contains(expected),
+                "message must stay as actionable as the legacy-table refusal \
+                 (missing {expected:?}), got: {msg}"
+            );
+        }
+        assert!(
+            msg.contains(&companion.display().to_string()),
+            "message must name the file to act on, got: {msg}"
+        );
+        assert!(
+            companion.exists(),
+            "refusing must not delete the file — it is the only copy of those views"
+        );
+
+        drop(con);
+        let _ = std::fs::remove_file(db_path);
+        let _ = std::fs::remove_file(&companion);
+    }
+
+    /// The CAT-8 control: a read-only open with **no** companion file is still
+    /// a clean no-op. Without this the fix could refuse every read-only open
+    /// and the test above would not notice.
+    #[cfg(not(feature = "extension"))]
+    #[test]
+    fn cat8_read_only_open_without_a_companion_file_is_a_no_op() {
+        let db_path_buf = unique_temp_db_path("test_cat8_ro_clean");
+        let db_path = db_path_buf.to_str().expect("temp dir is UTF-8");
+
+        bootstrap_empty_db_file(db_path);
+        let con = open_read_only(db_path);
+        init_catalog(&con, db_path, true)
+            .expect("a read-only open with nothing to migrate must succeed");
+
+        drop(con);
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    /// The companion path both branches compute has to be the same one, or the
+    /// read-only refusal fires for a file the writable import would never look
+    /// at. Pins the `set_extension` shape (`x.duckdb` -> `x.duckdb.semantic_views`,
+    /// extensionless `x` -> `x.semantic_views`) and the in-memory exemption.
+    #[test]
+    fn cat8_companion_path_shape() {
+        assert_eq!(
+            v010_companion_path("/tmp/x.duckdb"),
+            Some(PathBuf::from("/tmp/x.duckdb.semantic_views"))
+        );
+        assert_eq!(
+            v010_companion_path("/tmp/x"),
+            Some(PathBuf::from("/tmp/x.semantic_views"))
+        );
+        assert_eq!(v010_companion_path(":memory:"), None);
     }
 
     #[cfg(not(feature = "extension"))]

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -21,6 +21,29 @@ pub(crate) mod writes;
 // companion file is deleted and this constant is never referenced again at runtime.
 const V010_COMPANION_EXT: &str = "semantic_views";
 
+/// A unique temp-file path for a file-backed unit test (CAT-7).
+///
+/// File-backed tests used to hardcode a fixed name under `std::env::temp_dir()`.
+/// `cargo test` runs several test binaries **concurrently**, and this crate's
+/// tests are also run concurrently with other checkouts on a shared machine, so
+/// two processes could open the same DuckDB file — one taking a conflicting
+/// lock, and each `remove_file`-ing the other's live database on the way in.
+/// Observed live during the 2026-08-08 review: four tests failed on a
+/// conflicting-lock error and passed in isolation.
+///
+/// Uniqueness comes from the process id plus a nanosecond timestamp, the
+/// pattern `tc6_restart_persistence_survives_reopen` already used. `stem` keeps
+/// the failing file identifiable in a `ls /tmp` after a crash, and callers that
+/// need companion/WAL siblings derive them from the returned path so all of a
+/// test's files share the unique stem.
+#[cfg(test)]
+pub(crate) fn unique_temp_db_path(stem: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    std::env::temp_dir().join(format!("{stem}_{}_{nanos}.duckdb", std::process::id()))
+}
+
 /// Schema holding the semantic-view catalog table.
 pub const DEFINITIONS_SCHEMA: &str = "semantic_layer";
 /// Bare (unqualified) name of the semantic-view catalog table.
@@ -1826,12 +1849,10 @@ mod tests {
         // v0.1.0 companion file was silently DELETED without importing —
         // permanent loss of pre-v0.2 definitions. Post-fix init_catalog must
         // error, and the file must be left in place for the user to repair.
-        let tmp = std::env::temp_dir();
-        let db_path_buf = tmp.join("test_ms2_corrupt.duckdb");
+        // CAT-7: unique per-invocation paths; see `unique_temp_db_path`.
+        let db_path_buf = unique_temp_db_path("test_ms2_corrupt");
         let db_path = db_path_buf.to_str().expect("temp dir is UTF-8");
-        let companion = tmp.join("test_ms2_corrupt.duckdb.semantic_views");
-        let _ = std::fs::remove_file(db_path);
-        let _ = std::fs::remove_file(&companion);
+        let companion = PathBuf::from(format!("{db_path}.{V010_COMPANION_EXT}"));
 
         std::fs::write(&companion, "{not valid json").unwrap();
         let con = Connection::open(db_path).expect("open file-backed DB");
@@ -1853,12 +1874,10 @@ mod tests {
     #[cfg(not(feature = "extension"))]
     #[test]
     fn migration_valid_companion_file_imports_then_deletes() {
-        let tmp = std::env::temp_dir();
-        let db_path_buf = tmp.join("test_ms2_valid.duckdb");
+        // CAT-7: unique per-invocation paths; see `unique_temp_db_path`.
+        let db_path_buf = unique_temp_db_path("test_ms2_valid");
         let db_path = db_path_buf.to_str().expect("temp dir is UTF-8");
-        let companion = tmp.join("test_ms2_valid.duckdb.semantic_views");
-        let _ = std::fs::remove_file(db_path);
-        let _ = std::fs::remove_file(&companion);
+        let companion = PathBuf::from(format!("{db_path}.{V010_COMPANION_EXT}"));
 
         std::fs::write(
             &companion,
@@ -1895,12 +1914,10 @@ mod tests {
         // with an empty schema in `SHOW SEMANTIC VIEWS`, and was missed
         // entirely by `SHOW SEMANTIC VIEWS IN SCHEMA main` — the listings read
         // the JSON, not the column.
-        let tmp = std::env::temp_dir();
-        let db_path_buf = tmp.join("test_cat3_backfill.duckdb");
+        // CAT-7: unique per-invocation paths; see `unique_temp_db_path`.
+        let db_path_buf = unique_temp_db_path("test_cat3_backfill");
         let db_path = db_path_buf.to_str().expect("temp dir is UTF-8");
-        let companion = tmp.join("test_cat3_backfill.duckdb.semantic_views");
-        let _ = std::fs::remove_file(db_path);
-        let _ = std::fs::remove_file(&companion);
+        let companion = PathBuf::from(format!("{db_path}.{V010_COMPANION_EXT}"));
 
         std::fs::write(
             &companion,
@@ -1938,10 +1955,9 @@ mod tests {
     #[cfg(not(feature = "extension"))]
     #[test]
     fn pragma_database_list_returns_file_path() {
-        let tmp = std::env::temp_dir();
-        let tmpfile_buf = tmp.join("test_pragma_rust_check.duckdb");
+        // CAT-7: unique per-invocation paths; see `unique_temp_db_path`.
+        let tmpfile_buf = unique_temp_db_path("test_pragma_rust_check");
         let tmpfile = tmpfile_buf.to_str().expect("temp dir is UTF-8");
-        let _ = std::fs::remove_file(tmpfile);
         let con = Connection::open(tmpfile).expect("open file-backed connection");
         let mut stmt = con.prepare("PRAGMA database_list").expect("prepare PRAGMA");
         let paths: Vec<Option<String>> = stmt
@@ -1982,11 +1998,9 @@ mod tests {
     #[cfg(not(feature = "extension"))]
     #[test]
     fn persist_02_rollback_leaves_catalog_unchanged() {
-        let tmp = std::env::temp_dir();
-        let db_path_buf = tmp.join("test_persist02_rollback.duckdb");
+        // CAT-7: unique per-invocation paths; see `unique_temp_db_path`.
+        let db_path_buf = unique_temp_db_path("test_persist02_rollback");
         let db_path = db_path_buf.to_str().expect("temp dir is UTF-8");
-        let _ = std::fs::remove_file(db_path);
-        let _ = std::fs::remove_file(format!("{db_path}.wal"));
 
         let con = Connection::open(db_path).expect("open file-backed DB");
         init_catalog(&con, db_path, false).unwrap();
@@ -2047,19 +2061,11 @@ mod tests {
     fn tc6_restart_persistence_survives_reopen() {
         // Unique per-invocation filename (pid + nanos) so concurrent `cargo test`
         // runs — in this binary or another process — cannot race on the same
-        // DB/WAL paths and flake via cross-deletion/reuse.
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let tmp = std::env::temp_dir();
-        let db_path_buf = tmp.join(format!(
-            "test_tc6_restart_persistence_{}_{nanos}.duckdb",
-            std::process::id()
-        ));
+        // DB/WAL paths and flake via cross-deletion/reuse. CAT-7 lifted this
+        // out of here into `unique_temp_db_path` and put every other
+        // file-backed test on it.
+        let db_path_buf = unique_temp_db_path("test_tc6_restart_persistence");
         let db_path = db_path_buf.to_str().expect("temp dir is UTF-8");
-        let _ = std::fs::remove_file(db_path);
-        let _ = std::fs::remove_file(format!("{db_path}.wal"));
 
         let json = r#"{"schema_version":1,"base_table":"sales","dimensions":[],"metrics":[]}"#;
 

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -59,10 +59,29 @@ fn v010_companion_path(db_path: &str) -> Option<PathBuf> {
 /// test's files share the unique stem.
 #[cfg(test)]
 pub(crate) fn unique_temp_db_path(stem: &str) -> PathBuf {
+    // Three components, because two of them are individually insufficient:
+    //
+    // - the PID separates concurrent `cargo test` PROCESSES (the CAT-7
+    //   collision this helper exists to fix — a sibling run took a conflicting
+    //   DuckDB lock, and each test's up-front `remove_file` could delete the
+    //   other run's live database);
+    // - the counter separates callers WITHIN a process, which the PID cannot:
+    //   Rust runs tests on concurrent threads, so every caller here shares a
+    //   PID, and `SystemTime` resolution is coarser than nanoseconds on some
+    //   platforms — two threads in one tick would otherwise get one path, which
+    //   is CAT-7 again inside a single run;
+    // - the timestamp keeps names distinct across sequential runs of the same
+    //   process image, so a crashed run's leftover file cannot be mistaken for
+    //   the current one.
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |d| d.as_nanos());
-    std::env::temp_dir().join(format!("{stem}_{}_{nanos}.duckdb", std::process::id()))
+    std::env::temp_dir().join(format!(
+        "{stem}_{}_{nanos}_{seq}.duckdb",
+        std::process::id()
+    ))
 }
 
 /// Schema holding the semantic-view catalog table.
@@ -1014,6 +1033,58 @@ mod tests {
     use super::*;
     #[cfg(not(feature = "extension"))]
     use duckdb::Connection;
+
+    /// CAT-7's helper must be unique WITHIN a process, not just across them.
+    ///
+    /// The first version used PID + `SystemTime` nanos only. Rust runs tests on
+    /// concurrent threads, so every caller shares a PID, and on a platform whose
+    /// clock is coarser than nanoseconds two callers in one tick get the same
+    /// path — CAT-7 again, inside a single run.
+    ///
+    /// This asserts the **counter**, not "1000 calls happened to differ". A
+    /// tight loop on a fine-grained clock (Linux here) produces distinct
+    /// timestamps anyway, so that version of the test passes with the counter
+    /// removed — vacuous exactly where it matters, since the bug only bites on
+    /// the coarse-clock platforms this cannot simulate. Pinning the monotonic
+    /// component instead is clock-independent: with the counter gone the
+    /// filename has three components rather than four and this fails outright.
+    #[test]
+    fn unique_temp_db_path_carries_a_clock_independent_counter() {
+        // Underscore-free stem so the components are countable: the name is
+        // exactly `<stem>_<pid>_<nanos>_<counter>`. Drop the counter and it is
+        // three fields, which is what makes this fail pre-fix — checking "the
+        // last field increases" would NOT, because the nanos field increases
+        // too and parses as an integer just as happily.
+        let fields = |p: PathBuf| -> Vec<String> {
+            p.file_stem()
+                .expect("stem")
+                .to_string_lossy()
+                .split('_')
+                .map(str::to_owned)
+                .collect()
+        };
+
+        let a = fields(unique_temp_db_path("cat7seq"));
+        let b = fields(unique_temp_db_path("cat7seq"));
+        assert_eq!(
+            a.len(),
+            4,
+            "expected <stem>_<pid>_<nanos>_<counter>, got {a:?} — without the \
+             counter, within-process uniqueness rests entirely on clock \
+             resolution, which is the CAT-7 collision"
+        );
+
+        let (sa, sb): (u64, u64) = (
+            a[3].parse().expect("counter"),
+            b[3].parse().expect("counter"),
+        );
+        assert_eq!(
+            sb,
+            sa + 1,
+            "counter must advance by exactly one per call, got {sa} then {sb}"
+        );
+        assert_eq!(a[1], b[1], "same process, so the PID field must match");
+    }
 
     // CAT-4 (code-review 2026-08-03): the read side's foreign-database rule.
     // The end-to-end coverage is `test/sql/cat4_read_foreign_database.test`,

--- a/src/expand/role_playing.rs
+++ b/src/expand/role_playing.rs
@@ -168,24 +168,42 @@ pub(super) fn check_fact_role_playing_path(
 /// guess (several metrics may name several roles, and a predicate is not bound
 /// to any of them), and guessing is what produces a wrong number instead of an
 /// error — the reasoning behind EXP-4/EXP-5.
+///
+/// # What counts as "the member's table"
+///
+/// EXP-31 (code-review 2026-08-08). A member forces a join not only of the
+/// table it is *declared* on but of every table its expression reaches through
+/// a fact reference ([`WhereMember::fact_tables`], the set #207 added to
+/// `ResolvedWhere::source_tables` so those joins are emitted at all). Reading
+/// only the declared table meant a member on an unambiguous base table whose
+/// fact chain lands on a role-playing one sailed through and bound to
+/// `tree_parent`, the first-declared relationship — the exact silent,
+/// declaration-order-dependent binding this check exists to prevent, one hop
+/// further along. Same blind spot #207 opened for fan traps (EXP-27), at a
+/// different fence, so both walk the pair the same way.
+///
+/// [`WhereMember::fact_tables`]: super::where_clause::WhereMember::fact_tables
 pub(super) fn check_where_clause_role_playing_path(
     view_name: &str,
     def: &SemanticViewDefinition,
     where_members: &[super::where_clause::WhereMember],
 ) -> Result<(), ExpandError> {
     for member in where_members {
-        let Some(member_table) = member.table.as_ref() else {
-            continue; // Unqualified member: base-table grain, no role to pick.
-        };
-        if let Some(rp) = role_playing_on_path(view_name, def, member_table)? {
-            let available_relationships = relationships_to_table(def, &rp);
-            return Err(ExpandError::AmbiguousWhereClausePath {
-                view_name: view_name.to_string(),
-                member_name: member.name.clone(),
-                member_table: member_table.to_ascii_lowercase(),
-                role_playing_table: rp,
-                available_relationships,
-            });
+        // A member declared without a table is base-table grain and picks no
+        // role of its own — but its fact chain still can, so the chain is
+        // walked either way.
+        let joined_tables = member.table.iter().chain(member.fact_tables.iter());
+        for member_table in joined_tables {
+            if let Some(rp) = role_playing_on_path(view_name, def, member_table)? {
+                let available_relationships = relationships_to_table(def, &rp);
+                return Err(ExpandError::AmbiguousWhereClausePath {
+                    view_name: view_name.to_string(),
+                    member_name: member.name.clone(),
+                    member_table: member_table.to_ascii_lowercase(),
+                    role_playing_table: rp,
+                    available_relationships,
+                });
+            }
         }
     }
     Ok(())

--- a/src/expand/tests_role_playing.rs
+++ b/src/expand/tests_role_playing.rs
@@ -663,3 +663,174 @@ fn where_clause_on_non_role_playing_table_still_allowed() {
         result.err()
     );
 }
+
+// ---------------------------------------------------------------------------
+// EXP-31 (code-review 2026-08-08): the role-playing twin of EXP-27. A
+// `where_clause` member whose FACT CHAIN reaches a ROLE-PLAYING table had that
+// table joined with no ambiguity check at all.
+//
+// EXP-10 (above) closed the case where the member is *declared* on the
+// role-playing table. #207 (EXP-23) then taught `resolve_where_clause` to
+// contribute the tables a member reaches THROUGH its fact references to
+// `source_tables`, so the join resolver joins those too — and
+// `check_where_clause_role_playing_path` still read only `member.table`. The
+// reached table therefore rode `fact_source_tables` straight to `tree_parent`,
+// the first-declared relationship: exactly the silent, declaration-order-
+// dependent binding EXP-10 exists to prevent, reached one hop further along.
+//
+// Same blind spot #207 opened for fan traps (EXP-27) at a different fence,
+// which is why both now walk `WhereMember::fact_tables` alongside
+// `WhereMember::table`.
+// ---------------------------------------------------------------------------
+
+/// `flights_airports_def` plus a fact on the ROLE-PLAYING table `a` and a fact
+/// on the base whose expression reaches it, so a predicate naming the base
+/// fact pulls `a` in without ever naming it.
+///
+/// A fact on `a` is not itself illegal: `check_fact_role_playing_path` rejects
+/// one when it is *queried*, and a `where_clause` member is not queried.
+fn flights_airports_fact_chain_def() -> SemanticViewDefinition {
+    flights_airports_def()
+        // A plain metric with no USING, so nothing else in the query supplies a
+        // role and the ambiguity is the member's alone.
+        .with_metric("flight_count", "COUNT(*)", Some("f"))
+        .with_fact("ap_elev", "a.elevation", "a")
+        .with_fact("f_elev", "ap_elev + 1", "f")
+}
+
+/// The FACT branch: the predicate names a fact on the base whose expression
+/// reaches a fact on the role-playing table.
+#[test]
+fn exp31_where_member_fact_chain_to_a_role_playing_table_is_rejected() {
+    let def = flights_airports_fact_chain_def();
+    let req = QueryRequest {
+        where_clause: Some("f_elev > 0".to_string()),
+        facts: vec![],
+        dimensions: vec![],
+        metrics: vec![MetricName::new("flight_count")],
+    };
+    match expand("flights_sv", &def, &req) {
+        Err(ExpandError::AmbiguousWhereClausePath {
+            member_name,
+            member_table,
+            role_playing_table,
+            available_relationships,
+            ..
+        }) => {
+            assert_eq!(member_name, "f_elev");
+            assert_eq!(
+                member_table, "a",
+                "the error must name the table joined on the member's behalf; \
+                 the table the member is declared on is unambiguous"
+            );
+            assert_eq!(role_playing_table, "a");
+            assert_eq!(
+                available_relationships,
+                vec!["dep_airport".to_string(), "arr_airport".to_string()],
+                "the message must list the roles the user has to choose between"
+            );
+        }
+        Err(other) => panic!(
+            "expected AmbiguousWhereClausePath — a different error means this \
+             case stopped guarding EXP-31: {other}"
+        ),
+        Ok(sql) => panic!(
+            "EXP-31: the role-playing table was joined for a where_clause fact \
+             chain with no ambiguity check, so the predicate binds to the \
+             first-declared relationship (dep_airport) silently.\n\
+             emitted SQL:\n{sql}"
+        ),
+    }
+}
+
+/// The DIMENSION branch: TECH-DEBT #54 made predicate dimensions' expressions
+/// fact-inlined too, so a dimension on the base reaching the same fact takes
+/// the identical unchecked path.
+#[test]
+fn exp31_where_member_dimension_reaching_a_role_playing_fact_is_rejected() {
+    let def = flights_airports_fact_chain_def().with_dimension(
+        "high_altitude",
+        "CASE WHEN ap_elev > 5000 THEN 'hi' ELSE 'lo' END",
+        Some("f"),
+    );
+    let req = QueryRequest {
+        where_clause: Some("high_altitude = 'hi'".to_string()),
+        facts: vec![],
+        dimensions: vec![],
+        metrics: vec![MetricName::new("flight_count")],
+    };
+    match expand("flights_sv", &def, &req) {
+        Err(ExpandError::AmbiguousWhereClausePath {
+            member_name,
+            member_table,
+            ..
+        }) => {
+            assert_eq!(member_name, "high_altitude");
+            assert_eq!(member_table, "a");
+        }
+        Err(other) => panic!("expected AmbiguousWhereClausePath, got: {other}"),
+        Ok(sql) => panic!(
+            "EXP-31 (dimension branch): a where_clause DIMENSION whose \
+             expression reaches a fact on the role-playing table joined it \
+             unchecked.\nemitted SQL:\n{sql}"
+        ),
+    }
+}
+
+/// Transitivity: the reached set walks the whole chain, so a two-hop chain
+/// that only arrives at the role-playing table at its far end is rejected too.
+/// A check that looked at the directly-named fact alone would miss this.
+#[test]
+fn exp31_transitive_fact_chain_to_a_role_playing_table_is_rejected() {
+    let def = flights_airports_fact_chain_def().with_fact("f_elev2", "f_elev * 2", "f");
+    let req = QueryRequest {
+        where_clause: Some("f_elev2 > 0".to_string()),
+        facts: vec![],
+        dimensions: vec![],
+        metrics: vec![MetricName::new("flight_count")],
+    };
+    match expand("flights_sv", &def, &req) {
+        Err(ExpandError::AmbiguousWhereClausePath { member_name, .. }) => {
+            assert_eq!(member_name, "f_elev2");
+        }
+        Err(other) => panic!("expected AmbiguousWhereClausePath, got: {other}"),
+        Ok(sql) => panic!(
+            "EXP-31 (transitive): `f_elev2 -> f_elev -> ap_elev@a` reached the \
+             role-playing table through two hops unchecked.\n\
+             emitted SQL:\n{sql}"
+        ),
+    }
+}
+
+/// CONTROL — a fact chain reaching a NON-role-playing table must still expand.
+/// Without this the fix could be "reject every where_clause fact chain" and
+/// still look green. The same shape as the tests above with one relationship
+/// instead of two, so nothing but the role-playing multi-edge differs.
+#[test]
+fn exp31_control_fact_chain_to_a_non_role_playing_table_still_expands() {
+    let def = SemanticViewDefinition::default()
+        .with_table("f", "exp31_flights", &["flight_id"])
+        .with_table("a", "exp31_airports", &["airport_code"])
+        .with_metric("flight_count", "COUNT(*)", Some("f"))
+        .with_fact("ap_elev", "a.elevation", "a")
+        .with_fact("f_elev", "ap_elev + 1", "f")
+        .with_pkfk_join(
+            "dep_airport",
+            "f",
+            "a",
+            &["departure_code"],
+            &["airport_code"],
+        );
+    let req = QueryRequest {
+        where_clause: Some("f_elev > 0".to_string()),
+        facts: vec![],
+        dimensions: vec![],
+        metrics: vec![MetricName::new("flight_count")],
+    };
+    let sql = expand("flights_sv", &def, &req)
+        .expect("one relationship to the target means no role to disambiguate");
+    assert!(
+        sql.contains("exp31_airports"),
+        "the table reached through the fact chain must still be joined: {sql}"
+    );
+}

--- a/src/expand/wildcard.rs
+++ b/src/expand/wildcard.rs
@@ -46,11 +46,16 @@ pub fn expand_wildcards(
         }
         if item.ends_with(".*") {
             let alias = &item[..item.len() - 2];
-            // Validate alias exists in tables
+            // EXP-30: match the qualifier the way DuckDB resolves identifiers —
+            // case-insensitively, quoted or not (CLAUDE.md; `ident_matches`).
+            // A raw `eq_ignore_ascii_case` made `"O".*` fail against alias `o`
+            // with "unknown table alias", the last production residue of the
+            // family PARSE-8 closed in the parse layer. All three comparisons
+            // below are of the same qualifier and move together.
             let alias_exists = def
                 .tables
                 .iter()
-                .any(|t| t.alias.eq_ignore_ascii_case(alias));
+                .any(|t| crate::ident::ident_matches(&t.alias, alias));
             if !alias_exists {
                 return Err(format!(
                     "unknown table alias '{alias}' in wildcard '{item}'. Available aliases: [{}]",
@@ -66,9 +71,9 @@ pub fn expand_wildcards(
             let is_base_alias = def
                 .tables
                 .first()
-                .is_some_and(|t| t.alias.eq_ignore_ascii_case(alias));
+                .is_some_and(|t| crate::ident::ident_matches(&t.alias, alias));
             let on_table = |source_table: Option<&str>| -> bool {
-                source_table.map_or(is_base_alias, |st| st.eq_ignore_ascii_case(alias))
+                source_table.map_or(is_base_alias, |st| crate::ident::ident_matches(st, alias))
             };
             match item_type {
                 WildcardItemType::Dimension => {
@@ -227,6 +232,69 @@ mod tests {
         let result = expand_wildcards(&items, &def, &WildcardItemType::Fact).unwrap();
         // hidden_fact is PRIVATE, should be excluded
         assert_eq!(result, vec!["line_total"]);
+    }
+
+    /// EXP-30 (code-review 2026-08-08): the wildcard qualifier was compared
+    /// with a raw `eq_ignore_ascii_case`, so a **quoted** qualifier failed to
+    /// match its own alias — `"O".*` reported "unknown table alias" against a
+    /// definition whose alias is `o`. DuckDB resolves identifiers
+    /// case-insensitively whether or not they are quoted (CLAUDE.md), which is
+    /// what `ident::ident_matches` implements; PARSE-8 migrated the parse layer
+    /// onto it and this was the surviving production site.
+    ///
+    /// Both spellings must expand identically, and the base-alias branch (which
+    /// picks up members declared with no `source_table`, SG-15) has to agree —
+    /// it is a second comparison of the same alias.
+    #[test]
+    fn quoted_wildcard_qualifier_matches_its_alias() {
+        let def = test_def();
+        let expected = vec!["region", "status"];
+        for spelling in ["o.*", "\"o\".*", "\"O\".*", "O.*"] {
+            let items = vec![spelling.to_string()];
+            let result = expand_wildcards(&items, &def, &WildcardItemType::Dimension)
+                .unwrap_or_else(|e| panic!("`{spelling}` names alias `o`: {e}"));
+            assert_eq!(result, expected, "spelling: {spelling}");
+        }
+    }
+
+    /// The SG-15 half of EXP-30: a member declared without a `source_table` is
+    /// a base-table member, and `base_alias.*` must include it however the base
+    /// alias is spelled. This is `is_base_alias`, the second of the three
+    /// quote-blind comparisons.
+    #[test]
+    fn quoted_base_alias_wildcard_includes_unqualified_members() {
+        let mut def = test_def();
+        def.dimensions.push(Dimension {
+            name: "unqualified".to_string(),
+            expr: "o.something".to_string(),
+            source_table: None,
+            ..Default::default()
+        });
+        for spelling in ["o.*", "\"O\".*"] {
+            let items = vec![spelling.to_string()];
+            let result = expand_wildcards(&items, &def, &WildcardItemType::Dimension)
+                .unwrap_or_else(|e| panic!("`{spelling}` names base alias `o`: {e}"));
+            assert_eq!(
+                result,
+                vec!["region", "status", "unqualified"],
+                "spelling: {spelling}"
+            );
+        }
+    }
+
+    /// The `unknown table alias` error must still fire for a genuinely unknown
+    /// qualifier when it is quoted — the fix widens matching, it does not make
+    /// every quoted qualifier match.
+    #[test]
+    fn quoted_unknown_wildcard_qualifier_still_errors() {
+        let def = test_def();
+        let items = vec!["\"nope\".*".to_string()];
+        let err = expand_wildcards(&items, &def, &WildcardItemType::Dimension)
+            .expect_err("an unknown alias stays an error however it is quoted");
+        assert!(
+            err.contains("unknown table alias"),
+            "Error should contain 'unknown table alias': {err}"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -829,8 +829,11 @@ mod tests {
         // the lowercased enum form ("read_only"), not "READ_ONLY".
         // If a future DuckDB version changes this rendering, this test
         // catches it at CI bump time rather than in production.
-        let tmp = std::env::temp_dir().join("phase63_access_mode_pin.duckdb");
-        let _ = std::fs::remove_file(&tmp);
+        // CAT-7: unique per-invocation path — a fixed `/tmp` name collides with
+        // a concurrent `cargo test` process, which then takes a conflicting
+        // DuckDB lock (and the up-front `remove_file` could delete the other
+        // run's live database). See `catalog::unique_temp_db_path`.
+        let tmp = crate::catalog::unique_temp_db_path("phase63_access_mode_pin");
         // Bootstrap an empty file with valid header bytes by opening
         // writable then closing.
         {

--- a/src/parse/rewrite.rs
+++ b/src/parse/rewrite.rs
@@ -1341,7 +1341,7 @@ mod tests {
         let sql = passthrough_sql("SHOW SEMANTIC VIEWS STARTS WITH 'a' LIMIT 5");
         assert_eq!(
             sql,
-            "SELECT * FROM list_semantic_views() WHERE name LIKE 'a%' LIMIT 5"
+            "SELECT * FROM list_semantic_views() WHERE starts_with(name, 'a') LIMIT 5"
         );
     }
 
@@ -2070,7 +2070,7 @@ mod tests {
         fn test_build_filter_suffix_starts_with_only() {
             assert_eq!(
                 build_filter_suffix(None, Some("total"), None, None, None),
-                " WHERE name LIKE 'total%'"
+                " WHERE starts_with(name, 'total')"
             );
         }
 
@@ -2086,7 +2086,7 @@ mod tests {
         fn test_build_filter_suffix_all_three() {
             assert_eq!(
                 build_filter_suffix(Some("%x%"), Some("a"), Some(10), None, None),
-                " WHERE name ILIKE '%x%' AND name LIKE 'a%' LIMIT 10"
+                " WHERE name ILIKE '%x%' AND starts_with(name, 'a') LIMIT 10"
             );
         }
 
@@ -2163,7 +2163,7 @@ mod tests {
             );
             assert_eq!(
                 sql,
-                "SELECT * FROM show_semantic_dimensions('v') WHERE name ILIKE '%c%' AND name LIKE 'cust%' LIMIT 2"
+                "SELECT * FROM show_semantic_dimensions('v') WHERE name ILIKE '%c%' AND starts_with(name, 'cust') LIMIT 2"
             );
         }
 
@@ -2172,7 +2172,7 @@ mod tests {
             let sql = passthrough_sql("SHOW SEMANTIC METRICS STARTS WITH 'total' LIMIT 1");
             assert_eq!(
                 sql,
-                "SELECT * FROM show_semantic_metrics_all() WHERE name LIKE 'total%' LIMIT 1"
+                "SELECT * FROM show_semantic_metrics_all() WHERE starts_with(name, 'total') LIMIT 1"
             );
         }
 
@@ -2189,7 +2189,7 @@ mod tests {
             );
             assert_eq!(
                 sql,
-                "SELECT * FROM show_semantic_dimensions_for_metric('v', 'm') WHERE name ILIKE '%x%' AND name LIKE 'a%' LIMIT 3"
+                "SELECT * FROM show_semantic_dimensions_for_metric('v', 'm') WHERE name ILIKE '%x%' AND starts_with(name, 'a') LIMIT 3"
             );
         }
 
@@ -2238,7 +2238,7 @@ mod tests {
             let sql = passthrough_sql("SHOW SEMANTIC VIEWS STARTS WITH 'sales' LIMIT 5");
             assert_eq!(
                 sql,
-                "SELECT * FROM list_semantic_views() WHERE name LIKE 'sales%' LIMIT 5"
+                "SELECT * FROM list_semantic_views() WHERE starts_with(name, 'sales') LIMIT 5"
             );
         }
 
@@ -2247,7 +2247,7 @@ mod tests {
             let sql = passthrough_sql("SHOW SEMANTIC VIEWS LIKE '%x%' STARTS WITH 'a' LIMIT 3");
             assert_eq!(
                 sql,
-                "SELECT * FROM list_semantic_views() WHERE name ILIKE '%x%' AND name LIKE 'a%' LIMIT 3"
+                "SELECT * FROM list_semantic_views() WHERE name ILIKE '%x%' AND starts_with(name, 'a') LIMIT 3"
             );
         }
 
@@ -4001,7 +4001,7 @@ $$"#;
             assert_eq!(
                 passthrough_sql("SHOW SEMANTIC VIEWS IN SCHEMA STARTS WITH 'a'"),
                 "SELECT * FROM list_semantic_views() \
-                 WHERE name LIKE 'a%' AND lower(schema_name) = lower(current_schema())"
+                 WHERE starts_with(name, 'a') AND lower(schema_name) = lower(current_schema())"
             );
         }
 

--- a/src/parse/show_clauses.rs
+++ b/src/parse/show_clauses.rs
@@ -74,7 +74,7 @@ fn scope_name_parts(
 /// Build optional WHERE and LIMIT suffix for a SHOW rewrite.
 ///
 /// LIKE maps to `name ILIKE '<escaped>'` (case-insensitive).
-/// STARTS WITH maps to `name LIKE '<escaped>%'` (case-sensitive).
+/// STARTS WITH maps to `starts_with(name, '<escaped>')` (case-sensitive).
 /// IN SCHEMA maps to `lower(schema_name) = lower('<escaped>')`.
 /// IN DATABASE maps to `lower(database_name) = lower('<escaped>')`.
 /// All conditions combined with AND. LIMIT appended last.
@@ -97,6 +97,16 @@ fn scope_name_parts(
 /// It stays an equality rather than becoming `ILIKE`: `SqlLit::escape` only
 /// doubles single quotes, so a `%` or `_` in a schema name would turn into a
 /// wildcard.
+///
+/// IDENT-6: `STARTS WITH` takes the same treatment for the same reason. It used
+/// to emit `name LIKE '<escaped>%'`, which handed the user's prefix to the
+/// pattern matcher — `STARTS WITH 'a_b'` also matched `axb`, and
+/// `STARTS WITH '100%'` matched every name beginning `100`. Snowflake's
+/// `STARTS WITH` is a literal prefix, so the predicate is now `DuckDB`'s
+/// `starts_with(name, '<escaped>')` scalar function: no metacharacters, nothing
+/// to escape beyond the quote doubling `SqlLit` already does, and no `ESCAPE`
+/// clause whose escape character would itself need escaping. `LIKE` keeps its
+/// pattern semantics — there the wildcards are the point.
 pub(crate) fn build_filter_suffix(
     like_pattern: Option<&str>,
     starts_with: Option<&str>,
@@ -111,7 +121,7 @@ pub(crate) fn build_filter_suffix(
     }
     if let Some(prefix) = starts_with {
         let escaped = SqlLit::escape(prefix);
-        parts.push(format!("name LIKE '{escaped}%'"));
+        parts.push(format!("starts_with(name, '{escaped}')"));
     }
     if let Some(schema) = in_schema {
         parts.push(schema.predicate("schema_name", "current_schema"));
@@ -559,7 +569,7 @@ mod tests {
         );
         assert_eq!(
             build_filter_suffix(None, Some("O'Br"), None, None, None),
-            " WHERE name LIKE 'O''Br%'"
+            " WHERE starts_with(name, 'O''Br')"
         );
         assert_eq!(
             build_filter_suffix(
@@ -580,5 +590,74 @@ mod tests {
             " WHERE name ILIKE 'cust%' LIMIT 10"
         );
         assert_eq!(build_filter_suffix(None, None, None, None, None), "");
+    }
+
+    /// IDENT-6 (code-review 2026-08-08): `STARTS WITH` is a **literal** prefix
+    /// in Snowflake, but the predicate used to be `name LIKE '<prefix>%'` with
+    /// only `SqlLit`'s quote-doubling applied — so a `_` or `%` inside the
+    /// prefix reached `LIKE` as a wildcard. `STARTS WITH 'a_b'` matched `axb`.
+    ///
+    /// The fix routes the prefix through `starts_with(name, '<literal>')`, the
+    /// same "don't hand a user value to a pattern matcher" choice
+    /// [`build_filter_suffix`]'s doc records for IN SCHEMA (equality, not
+    /// `ILIKE`). Nothing else changes: `starts_with` is case-sensitive, which
+    /// is what the clause already promised.
+    #[test]
+    fn starts_with_prefix_is_literal_not_a_like_pattern() {
+        assert_eq!(
+            build_filter_suffix(None, Some("a_b"), None, None, None),
+            " WHERE starts_with(name, 'a_b')"
+        );
+        assert_eq!(
+            build_filter_suffix(None, Some("100%"), None, None, None),
+            " WHERE starts_with(name, '100%')"
+        );
+        // Quote escaping still happens exactly once.
+        assert_eq!(
+            build_filter_suffix(None, Some("O'Br"), None, None, None),
+            " WHERE starts_with(name, 'O''Br')"
+        );
+        // LIKE is untouched: it is a pattern slot by contract.
+        assert_eq!(
+            build_filter_suffix(Some("a_b"), None, None, None, None),
+            " WHERE name ILIKE 'a_b'"
+        );
+    }
+
+    /// The behavioural half of IDENT-6: the emitted predicate must actually
+    /// discriminate `a_b` from `axb` when `DuckDB` runs it. A unit test on the
+    /// predicate string alone cannot tell a correct escape from a
+    /// plausible-looking one, so this executes it.
+    #[test]
+    fn starts_with_discriminates_underscore_from_wildcard_in_duckdb() {
+        let conn = duckdb::Connection::open_in_memory().expect("in-memory DuckDB opens");
+        conn.execute_batch(
+            "CREATE TABLE t(name VARCHAR); \
+             INSERT INTO t VALUES ('a_b'), ('axb'), ('a_bc'), ('100%x'), ('1005x');",
+        )
+        .expect("fixture rows insert");
+
+        let matches = |prefix: &str| -> Vec<String> {
+            let suffix = build_filter_suffix(None, Some(prefix), None, None, None);
+            let sql = format!("SELECT name FROM t{suffix} ORDER BY name");
+            let mut stmt = conn.prepare(&sql).expect("emitted predicate is valid SQL");
+            let rows = stmt
+                .query_map([], |r| r.get::<_, String>(0))
+                .expect("query runs")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("rows read");
+            rows
+        };
+
+        assert_eq!(
+            matches("a_b"),
+            vec!["a_b".to_string(), "a_bc".to_string()],
+            "`_` in a STARTS WITH prefix is a literal underscore, not a single-char wildcard"
+        );
+        assert_eq!(
+            matches("100%"),
+            vec!["100%x".to_string()],
+            "`%` in a STARTS WITH prefix is a literal percent, not a match-anything wildcard"
+        );
     }
 }

--- a/src/parse/show_clauses.rs
+++ b/src/parse/show_clauses.rs
@@ -628,6 +628,11 @@ mod tests {
     /// discriminate `a_b` from `axb` when `DuckDB` runs it. A unit test on the
     /// predicate string alone cannot tell a correct escape from a
     /// plausible-looking one, so this executes it.
+    ///
+    /// Gated off the `extension` feature, which swaps the bundled `DuckDB` API
+    /// for loadable-extension stubs — `Connection::open_in_memory` panics there
+    /// with "DuckDB API not initialized". The default-features run covers it.
+    #[cfg(not(feature = "extension"))]
     #[test]
     fn starts_with_discriminates_underscore_from_wildcard_in_duckdb() {
         let conn = duckdb::Connection::open_in_memory().expect("in-memory DuckDB opens");

--- a/test/sql/TEST_LIST
+++ b/test/sql/TEST_LIST
@@ -107,3 +107,4 @@ test/sql/member_reference_scoping.test
 test/sql/cr20260808_where_member_fan_fence.test
 test/sql/cr20260808_parser_fixes.test
 test/sql/cr20260808_phantom_row_guard.test
+test/sql/cr20260808_small_fixes.test

--- a/test/sql/cr20260808_small_fixes.test
+++ b/test/sql/cr20260808_small_fixes.test
@@ -68,3 +68,147 @@ SHOW SEMANTIC DIMENSIONS IN cr0808_starts_with_sv STARTS WITH 'A'
 
 statement ok
 DROP SEMANTIC VIEW cr0808_starts_with_sv
+
+# ============================================================
+# EXP-31: a `where_clause` member whose FACT CHAIN reaches a
+# ROLE-PLAYING table had that table joined with no ambiguity
+# check — the role-playing twin of EXP-27.
+#
+# EXP-10 closed the case where the member is DECLARED on the
+# role-playing table. #207 (EXP-23) then taught
+# `resolve_where_clause` to contribute the tables a member
+# reaches THROUGH its fact references, so the join resolver
+# joins those too, while
+# `check_where_clause_role_playing_path` still read only
+# `member.table`. Observed pre-fix at the unit layer, the
+# emitted SQL was
+#   FROM "flights" AS "f"
+#   LEFT JOIN "airports" AS "a"
+#     ON "f"."departure_code" = "a"."airport_code"
+#   WHERE ((a.elevation) + 1) > 0
+# — bound to the FIRST-DECLARED relationship, so a filter the
+# user believes is about either airport silently became one
+# about the departure airport.
+#
+# The runner halts a file at its first failing statement, so
+# the per-case red proof lives at the unit layer
+# (`expand::tests_role_playing::exp31_*`, three cases each
+# individually observed emitting SQL before the fix).
+# ============================================================
+
+statement ok
+CREATE TABLE cr0808_flights (
+  flight_id INTEGER PRIMARY KEY,
+  departure_code VARCHAR,
+  arrival_code VARCHAR,
+  carrier VARCHAR
+);
+
+statement ok
+INSERT INTO cr0808_flights VALUES (1, 'JFK', 'LAX', 'AA');
+
+statement ok
+CREATE TABLE cr0808_airports (airport_code VARCHAR PRIMARY KEY, city VARCHAR, elevation INTEGER);
+
+statement ok
+INSERT INTO cr0808_airports VALUES ('JFK', 'New York', 13), ('LAX', 'Los Angeles', 125);
+
+statement ok
+CREATE SEMANTIC VIEW cr0808_rp AS
+TABLES (
+    f AS cr0808_flights PRIMARY KEY (flight_id),
+    a AS cr0808_airports PRIMARY KEY (airport_code)
+)
+RELATIONSHIPS (
+    dep_airport AS f(departure_code) REFERENCES a,
+    arr_airport AS f(arrival_code) REFERENCES a
+)
+FACTS (
+    a.ap_elev AS a.elevation,
+    f.f_elev AS ap_elev + 1
+)
+DIMENSIONS (
+    f.carrier AS f.carrier,
+    f.high_altitude AS CASE WHEN ap_elev > 5000 THEN 'hi' ELSE 'lo' END
+)
+METRICS (
+    f.flight_count AS COUNT(*)
+);
+
+# Control first: with no predicate the role-playing table is never
+# reached, so the query is unambiguous and runs.
+query I
+SELECT flight_count FROM semantic_view('cr0808_rp', metrics := ['flight_count']);
+----
+1
+
+# EXP-31 fact branch: `f_elev` is declared on `f` (unambiguous) but its
+# expression reaches `ap_elev` on the role-playing `a`.
+statement error
+SELECT flight_count FROM semantic_view(
+  'cr0808_rp',
+  metrics := ['flight_count'],
+  where_clause := 'f_elev > 0'
+);
+----
+is ambiguous
+
+# EXP-31 dimension branch: the same fact reached from a DIMENSION's
+# expression (TECH-DEBT #54 made those fact-inlined too).
+statement error
+SELECT flight_count FROM semantic_view(
+  'cr0808_rp',
+  metrics := ['flight_count'],
+  where_clause := 'high_altitude = ''hi'''
+);
+----
+is ambiguous
+
+# A predicate that stays on the base table's own dimension is still
+# unambiguous — the fix must not reject every where_clause.
+query I
+SELECT flight_count FROM semantic_view(
+  'cr0808_rp',
+  metrics := ['flight_count'],
+  where_clause := 'carrier = ''AA'''
+);
+----
+1
+
+statement ok
+DROP SEMANTIC VIEW cr0808_rp
+
+# EXP-31 control: the same fact chain against a table reached by a
+# SINGLE relationship has no role to disambiguate, so it must still
+# expand and return a number.
+statement ok
+CREATE SEMANTIC VIEW cr0808_rp_control AS
+TABLES (
+    f AS cr0808_flights PRIMARY KEY (flight_id),
+    a AS cr0808_airports PRIMARY KEY (airport_code)
+)
+RELATIONSHIPS (
+    dep_airport AS f(departure_code) REFERENCES a
+)
+FACTS (
+    a.ap_elev AS a.elevation,
+    f.f_elev AS ap_elev + 1
+)
+DIMENSIONS (
+    f.carrier AS f.carrier
+)
+METRICS (
+    f.flight_count AS COUNT(*)
+);
+
+query I
+SELECT flight_count FROM semantic_view(
+  'cr0808_rp_control',
+  metrics := ['flight_count'],
+  where_clause := 'f_elev > 0'
+);
+----
+1
+
+statement ok
+DROP SEMANTIC VIEW cr0808_rp_control

--- a/test/sql/cr20260808_small_fixes.test
+++ b/test/sql/cr20260808_small_fixes.test
@@ -1,0 +1,70 @@
+# Code review 2026-08-08 — small-finding regression guards.
+#
+# IDENT-6: `SHOW ... STARTS WITH` is a LITERAL prefix. It used to emit
+# `name LIKE '<prefix>%'`, so `_` and `%` inside the prefix reached the pattern
+# matcher as wildcards.
+
+require semantic_views
+
+statement ok
+CREATE TABLE cr0808_t (id INTEGER PRIMARY KEY, a_b VARCHAR, axb VARCHAR, pq VARCHAR, pzq VARCHAR);
+
+statement ok
+CREATE SEMANTIC VIEW cr0808_starts_with_sv AS
+  TABLES (
+    t AS cr0808_t PRIMARY KEY (id)
+  )
+  DIMENSIONS (
+    t.a_b AS t.a_b,
+    t.axb AS t.axb,
+    t."p%q" AS t.pq,
+    t.pzq AS t.pzq
+  )
+  METRICS (
+    t.n AS COUNT(t.id)
+  )
+
+# ============================================================
+# IDENT-6 case 1: `_` in the prefix is a literal underscore.
+# Pre-fix this also returned `axb`, because `_` was a LIKE
+# single-character wildcard.
+# ============================================================
+
+query TTTTTTTT rowsort
+SHOW SEMANTIC DIMENSIONS IN cr0808_starts_with_sv STARTS WITH 'a_b'
+----
+memory	main	cr0808_starts_with_sv	cr0808_t	a_b	(empty)	[]	(empty)
+
+# ============================================================
+# IDENT-6 case 2: `%` in the prefix is a literal percent.
+# Pre-fix `p%` matched every name beginning with `p` — both
+# `p%q` and `pzq`.
+# ============================================================
+
+query TTTTTTTT rowsort
+SHOW SEMANTIC DIMENSIONS IN cr0808_starts_with_sv STARTS WITH 'p%'
+----
+memory	main	cr0808_starts_with_sv	cr0808_t	p%q	(empty)	[]	(empty)
+
+# ============================================================
+# IDENT-6 control: an ordinary prefix still matches every name
+# that starts with it (the clause did not become an equality).
+# ============================================================
+
+query TTTTTTTT rowsort
+SHOW SEMANTIC DIMENSIONS IN cr0808_starts_with_sv STARTS WITH 'a'
+----
+memory	main	cr0808_starts_with_sv	cr0808_t	a_b	(empty)	[]	(empty)
+memory	main	cr0808_starts_with_sv	cr0808_t	axb	(empty)	[]	(empty)
+
+# ============================================================
+# IDENT-6 control: STARTS WITH stays case-SENSITIVE (Snowflake's
+# rule for this clause, unlike LIKE which maps to ILIKE).
+# ============================================================
+
+query TTTTTTTT rowsort
+SHOW SEMANTIC DIMENSIONS IN cr0808_starts_with_sv STARTS WITH 'A'
+----
+
+statement ok
+DROP SEMANTIC VIEW cr0808_starts_with_sv

--- a/tests/fuzz_render_roundtrip_regression.rs
+++ b/tests/fuzz_render_roundtrip_regression.rs
@@ -59,13 +59,45 @@ fn ci_crash_input_no_longer_breaks_the_fixpoint() {
 
     let rendered0 = render_create_ddl("fuzz_view", &def).expect("render0");
     let body0 = body_of(&rendered0).expect("body0");
-    let Ok(kb1) = parse_keyword_body(body0, 0) else {
-        return; // not in the parser's image — stage-0 skip, the fixpoint is safe
-    };
-    for m in &kb1.metrics {
-        assert!(
-            !m.name.trim().is_empty(),
-            "parser produced a nameless metric: {kb1:#?}"
-        );
+
+    // TC-14 (code-review 2026-08-08): this used to be
+    // `let Ok(kb1) = ... else { return; }` — a silent escape. The input is
+    // FIXED, so "the parser happened to reject it" is not a case to skip past:
+    // the assertion below evaporates with no signal, the RT-5 fuzz-oracle
+    // shape. Making it explicit immediately showed the escape was live rather
+    // than defensive — the body does NOT parse today.
+    //
+    // What matters here is the invariant the CI crash was about: a
+    // round-tripped definition must never yield a metric with no name. Both
+    // outcomes satisfy it, and both are now pinned, so neither can change
+    // unobserved:
+    //
+    //   Ok  — every parsed metric carries a name (the original assertion).
+    //   Err — the parser refuses LOUDLY, and for the one reason we know of.
+    //         The metric here is named `PRIVATE`; `render_create_ddl`
+    //         quote-protects names on lexing grounds only, so it emits it bare
+    //         and the parser peels entry-initial `PRIVATE` as the access
+    //         modifier. That is review finding RT-9 (2026-08-08), still open:
+    //         the arm below is pinning a *known-degraded* state, not a
+    //         contract. When RT-9 is fixed this test flips to the Ok arm on
+    //         its own and this arm becomes dead — delete it then.
+    match parse_keyword_body(body0, 0) {
+        Ok(kb1) => {
+            for m in &kb1.metrics {
+                assert!(
+                    !m.name.trim().is_empty(),
+                    "parser produced a nameless metric: {kb1:#?}"
+                );
+            }
+        }
+        Err(e) => {
+            assert!(
+                e.message.contains("Missing metric name"),
+                "the only rejection we accept for this fixed body is RT-9's \
+                 bare-`PRIVATE`-metric-name one; any other parse failure means \
+                 this replay stopped exercising what it was written for.\n\
+                 got: {e:?}\nrendered body: {body0}"
+            );
+        }
     }
 }

--- a/tests/semi_additive_proptest.rs
+++ b/tests/semi_additive_proptest.rs
@@ -749,6 +749,16 @@ fn predicate_is_applied_before_the_snapshot_not_after() {
 //
 // The second branch is what stops the first from being satisfiable by erroring
 // on everything.
+//
+// PBT-14 (code-review 2026-08-08): the window half of that second branch used
+// to `return Ok(())` before the numeric comparison, deferring to
+// `window_metric_proptest` — whose inner metric is always the self-referential
+// `w`. A window wrapping a DIFFERENT (here semi-additive-classified) inner
+// metric therefore had numeric coverage nowhere: EXP-19's fence was randomized,
+// EXP-20's arithmetic was not. `wbal` is now oracled with the same
+// correlated-subquery formulation `window_metric_proptest` uses (the partition
+// key `ent` is fixed here, so it is mechanical), and the early return is gone.
+// The same change un-pins the harness's `where_clause: None`.
 
 /// [`build_def`] plus the two dependent metrics: `dbal = bal * 2` (derived) and
 /// `wbal = SUM(bal) OVER (PARTITION BY ent)` (window over the same inner).
@@ -783,21 +793,90 @@ fn build_def_with_dependents(order: SortOrder) -> SemanticViewDefinition {
     def
 }
 
+/// One generated dependent-metric case. A struct rather than four bare
+/// `proptest!` arguments so [`dependent_generator_reaches_every_branch`] can
+/// sample the same strategy and count what it actually produces (PBT-14).
+#[derive(Debug, Clone)]
+struct DependentCase {
+    inst: Instance,
+    order: SortOrder,
+    /// Whether the NA dimension `ts` is queried — the dichotomy's switch.
+    na_dim_queried: bool,
+    /// `true` selects the WINDOW dependent `wbal`, `false` the DERIVED `dbal`.
+    pick_window: bool,
+    /// PBT-14: previously pinned at `None` here, the shape CLAUDE.md names as
+    /// how EXP-9/EXP-10 reached `main`. A predicate is the most direct way to
+    /// break a dependent metric's grain: it changes which rows reach the inner
+    /// aggregate, and for `wbal` it can empty a group and so remove a row from
+    /// the partition the window then sums over.
+    where_pred: Option<Pred>,
+}
+
+fn arb_dependent_case() -> impl Strategy<Value = DependentCase> {
+    (
+        arb_instance(),
+        prop_oneof![Just(SortOrder::Asc), Just(SortOrder::Desc)],
+        any::<bool>(),
+        any::<bool>(),
+        prop_oneof![1 => Just(None), 3 => arb_pred().prop_map(Some)],
+    )
+        .prop_map(
+            |(inst, order, na_dim_queried, pick_window, where_pred)| DependentCase {
+                inst,
+                order,
+                na_dim_queried,
+                pick_window,
+                where_pred,
+            },
+        )
+}
+
+/// Independent oracle for the effectively-regular branch, per dependent metric.
+///
+/// The predicate belongs PRE-aggregation in both formulations: it decides which
+/// rows reach `sum(s.balance)`, and — for the window metric — emptying a group
+/// removes that row from the partition entirely, which is why the correlated
+/// subquery reads from the already-filtered CTE rather than filtering after.
+///
+/// `dbal` is the direct arithmetic. `wbal` is deliberately NOT written as
+/// `SUM(...) OVER (PARTITION BY ...)`: that would restate the extension's own
+/// construct and agree with it by construction. It uses the correlated-subquery
+/// formulation from `window_metric_proptest` — pre-aggregate by every queried
+/// dim, then aggregate over the rows sharing the partition key, matched with
+/// `IS NOT DISTINCT FROM` so NULL keys group together exactly as `PARTITION BY`
+/// does.
+fn dependent_oracle_sql(case: &DependentCase) -> String {
+    let where_sql = case
+        .where_pred
+        .as_ref()
+        .map_or_else(String::new, |p| format!(" WHERE {}", p.to_raw_sql()));
+    if case.pick_window {
+        format!(
+            "WITH agg AS (SELECT s.entity AS ent, s.ts AS ts, sum(s.balance) AS bal \
+             FROM s{where_sql} GROUP BY 1, 2) \
+             SELECT a1.ent, a1.ts, \
+             (SELECT SUM(a2.bal) FROM agg a2 \
+              WHERE a2.ent IS NOT DISTINCT FROM a1.ent) AS wbal \
+             FROM agg a1"
+        )
+    } else {
+        format!(
+            "SELECT s.entity AS ent, s.ts AS ts, sum(s.balance) * 2 AS dbal \
+             FROM s{where_sql} GROUP BY 1, 2"
+        )
+    }
+}
+
 proptest! {
     #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
 
     #[test]
-    fn a_dependent_metric_never_silently_drops_the_snapshot(
-        inst in arb_instance(),
-        order in prop_oneof![Just(SortOrder::Asc), Just(SortOrder::Desc)],
-        na_dim_queried in any::<bool>(),
-        pick_window in any::<bool>(),
-    ) {
-        let def = build_def_with_dependents(order);
-        let metric = if pick_window { "wbal" } else { "dbal" };
-        let dims: Vec<&str> = if na_dim_queried { vec!["ent", "ts"] } else { vec!["ent"] };
+    fn a_dependent_metric_never_silently_drops_the_snapshot(case in arb_dependent_case()) {
+        let def = build_def_with_dependents(case.order);
+        let metric = if case.pick_window { "wbal" } else { "dbal" };
+        let dims: Vec<&str> = if case.na_dim_queried { vec!["ent", "ts"] } else { vec!["ent"] };
         let req = QueryRequest {
-            where_clause: None,
+            where_clause: case.where_pred.as_ref().map(Pred::to_member_sql),
             dimensions: dims.iter().map(|d| DimensionName::new(*d)).collect(),
             metrics: vec![MetricName::new(metric)],
             facts: vec![],
@@ -807,7 +886,7 @@ proptest! {
             Err(e) => {
                 let msg = e.to_string();
                 prop_assert!(
-                    !na_dim_queried,
+                    !case.na_dim_queried,
                     "with the NA dimension queried '{metric}' is effectively regular \
                      and must expand, got error: {msg}"
                 );
@@ -818,40 +897,152 @@ proptest! {
             }
             Ok(sql) => {
                 prop_assert!(
-                    na_dim_queried,
+                    case.na_dim_queried,
                     "without the NA dimension the snapshot cannot be composed through \
                      '{metric}' and must not be silently dropped, got SQL:\n{sql}"
                 );
-                // Effectively-regular branch: check the number, not just the
-                // absence of an error. Only the derived metric has a
-                // formulation simple enough to oracle independently here; the
-                // window metric's numeric coverage lives in
-                // `window_metric_proptest`.
-                if pick_window {
-                    return Ok(());
-                }
-                let oracle = "SELECT s.entity AS ent, s.ts AS ts, \
-                              sum(s.balance) * 2 AS dbal FROM s GROUP BY 1, 2";
+                // Effectively-regular branch: check the NUMBER, not just the
+                // absence of an error. PBT-14: this now covers the window
+                // dependent too — it used to return here, leaving a window over
+                // a non-self-referential inner metric unoracled anywhere.
+                let oracle = dependent_oracle_sql(&case);
                 let cmp = format!(
                     "SELECT \
-                       (SELECT count(*) FROM (SELECT dbal, ent, ts FROM ({sql}) qa \
+                       (SELECT count(*) FROM (SELECT {metric}, ent, ts FROM ({sql}) qa \
                                               EXCEPT ALL \
-                                              SELECT dbal, ent, ts FROM ({oracle}) qb) e1) \
-                     + (SELECT count(*) FROM (SELECT dbal, ent, ts FROM ({oracle}) qc \
+                                              SELECT {metric}, ent, ts FROM ({oracle}) qb) e1) \
+                     + (SELECT count(*) FROM (SELECT {metric}, ent, ts FROM ({oracle}) qc \
                                               EXCEPT ALL \
-                                              SELECT dbal, ent, ts FROM ({sql}) qd) e2) AS diff"
+                                              SELECT {metric}, ent, ts FROM ({sql}) qd) e2) AS diff"
                 );
-                let conn = make_db(&inst);
+                let conn = make_db(&case.inst);
                 let diff: i64 = conn.query_row(&cmp, [], |r| r.get(0)).unwrap_or_else(|e| {
                     panic!("comparison failed: {e}\n--- expanded:\n{sql}\n--- oracle:\n{oracle}")
                 });
                 prop_assert_eq!(
                     diff, 0,
-                    "an effectively-regular derived metric disagrees with the oracle\
-                     \n--- expanded:\n{}\n--- oracle:\n{}",
-                    sql, oracle
+                    "an effectively-regular dependent metric ('{}') disagrees with the \
+                     independent oracle\n--- expanded:\n{}\n--- oracle:\n{}",
+                    metric, sql, oracle
                 );
             }
         }
     }
+}
+
+/// PBT-14 anti-vacuity guard for the dependent-metric property.
+///
+/// The property is a dichotomy over four independent switches, and every one of
+/// its `prop_assert!`s sits inside a branch. A branch that is never generated is
+/// exactly as green as a correct one — the same reasoning as
+/// `generator_reaches_both_where_clause_branches` in the sibling harnesses — so
+/// the branch counts are asserted directly here. In particular
+/// `window_effectively_regular` is the cell PBT-14 opened: before the fix that
+/// combination returned before comparing anything.
+#[test]
+fn dependent_generator_reaches_every_branch() {
+    use proptest::strategy::ValueTree;
+    use proptest::test_runner::TestRunner;
+    use std::collections::HashSet;
+
+    let mut runner = TestRunner::deterministic();
+    let mut window = 0usize;
+    let mut derived = 0usize;
+    let mut window_effectively_regular = 0usize;
+    let mut window_rejected = 0usize;
+    let mut derived_effectively_regular = 0usize;
+    let mut derived_rejected = 0usize;
+    let mut with_pred = 0usize;
+    let mut without_pred = 0usize;
+    let mut window_regular_with_pred = 0usize;
+    let mut pred_touches_ts = 0usize;
+    let mut pred_uses_filter_member = 0usize;
+    let mut distinct: HashSet<String> = HashSet::new();
+
+    for _ in 0..400 {
+        let case = arb_dependent_case()
+            .new_tree(&mut runner)
+            .expect("strategy must produce a value")
+            .current();
+        match (case.pick_window, case.na_dim_queried) {
+            (true, true) => {
+                window += 1;
+                window_effectively_regular += 1;
+            }
+            (true, false) => {
+                window += 1;
+                window_rejected += 1;
+            }
+            (false, true) => {
+                derived += 1;
+                derived_effectively_regular += 1;
+            }
+            (false, false) => {
+                derived += 1;
+                derived_rejected += 1;
+            }
+        }
+        match &case.where_pred {
+            None => without_pred += 1,
+            Some(p) => {
+                with_pred += 1;
+                if p.touches_ts() {
+                    pred_touches_ts += 1;
+                }
+                if p.references_filter() {
+                    pred_uses_filter_member += 1;
+                }
+                if case.pick_window && case.na_dim_queried {
+                    window_regular_with_pred += 1;
+                }
+                distinct.insert(p.to_member_sql());
+            }
+        }
+    }
+
+    assert!(
+        window > 0 && derived > 0,
+        "both dependent metrics must be generated (window={window}, derived={derived})"
+    );
+    assert!(
+        window_effectively_regular > 0,
+        "no case reached the window + NA-dim-queried cell — the numeric \
+         comparison PBT-14 added is unreachable and therefore vacuous"
+    );
+    assert!(
+        window_rejected > 0,
+        "no case reached the window + NA-dim-absent cell — the EXP-19 rejection \
+         assertion is never exercised for the window dependent"
+    );
+    assert!(
+        derived_effectively_regular > 0 && derived_rejected > 0,
+        "both derived cells must be reached (regular={derived_effectively_regular}, \
+         rejected={derived_rejected})"
+    );
+    assert!(
+        with_pred > 0 && without_pred > 0,
+        "where_clause must be both present and absent (present={with_pred}, \
+         absent={without_pred}) — a field pinned at its inert default is not \
+         coverage"
+    );
+    assert!(
+        window_regular_with_pred > 0,
+        "no case combined a predicate with the window metric on the oracled \
+         branch, so the predicate never reaches the partition the window sums \
+         over"
+    );
+    assert!(
+        pred_touches_ts > 0,
+        "no generated predicate constrained the NA dimension `ts`"
+    );
+    assert!(
+        pred_uses_filter_member > 0,
+        "no generated predicate named a FILTER member, so the member-substitution \
+         surface is untested here"
+    );
+    assert!(
+        distinct.len() > 50,
+        "generator produced only {} distinct predicates; search space collapsed",
+        distinct.len()
+    );
 }

--- a/tests/star_schema_proptest.rs
+++ b/tests/star_schema_proptest.rs
@@ -817,6 +817,25 @@ fn generator_reaches_both_where_clause_branches() {
     // could be generated only in accepted queries and the fence stay untested.
     let mut parent_metric_fact_chain_pred = 0usize;
     let mut accepted_fact_chain_pred = 0usize;
+    // PBT-15 (code-review 2026-08-08): the two metrics this harness added for
+    // specific past defects. Nothing asserted they are ever SELECTED, let alone
+    // that they reach the numeric comparison — the counts below were all about
+    // the predicate. `differential_proptest` pins its equivalent
+    // (`references_chained_fact`); this file's own doctrine is to assert reach,
+    // not assume it.
+    //   `svf` — PAR-6: a child-grain metric whose expression reaches a fact on
+    //           the parent, with a compound fact expression that catches a
+    //           paren-losing splice.
+    //   `dsv` — EXP-24: a derived metric referencing its base by the
+    //           own-qualified spelling `t.sv`.
+    // Both are only worth anything on the ORACLED path, so each is counted
+    // twice: selected at all, and selected in a case the property actually
+    // compares against the oracle.
+    let mut svf_selected = 0usize;
+    let mut svf_oracled = 0usize;
+    let mut dsv_selected = 0usize;
+    let mut dsv_oracled = 0usize;
+    let mut svf_and_dsv_oracled = 0usize;
     let mut distinct: HashSet<String> = HashSet::new();
 
     for _ in 0..400 {
@@ -826,6 +845,27 @@ fn generator_reaches_both_where_clause_branches() {
             .current();
         let selects_parent_metric = case.sel_metrics.iter().any(|&i| METS[i] == "sw");
         let selects_child_dim = case.sel_dims.iter().any(|&i| DIMS[i] == "td");
+
+        // The two rejection branches of the property, mirrored: everything else
+        // falls through to the differential comparison.
+        let pred_touches_child = case.where_pred.as_ref().is_some_and(Pred::touches_child);
+        let oracled = !(selects_parent_metric && (selects_child_dim || pred_touches_child));
+        let has = |name: &str| case.sel_metrics.iter().any(|&i| METS[i] == name);
+        if has("svf") {
+            svf_selected += 1;
+            if oracled {
+                svf_oracled += 1;
+            }
+        }
+        if has("dsv") {
+            dsv_selected += 1;
+            if oracled {
+                dsv_oracled += 1;
+            }
+        }
+        if oracled && has("svf") && has("dsv") {
+            svf_and_dsv_oracled += 1;
+        }
         match &case.where_pred {
             None => without_pred += 1,
             Some(p) => {
@@ -893,6 +933,25 @@ fn generator_reaches_both_where_clause_branches() {
         "the fact-chain member only ever appeared in REJECTED cases, so the \
          non-fanning half -- that resolving it still produces the right number \
          -- is never oracled"
+    );
+    // PBT-15: the metric-selection half of the same guard.
+    assert!(
+        svf_selected > 0 && svf_oracled > 0,
+        "the PAR-6 cross-table metric `svf` never reached the numeric \
+         comparison (selected={svf_selected}, oracled={svf_oracled}); its \
+         parent-fact splice has no randomized coverage here"
+    );
+    assert!(
+        dsv_selected > 0 && dsv_oracled > 0,
+        "the EXP-24 derived metric `dsv` never reached the numeric comparison \
+         (selected={dsv_selected}, oracled={dsv_oracled}); the own-qualified \
+         derived-metric reference has no randomized coverage here"
+    );
+    assert!(
+        svf_and_dsv_oracled > 0,
+        "`svf` and `dsv` were never oracled in the SAME query, so the \
+         cross-table fact splice and the derived-metric substitution are never \
+         exercised against each other"
     );
     assert!(
         distinct.len() > 50,


### PR DESCRIPTION
Stacked on #216. Eight independent findings, one commit each.

## EXP-31 — a WHERE member's fact chain reaching a **role-playing** table bound silently

Found while fixing EXP-27 (#214): `check_where_clause_role_playing_path` has the identical blind spot #207 opened for fan traps — it looks only at `member.table`, so a member whose fact chain reaches a role-playing table joined it with no ambiguity check and bound to the **first-declared relationship**.

Pre-fix, a filter the author reads as "about an airport" silently became one about the *departure* airport:

```
FROM "flights" AS "f" LEFT JOIN "airports" AS "a" ON "f"."departure_code" = "a"."airport_code"
WHERE ((a.elevation) + 1) > 0
```

Fixed the same way EXP-27 was, reusing the `WhereMember::fact_tables` set that PR added. Three cases red individually; control (single relationship) passes in both states.

## IDENT-6 — `SHOW … STARTS WITH` treated `_` and `%` as wildcards

Emitted `name LIKE '<prefix>%'` with only quote escaping, so `STARTS WITH 'a_b'` also returned `axb`. Now `starts_with(name, '<escaped>')` — chosen over escaping + `ESCAPE` because it needs no escape character that would itself need escaping, matching the "don't hand a user value to a pattern matcher" choice `build_filter_suffix` already documents for IN SCHEMA. Case sensitivity preserved.

## EXP-30 — quoted wildcard qualifier failed against its alias

`"O".*` reported an unknown alias because three comparisons in `wildcard.rs` used raw `eq_ignore_ascii_case` — the class PARSE-8 closed elsewhere. Now `ident_matches`.

## CAT-7 — fixed `/tmp` names collided across concurrent test processes

Observed live twice during this round: six file-backed tests used fixed paths, so a concurrent `cargo test` took a conflicting DuckDB lock — and each test's up-front `remove_file` could delete the *other* run's live database. Now on the pid+nanos pattern `tc6_restart_persistence_survives_reopen` already used. Red confirmed per site by running 4 and 6 concurrent processes pre-fix (2–5 failures each); 4/4 and 6/6 green after.

## CAT-8 — read-only open of a v0.1.0 companion-file database silently lost every view

The RO branch checked only for the legacy *table* shape, so companion-file detection was unreachable and every view resolved as nonexistent — while the analogous legacy-table case refuses loudly with actionable wording. Now both refuse the same way.

## PBT-14 / PBT-15 / TC-14 — test honesty

- **PBT-14**: `if pick_window { return Ok(()); }` skipped the numeric comparison, so window-over-semi-additive-inner had no randomized numeric coverage anywhere. Now oracled with the correlated-subquery formulation, `where_clause` un-pinned, and a guard asserting all four `pick_window × na_dim_queried` cells occur. Sanity-checked by corrupting the oracle (property fails naming `wbal`) and by dropping the predicate from the CTE (property fails), then restoring.
- **PBT-15**: `dsv`/`svf` anti-vacuity counters, each verified to fail independently when the metric generator excludes them.
- **TC-14**: the silent `else { return; }` escape **was hiding a live defect** — the fixed input did not parse (RT-9), so the nameless-metric assertion had not been running. Both branches now assert; the degraded arm is removed in #218 once RT-9 lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PT3CfUdQoRfc2SnvdzrbB)_